### PR TITLE
#2 Add Cards CRUD endpoints

### DIFF
--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -374,6 +374,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Card'
+        '400':
+          description: Validation error
         '401':
           description: Unauthorized
   /cards/{card_id}:
@@ -437,6 +439,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Card'
+        '400':
+          description: Validation error
         '401':
           description: Unauthorized
         '404':


### PR DESCRIPTION
## Cards CRUD Endpoints

The Cards CRUD endpoints were already present in the spec from a previous commit. This PR adds missing `400` validation error response codes to:
- `POST /cards` (create_card)
- `PATCH /cards/{card_id}` (update_card)

### Endpoints in spec:
- `GET /cards` — list cards with filtering
- `POST /cards` — create a new card
- `GET /cards/{card_id}` — get card by ID
- `PATCH /cards/{card_id}` — partial update card
- `DELETE /cards/{card_id}` — delete card

All use `$ref` to `Card` schema and OpenAPI 3.1 syntax.