### PR TITLE
#3 Extract shared schemas to components/schemas

### DIFF
--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -31,77 +31,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    updated:
-                      type: string
-                      description: Last update timestamp
-                    created:
-                      type: string
-                      description: Create date
-                    id:
-                      type: integer
-                      description: Column id
-                    title:
-                      type: string
-                      description: Column title
-                    sort_order:
-                      type: number
-                      description: Position
-                    col_count:
-                      type: integer
-                      description: Width
-                    wip_limit:
-                      type: integer
-                      description: Recommended limit for column
-                    type:
-                      type: string
-                      description: 1 - queue, 2 – in progress, 3 – done
-                    rules:
-                      type: integer
-                      description: 'Bit mask for column rules. Rules: 1 - checklists must be checked, 2 - display FIFO order'
-                    board_id:
-                      type: integer
-                      description: Board id
-                    column_id:
-                      type: string
-                      description: Parent column id
-                    archive_after_days:
-                      type: integer
-                      description: Specify amont of days after which cards will be automatically archived. Works only for
-                        columns with type **done**
-                    wip_limit_type:
-                      type: string
-                      description: 1 – card's count, 2 – card's size
-                    external_id:
-                      type: ["string", "null"]
-                      description: External id
-                    default_tags:
-                      type: string
-                      description: Default tags
-                    last_moved_warning_after_days:
-                      type: integer
-                      description: Warning appears on stale cards
-                    last_moved_warning_after_hours:
-                      type: integer
-                      description: Warning appears on stale cards
-                    last_moved_warning_after_minutes:
-                      type: integer
-                      description: Warning appears on stale cards
-                    months_to_hide_cards:
-                      type: ["integer", "null"]
-                      description: '[Deprecated] Hide cards not moved for the last N months'
-                    card_hide_after_days:
-                      type: ["integer", "null"]
-                      description: Hide cards not moved for the last N days
-                    pause_sla:
-                      type: boolean
-                      description: Indicates whether the SLA timer should be paused in this column
-                    subcolumns:
-                      type: array
-                      items:
-                        type: object
-                      description: Column subcolumns
+                  $ref: '#/components/schemas/Column'
         '401':
           description: Invalid token
         '403':
@@ -127,56 +57,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    updated:
-                      type: string
-                      description: Last update timestamp
-                    created:
-                      type: string
-                      description: Create date
-                    id:
-                      type: string
-                      description: Lane id
-                    title:
-                      type: string
-                      description: Lane title
-                    sort_order:
-                      type: number
-                      description: Position
-                    row_count:
-                      type: integer
-                      description: Height
-                    wip_limit:
-                      type: integer
-                      description: Recommended limit for column
-                    board_id:
-                      type: integer
-                      description: Board id
-                    default_card_type_id:
-                      type: ["integer", "null"]
-                      description: Default card type for new cards in lane
-                    wip_limit_type:
-                      type: string
-                      description: 1 – card's count, 2 – card's size
-                    external_id:
-                      type: ["string", "null"]
-                      description: External id
-                    default_tags:
-                      type: string
-                      description: Default tags
-                    last_moved_warning_after_days:
-                      type: integer
-                      description: Warning appears on stale cards
-                    last_moved_warning_after_hours:
-                      type: integer
-                      description: Warning appears on stale cards
-                    last_moved_warning_after_minutes:
-                      type: integer
-                      description: Warning appears on stale cards
-                    condition:
-                      type: string
-                      description: 1 - live, 2 - archived, 3 - deleted
+                  $ref: '#/components/schemas/Lane'
         '401':
           description: Invalid token
         '403':
@@ -200,85 +81,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  created:
-                    type: string
-                    description: Create date
-                  updated:
-                    type: string
-                    description: Last update timestamp
-                  id:
-                    type: integer
-                    description: Board id
-                  title:
-                    type: string
-                    description: Board title
-                  cell_wip_limits:
-                    type: array
-                    items:
-                      type: ["object", "null"]
-                    description: JSON containing wip limits rules for cells
-                  external_id:
-                    type: ["string", "null"]
-                    description: External id
-                  default_card_type_id:
-                    type: integer
-                    description: Default card type for new cards on board
-                  description:
-                    type: string
-                    description: Board description
-                  email_key:
-                    type: string
-                    description: Email key
-                  move_parents_to_done:
-                    type: boolean
-                    description: Automatically move parent cards to done when their children cards on this board is done
-                  default_tags:
-                    type: ["string", "null"]
-                    description: Default tags
-                  first_image_is_cover:
-                    type: boolean
-                    description: Automatically mark first uploaded card's image as card's cover
-                  reset_lane_spent_time:
-                    type: boolean
-                    description: Reset lane spent time when card changed lane
-                  backward_moves_enabled:
-                    type: boolean
-                    description: Allow automatic backward movement for summary boards
-                  hide_done_policies:
-                    type: boolean
-                    description: Hide done checklist policies
-                  hide_done_policies_in_done_column:
-                    type: boolean
-                    description: Hide done checklist policies only in done column
-                  automove_cards:
-                    type: boolean
-                    description: Automatically move cards depending on their children state
-                  auto_assign_enabled:
-                    type: boolean
-                    description: Automatically assign a user to the card when he/she moves the card if the user is not a member
-                      of the card
-                  card_properties:
-                    type: array
-                    items:
-                      type: ["object", "null"]
-                    description: 'Properties of the board cards suggested for filling '
-                  columns:
-                    type: array
-                    items:
-                      type: object
-                    description: Board columns
-                  lanes:
-                    type: array
-                    items:
-                      type: object
-                    description: Board lanes
-                  cards:
-                    type: array
-                    items:
-                      type: object
-                    description: Board cards
+                $ref: '#/components/schemas/Board'
         '401':
           description: Invalid token
         '403':
@@ -485,28 +288,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  updated:
-                    type: string
-                    description: Last update timestamp
-                  created:
-                    type: string
-                    description: Create date
-                  id:
-                    type: integer
-                    description: Card checklist id
-                  name:
-                    type: string
-                    description: Checklist name
-                  policy_id:
-                    type: ["integer", "null"]
-                    description: Template checklist id
-                  items:
-                    type: array
-                    items:
-                      type: object
-                    description: Checklist items
+                $ref: '#/components/schemas/Checklist'
         '401':
           description: Invalid token
         '403':
@@ -530,59 +312,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  updated:
-                    type: string
-                    description: Last update timestamp
-                  created:
-                    type: string
-                    description: Create date
-                  id:
-                    type: integer
-                    description: Comment id
-                  uid:
-                    type: integer
-                    description: Comment uid
-                  text:
-                    type: string
-                    description: Comment text
-                  type:
-                    type: string
-                    description: 1-markdown, 2-html
-                  edited:
-                    type: boolean
-                    description: Is comment edited
-                  card_id:
-                    type: integer
-                    description: Card id
-                  author_id:
-                    type: integer
-                    description: Author id
-                  email_addresses_to:
-                    type: string
-                    description: Mail addresses to send comment
-                  internal:
-                    type: boolean
-                    description: Internal flag
-                  deleted:
-                    type: boolean
-                    description: Deleted flag
-                  sd_external_recipients_cc:
-                    type: string
-                    description: Service desk external recipients
-                  sd_description:
-                    type: boolean
-                    description: Flag indicating that the comment is used as a request description when the card is a service
-                      desk request
-                  notification_sent:
-                    type: string
-                    description: Notification_sent date
-                  attacments:
-                    type: array
-                    items:
-                      type: object
-                    description: Comment attacments
+                $ref: '#/components/schemas/Comment'
         '400':
           description: validation Error
         '401':
@@ -607,57 +337,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  updated:
-                    type: string
-                    description: Last update timestamp
-                  created:
-                    type: string
-                    description: Create date
-                  id:
-                    type: integer
-                    description: Comment id
-                  uid:
-                    type: integer
-                    description: Comment uid
-                  text:
-                    type: string
-                    description: Comment text
-                  type:
-                    type: string
-                    description: 1-markdown, 2-html
-                  edited:
-                    type: boolean
-                    description: Is comment edited
-                  card_id:
-                    type: integer
-                    description: Card id
-                  author_id:
-                    type: integer
-                    description: Author id
-                  email_addresses_to:
-                    type: string
-                    description: Mail addresses to send comment
-                  internal:
-                    type: boolean
-                    description: Internal flag
-                  deleted:
-                    type: boolean
-                    description: Deleted flag
-                  sd_external_recipients_cc:
-                    type: ["string", "null"]
-                    description: Service desk external recipients
-                  sd_description:
-                    type: boolean
-                    description: Flag indicating that the comment is used as a request description when the card is a service
-                      desk request
-                  notification_sent:
-                    type: ["string", "null"]
-                    description: Notification sent date
-                  author:
-                    type: object
-                    description: Author info
+                $ref: '#/components/schemas/Comment'
         '401':
           description: Invalid token
         '403':
@@ -681,47 +361,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: integer
-                    description: User id
-                  full_name:
-                    type: string
-                    description: User full name
-                  email:
-                    type: string
-                    description: User email
-                  username:
-                    type: string
-                    description: Username for mentions and login
-                  avatar_initials_url:
-                    type: string
-                    description: Default user avatar
-                  avatar_uploaded_url:
-                    type: ["string", "null"]
-                    description: User uploaded avatar url
-                  initials:
-                    type: string
-                    description: User initials
-                  avatar_type:
-                    type: string
-                    description: 1 – gravatar, 2 – initials, 3 - uploaded
-                  lng:
-                    type: string
-                    description: Language
-                  timezone:
-                    type: string
-                    description: Time zone
-                  theme:
-                    type: string
-                    description: light - light color theme, dark - dark color theme, auto - color theme based on OS settings
-                  updated:
-                    type: string
-                    description: Last update timestamp
-                  type:
-                    type: integer
-                    description: 1 - member
+                $ref: '#/components/schemas/Member'
         '400':
           description: validation Error
         '401':
@@ -748,65 +388,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: integer
-                      description: User id
-                    full_name:
-                      type: string
-                      description: User full name
-                    email:
-                      type: string
-                      description: User email
-                    username:
-                      type: string
-                      description: Username for mentions and login
-                    avatar_initials_url:
-                      type: string
-                      description: Default user avatar
-                    avatar_uploaded_url:
-                      type: ["string", "null"]
-                      description: User uploaded avatar url
-                    initials:
-                      type: string
-                      description: User initials
-                    avatar_type:
-                      type: string
-                      description: 1 – gravatar, 2 – initials, 3 - uploaded
-                    lng:
-                      type: string
-                      description: Language
-                    timezone:
-                      type: string
-                      description: Time zone
-                    theme:
-                      type: string
-                      description: light - light color theme, dark - dark color theme, auto - color theme based on OS settings
-                    updated:
-                      type: string
-                      description: Last update timestamp
-                    created:
-                      type: string
-                      description: Create date
-                    activated:
-                      type: boolean
-                      description: User activated flag
-                    ui_version:
-                      type: string
-                      description: 1 - old ui. 2 - new ui
-                    virtual:
-                      type: boolean
-                      description: Virtual user flag
-                    card_id:
-                      type: integer
-                      description: Card id
-                    user_id:
-                      type: integer
-                      description: User id
-                    type:
-                      type: string
-                      description: 1 - member, 2 - responsible
+                  $ref: '#/components/schemas/MemberDetailed'
         '401':
           description: Invalid token
         '403':
@@ -834,23 +416,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  updated:
-                    type: string
-                    description: Last update timestamp
-                  created:
-                    type: string
-                    description: Create date
-                  card_id:
-                    type: integer
-                    description: Card id
-                  user_id:
-                    type: integer
-                    description: User id
-                  type:
-                    type: integer
-                    description: 2 - responsible
+                $ref: '#/components/schemas/MemberRole'
         '400':
           description: validation Error
         '401':
@@ -911,23 +477,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: integer
-                      description: Card tag id
-                    name:
-                      type: string
-                      description: Card tag name
-                    color:
-                      type: integer
-                      description: Card tag color number
-                    card_id:
-                      type: integer
-                      description: Card id
-                    tag_id:
-                      type: integer
-                      description: Card tag id
+                  $ref: '#/components/schemas/CardTag'
         '401':
           description: Invalid token
         '403':
@@ -953,69 +503,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    updated:
-                      type: string
-                      description: Last update timestamp
-                    created:
-                      type: string
-                      description: Create date
-                    id:
-                      type: integer
-                      description: Column id
-                    title:
-                      type: string
-                      description: Column title
-                    sort_order:
-                      type: number
-                      description: Position
-                    col_count:
-                      type: integer
-                      description: Width
-                    wip_limit:
-                      type: integer
-                      description: Recommended limit for column
-                    type:
-                      type: string
-                      description: 1 - queue, 2 – in progress, 3 – done
-                    rules:
-                      type: integer
-                      description: 'Bit mask for column rules. Rules: 1 - checklists must be checked, 2 - display FIFO order'
-                    board_id:
-                      type: integer
-                      description: Board id
-                    column_id:
-                      type: integer
-                      description: Parent column id
-                    archive_after_days:
-                      type: integer
-                      description: Specify amont of days after which cards will be automatically archived. Works only for
-                        columns with type **done**
-                    wip_limit_type:
-                      type: string
-                      description: 1 – card's count, 2 – card's size
-                    external_id:
-                      type: ["string", "null"]
-                      description: External id
-                    default_tags:
-                      type: string
-                      description: Default tags
-                    last_moved_warning_after_days:
-                      type: integer
-                      description: Warning appears on stale cards
-                    last_moved_warning_after_hours:
-                      type: integer
-                      description: Warning appears on stale cards
-                    last_moved_warning_after_minutes:
-                      type: integer
-                      description: Warning appears on stale cards
-                    months_to_hide_cards:
-                      type: ["integer", "null"]
-                      description: '[Deprecated] Hide cards not moved for the last N months'
-                    card_hide_after_days:
-                      type: ["integer", "null"]
-                      description: Hide cards not moved for the last N months
+                  $ref: '#/components/schemas/Column'
         '401':
           description: Invalid token
         '403':
@@ -1034,69 +522,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                      description: Custom property name
-                    type:
-                      type: string
-                      description: Custom property type
-                    show_on_facade:
-                      type: string
-                      description: Should show property on card's facade
-                    multiline:
-                      type: string
-                      description: Should render multiline text field
-                    fields_settings:
-                      type: ["object", "null"]
-                      description: Field settings for catalog type
-                    author_id:
-                      type: integer
-                      description: Author_id
-                    company_id:
-                      type: integer
-                      description: Company_id
-                    updated:
-                      type: string
-                      description: Last update timestamp
-                    created:
-                      type: string
-                      description: Create date
-                    id:
-                      type: integer
-                      description: Custom property id
-                    condition:
-                      type: string
-                      description: Custom property condition
-                    colorful:
-                      type: boolean
-                      description: Used for select properties. Determines should select color when creating new select value.
-                    multi_select:
-                      type: boolean
-                      description: Used for select properties. Determines is select property used as multi select
-                    values_creatable_by_users:
-                      type: boolean
-                      description: Used for select properties. Determines if users with writer role are able to create new
-                        select property values.
-                    data:
-                      type: ["object", "null"]
-                      description: Additional custom property data
-                    values_type:
-                      type: ["string", "null"]
-                      description: Type of values
-                    vote_variant:
-                      type: ["string", "null"]
-                      description: Type of vote or collective vote custom properties
-                    protected:
-                      type: boolean
-                      description: Protected flag
-                    color:
-                      type: ["integer", "null"]
-                      description: Color of catalog custom property
-                    external_id:
-                      type: ["string", "null"]
-                      description: External id
+                  $ref: '#/components/schemas/CustomProperty'
         '401':
           description: Invalid token
         '403':
@@ -1118,69 +544,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  name:
-                    type: string
-                    description: Custom property name
-                  type:
-                    type: string
-                    description: Custom property type
-                  show_on_facade:
-                    type: string
-                    description: Should show property on card's facade
-                  multiline:
-                    type: string
-                    description: Should render multiline text field
-                  fields_settings:
-                    type: ["object", "null"]
-                    description: Field settings for catalog type
-                  author_id:
-                    type: integer
-                    description: Author_id
-                  company_id:
-                    type: integer
-                    description: Company_id
-                  updated:
-                    type: string
-                    description: Last update timestamp
-                  created:
-                    type: string
-                    description: Create date
-                  id:
-                    type: integer
-                    description: Custom property id
-                  condition:
-                    type: string
-                    description: Custom property condition
-                  colorful:
-                    type: boolean
-                    description: Used for select properties. Determines should select color when creating new select value.
-                  multi_select:
-                    type: boolean
-                    description: Used for select properties. Determines is select property used as multi select
-                  values_creatable_by_users:
-                    type: boolean
-                    description: Used for select properties. Determines if users with writer role are able to create new select
-                      property values.
-                  data:
-                    type: ["object", "null"]
-                    description: Additional custom property data
-                  values_type:
-                    type: ["string", "null"]
-                    description: Type of values
-                  vote_variant:
-                    type: ["string", "null"]
-                    description: Type of vote or collective vote custom properties
-                  protected:
-                    type: boolean
-                    description: Protected flag
-                  color:
-                    type: ["integer", "null"]
-                    description: Color of catalog custom property
-                  external_id:
-                    type: ["string", "null"]
-                    description: External id
+                $ref: '#/components/schemas/CustomProperty'
         '401':
           description: Invalid token
         '403':
@@ -1199,72 +563,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: integer
-                      description: Space id
-                    uid:
-                      type: string
-                      description: Space uid
-                    title:
-                      type: string
-                      description: Space title
-                    updated:
-                      type: string
-                      description: Last update timestamp
-                    created:
-                      type: string
-                      description: Create date
-                    archived:
-                      type: boolean
-                      description: Space archived flag
-                    access:
-                      type: string
-                      description: Space access
-                    for_everyone_access_role_id:
-                      type: string
-                      description: Role id for everyone access
-                    entity_type:
-                      type: string
-                      description: Entity type
-                    path:
-                      type: string
-                      description: Inner path to entity
-                    sort_order:
-                      type: number
-                      description: Space sort order
-                    parent_entity_uid:
-                      type: ["string", "null"]
-                      description: Parent entity uid
-                    company_id:
-                      type: integer
-                      description: Company id
-                    allowed_card_type_ids:
-                      type: array
-                      items:
-                        type: ["object", "null"]
-                      description: Allowed card types for this space
-                    external_id:
-                      type: ["string", "null"]
-                      description: External id
-                    settings:
-                      type: object
-                      description: Space settings
-                    boards:
-                      type: array
-                      items:
-                        type: object
-                      description: Space boards
-                    entity_uid:
-                      type: string
-                      description: Entity uid
-                    user_id:
-                      type: integer
-                      description: User id
-                    access_mod:
-                      type: string
-                      description: User access modifier
+                  $ref: '#/components/schemas/Space'
         '401':
           description: Invalid token
   /spaces/{space_id}:
@@ -1284,58 +583,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: integer
-                    description: Space id
-                  uid:
-                    type: string
-                    description: Space uid
-                  title:
-                    type: string
-                    description: Space title
-                  updated:
-                    type: string
-                    description: Last update timestamp
-                  created:
-                    type: string
-                    description: Create date
-                  archived:
-                    type: boolean
-                    description: Space archived flag
-                  access:
-                    type: string
-                    description: Space access
-                  for_everyone_access_role_id:
-                    type: string
-                    description: Role id for everyone access
-                  entity_type:
-                    type: string
-                    description: Entity type
-                  path:
-                    type: string
-                    description: Inner path to entity
-                  sort_order:
-                    type: number
-                    description: Space sort order
-                  parent_entity_uid:
-                    type: ["string", "null"]
-                    description: Parent entity uid
-                  company_id:
-                    type: integer
-                    description: Company id
-                  allowed_card_type_ids:
-                    type: array
-                    items:
-                      type: ["object", "null"]
-                    description: Allowed card types for this space
-                  external_id:
-                    type: ["string", "null"]
-                    description: External id
-                  settings:
-                    type: object
-                    description: Space settings
+                $ref: '#/components/schemas/Space'
         '401':
           description: Invalid token
         '403':
@@ -1361,92 +609,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    created:
-                      type: string
-                      description: Create date
-                    updated:
-                      type: string
-                      description: Last update timestamp
-                    id:
-                      type: integer
-                      description: Board  id
-                    title:
-                      type: string
-                      description: Board title
-                    cell_wip_limits:
-                      type: array
-                      items:
-                        type: ["object", "null"]
-                      description: JSON containing wip limits rules for cells
-                    external_id:
-                      type: ["string", "null"]
-                      description: External id
-                    default_card_type_id:
-                      type: integer
-                      description: Default card type for new cards on board
-                    description:
-                      type: string
-                      description: Board description
-                    email_key:
-                      type: string
-                      description: Email key
-                    move_parents_to_done:
-                      type: boolean
-                      description: Automatically move parent cards to done when their children cards on this board is done
-                    default_tags:
-                      type: ["string", "null"]
-                      description: Default tags
-                    first_image_is_cover:
-                      type: boolean
-                      description: Automatically mark first uploaded card's image as card's cover
-                    reset_lane_spent_time:
-                      type: boolean
-                      description: Reset lane spent time when card changed lane
-                    backward_moves_enabled:
-                      type: boolean
-                      description: Allow automatic backward movement for summary boards
-                    hide_done_policies:
-                      type: boolean
-                      description: Hide done checklist policies
-                    hide_done_policies_in_done_column:
-                      type: boolean
-                      description: Hide done checklist policies only in done column
-                    automove_cards:
-                      type: boolean
-                      description: Automatically move cards depending on their children state
-                    auto_assign_enabled:
-                      type: boolean
-                      description: Automatically assign a user to the card when he/she moves the card if the user is not a
-                        member of the card
-                    card_properties:
-                      type: array
-                      items:
-                        type: ["object", "null"]
-                      description: 'Properties of the board cards suggested for filling '
-                    columns:
-                      type: array
-                      items:
-                        type: object
-                      description: Board columns
-                    lanes:
-                      type: array
-                      items:
-                        type: object
-                      description: Board lanes
-                    top:
-                      type: integer
-                      description: Y coordinate of the board on space
-                    left:
-                      type: integer
-                      description: X coordinate of the board on space
-                    sort_order:
-                      type: number
-                      description: Position
-                    type:
-                      type: integer
-                      description: 1 - place on space with coordinates (top, left), 5 - attach to space as sidebar
+                  $ref: '#/components/schemas/BoardInSpace'
         '401':
           description: Invalid token
         '403':
@@ -1465,29 +628,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    updated:
-                      type: string
-                      description: Last update timestamp
-                    created:
-                      type: string
-                      description: Create date
-                    id:
-                      type: integer
-                      description: Tag id
-                    name:
-                      type: string
-                      description: Tag name
-                    company_id:
-                      type: integer
-                      description: Company id
-                    color:
-                      type: integer
-                      description: Color number
-                    archived:
-                      type: boolean
-                      description: Archived flag
+                  $ref: '#/components/schemas/CompanyTag'
         '401':
           description: Invalid token
         '403':
@@ -1504,115 +645,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: integer
-                      description: User id
-                    full_name:
-                      type: string
-                      description: User full name
-                    email:
-                      type: string
-                      description: User email
-                    username:
-                      type: string
-                      description: Username for mentions and login
-                    avatar_initials_url:
-                      type: string
-                      description: Default user avatar
-                    avatar_uploaded_url:
-                      type: ["string", "null"]
-                      description: User uploaded avatar url
-                    initials:
-                      type: string
-                      description: User initials
-                    avatar_type:
-                      type: string
-                      description: 1 – gravatar, 2 – initials, 3 - uploaded
-                    lng:
-                      type: string
-                      description: Language
-                    timezone:
-                      type: string
-                      description: Time zone
-                    theme:
-                      type: string
-                      description: light - light color theme, dark - dark color theme, auto - color theme based on OS settings
-                    updated:
-                      type: string
-                      description: Last update timestamp
-                    created:
-                      type: string
-                      description: Create date
-                    activated:
-                      type: boolean
-                      description: User activated flag
-                    ui_version:
-                      type: string
-                      description: 1 - old ui. 2 - new ui
-                    company_id:
-                      type: integer
-                      description: Company id
-                    user_id:
-                      type: integer
-                      description: User id
-                    default_space_id:
-                      type: ["integer", "null"]
-                      description: Default space
-                    permissions:
-                      type: integer
-                      description: User company permissions
-                    role:
-                      type: string
-                      description: User role in company:\n 1 - owner,\n 2 - user,\n 3 - deactivated
-                    email_frequency:
-                      type: string
-                      description: 1 - never, 2 – instantly
-                    email_settings:
-                      type: object
-                      description: Email settings
-                    slack_id:
-                      type: ["string", "null"]
-                      description: User slack id
-                    slack_settings:
-                      type: ["string", "null"]
-                      description: Slack settings
-                    notification_settings:
-                      type: ["string", "null"]
-                      description: Notification settings
-                    notification_enabled_channels:
-                      type: array
-                      items:
-                        type: object
-                      description: List of enabled channels for notifications
-                    slack_private_channel_id:
-                      type: ["integer", "null"]
-                      description: User slack private channel id
-                    telegram_sd_bot_enabled:
-                      type: boolean
-                      description: Telegram bot enable flag
-                    invite_last_sent_at:
-                      type: string
-                      description: Last invite date
-                    apps_permissions:
-                      type: string
-                      description: 0 - no access,\n 1 - full access to {{projectName}}, access to service desk denied.\n 2
-                        - guest access to {{projectName}}, access to service desk denied.\n 4 - access only to service desk.\n
-                        5 - full access to {{projectName}} and service desk.\n 6 - guest access to {{projectName}}, access
-                        to service desk
-                    external:
-                      type: boolean
-                      description: Is user external
-                    last_request_date:
-                      type: ["string", "null"]
-                      description: Date of last request
-                    last_request_method:
-                      type: ["string", "null"]
-                      description: Type of last request
-                    include_inactive:
-                      type: boolean
-                      description: Includes in the list of deactivated users
+                  $ref: '#/components/schemas/UserInList'
         '400':
           description: validation Error
         '401':
@@ -1629,121 +662,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: integer
-                    description: User id
-                  full_name:
-                    type: string
-                    description: User full name
-                  email:
-                    type: string
-                    description: User email
-                  username:
-                    type: string
-                    description: Username for mentions and login
-                  avatar_initials_url:
-                    type: string
-                    description: Default user avatar
-                  avatar_uploaded_url:
-                    type: ["string", "null"]
-                    description: User uploaded avatar url
-                  initials:
-                    type: string
-                    description: User initials
-                  avatar_type:
-                    type: string
-                    description: 1 – gravatar, 2 – initials, 3 - uploaded
-                  lng:
-                    type: string
-                    description: Language
-                  timezone:
-                    type: string
-                    description: Time zone
-                  theme:
-                    type: string
-                    description: light - light color theme, dark - dark color theme, auto - color theme based on OS settings
-                  updated:
-                    type: string
-                    description: Last update timestamp
-                  created:
-                    type: string
-                    description: Create date
-                  activated:
-                    type: boolean
-                    description: User activated flag
-                  ui_version:
-                    type: string
-                    description: 1 - old ui. 2 - new ui
-                  company_id:
-                    type: integer
-                    description: Company id
-                  telegram_id:
-                    type: integer
-                    description: Telegram id
-                  telegram_settings:
-                    type: object
-                    description: Telegram settings
-                  user_id:
-                    type: integer
-                    description: User id
-                  default_space_id:
-                    type: ["integer", "null"]
-                    description: Default space
-                  permissions:
-                    type: integer
-                    description: User company permissions
-                  role:
-                    type: string
-                    description: User role in company:\n 1 - owner,\n 2 - user,\n 3 - deactivated
-                  email_frequency:
-                    type: string
-                    description: 1 - never, 2 – instantly
-                  email_settings:
-                    type: object
-                    description: Email settings
-                  slack_id:
-                    type: ["string", "null"]
-                    description: User slack id
-                  slack_settings:
-                    type: ["string", "null"]
-                    description: Slack settings
-                  notification_settings:
-                    type: ["string", "null"]
-                    description: Notification settings
-                  notification_enabled_channels:
-                    type: array
-                    items:
-                      type: object
-                    description: List of enabled channels for notifications
-                  slack_private_channel_id:
-                    type: ["integer", "null"]
-                    description: User slack private channel id
-                  telegram_sd_bot_enabled:
-                    type: boolean
-                    description: Telegram bot enable flag
-                  invite_last_sent_at:
-                    type: string
-                    description: Last invite date
-                  apps_permissions:
-                    type: string
-                    description: 0 - no access,\n 1 - full access to {{projectName}}, access to service desk denied.\n 2 -
-                      guest access to {{projectName}}, access to service desk denied.\n 4 - access only to service desk.\n
-                      5 - full access to {{projectName}} and service desk.\n 6 - guest access to {{projectName}}, access to
-                      service desk
-                  external:
-                    type: boolean
-                    description: Is user external
-                  last_request_date:
-                    type: ["string", "null"]
-                    description: Date of last request
-                  last_request_method:
-                    type: ["string", "null"]
-                    description: Type of last request
-                  has_password:
-                    type: boolean
-                    description: Has user password flag
+                $ref: '#/components/schemas/User'
         '401':
           description: Invalid token
         '403':
@@ -1769,7 +688,9 @@ components:
           type: string
           description: Card title
         description:
-          type: ["string", "null"]
+          type:
+          - string
+          - 'null'
           description: Card description (markdown)
         state:
           type: integer
@@ -1784,16 +705,22 @@ components:
           type: integer
           description: Column ID
         lane_id:
-          type: ["integer", "null"]
+          type:
+          - integer
+          - 'null'
           description: Lane ID
         sort_order:
           type: number
           description: Sort order in column
         type_id:
-          type: ["integer", "null"]
+          type:
+          - integer
+          - 'null'
           description: Card type ID
         size_text:
-          type: ["string", "null"]
+          type:
+          - string
+          - 'null'
           description: Size text
         created:
           type: string
@@ -1836,7 +763,9 @@ components:
             type: integer
           description: IDs of related cards
         condition:
-          type: ["object", "null"]
+          type:
+          - object
+          - 'null'
           description: Card condition/deadline info
     CardMember:
       type: object
@@ -1870,4 +799,978 @@ components:
         name:
           type: string
         color:
-          type: ["integer", "null"]
+          type:
+          - integer
+          - 'null'
+    Column:
+      type: object
+      properties:
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        id:
+          type: integer
+          description: Column id
+        title:
+          type: string
+          description: Column title
+        sort_order:
+          type: number
+          description: Position
+        col_count:
+          type: integer
+          description: Width
+        wip_limit:
+          type: integer
+          description: Recommended limit for column
+        type:
+          type: string
+          description: 1 - queue, 2 – in progress, 3 – done
+        rules:
+          type: integer
+          description: 'Bit mask for column rules. Rules: 1 - checklists must be checked, 2 - display FIFO order'
+        board_id:
+          type: integer
+          description: Board id
+        column_id:
+          type: string
+          description: Parent column id
+        archive_after_days:
+          type: integer
+          description: Specify amont of days after which cards will be automatically archived. Works only for columns with
+            type **done**
+        wip_limit_type:
+          type: string
+          description: 1 – card's count, 2 – card's size
+        external_id:
+          type:
+          - string
+          - 'null'
+          description: External id
+        default_tags:
+          type: string
+          description: Default tags
+        last_moved_warning_after_days:
+          type: integer
+          description: Warning appears on stale cards
+        last_moved_warning_after_hours:
+          type: integer
+          description: Warning appears on stale cards
+        last_moved_warning_after_minutes:
+          type: integer
+          description: Warning appears on stale cards
+        months_to_hide_cards:
+          type:
+          - integer
+          - 'null'
+          description: '[Deprecated] Hide cards not moved for the last N months'
+        card_hide_after_days:
+          type:
+          - integer
+          - 'null'
+          description: Hide cards not moved for the last N days
+        pause_sla:
+          type: boolean
+          description: Indicates whether the SLA timer should be paused in this column
+        subcolumns:
+          type: array
+          items:
+            type: object
+          description: Column subcolumns
+    Lane:
+      type: object
+      properties:
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        id:
+          type: string
+          description: Lane id
+        title:
+          type: string
+          description: Lane title
+        sort_order:
+          type: number
+          description: Position
+        row_count:
+          type: integer
+          description: Height
+        wip_limit:
+          type: integer
+          description: Recommended limit for column
+        board_id:
+          type: integer
+          description: Board id
+        default_card_type_id:
+          type:
+          - integer
+          - 'null'
+          description: Default card type for new cards in lane
+        wip_limit_type:
+          type: string
+          description: 1 – card's count, 2 – card's size
+        external_id:
+          type:
+          - string
+          - 'null'
+          description: External id
+        default_tags:
+          type: string
+          description: Default tags
+        last_moved_warning_after_days:
+          type: integer
+          description: Warning appears on stale cards
+        last_moved_warning_after_hours:
+          type: integer
+          description: Warning appears on stale cards
+        last_moved_warning_after_minutes:
+          type: integer
+          description: Warning appears on stale cards
+        condition:
+          type: string
+          description: 1 - live, 2 - archived, 3 - deleted
+    Board:
+      type: object
+      properties:
+        created:
+          type: string
+          description: Create date
+        updated:
+          type: string
+          description: Last update timestamp
+        id:
+          type: integer
+          description: Board id
+        title:
+          type: string
+          description: Board title
+        cell_wip_limits:
+          type: array
+          items:
+            type:
+            - object
+            - 'null'
+          description: JSON containing wip limits rules for cells
+        external_id:
+          type:
+          - string
+          - 'null'
+          description: External id
+        default_card_type_id:
+          type: integer
+          description: Default card type for new cards on board
+        description:
+          type: string
+          description: Board description
+        email_key:
+          type: string
+          description: Email key
+        move_parents_to_done:
+          type: boolean
+          description: Automatically move parent cards to done when their children cards on this board is done
+        default_tags:
+          type:
+          - string
+          - 'null'
+          description: Default tags
+        first_image_is_cover:
+          type: boolean
+          description: Automatically mark first uploaded card's image as card's cover
+        reset_lane_spent_time:
+          type: boolean
+          description: Reset lane spent time when card changed lane
+        backward_moves_enabled:
+          type: boolean
+          description: Allow automatic backward movement for summary boards
+        hide_done_policies:
+          type: boolean
+          description: Hide done checklist policies
+        hide_done_policies_in_done_column:
+          type: boolean
+          description: Hide done checklist policies only in done column
+        automove_cards:
+          type: boolean
+          description: Automatically move cards depending on their children state
+        auto_assign_enabled:
+          type: boolean
+          description: Automatically assign a user to the card when he/she moves the card if the user is not a member of the
+            card
+        card_properties:
+          type: array
+          items:
+            type:
+            - object
+            - 'null'
+          description: 'Properties of the board cards suggested for filling '
+        columns:
+          type: array
+          items:
+            type: object
+          description: Board columns
+        lanes:
+          type: array
+          items:
+            type: object
+          description: Board lanes
+        cards:
+          type: array
+          items:
+            type: object
+          description: Board cards
+    Space:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Space id
+        uid:
+          type: string
+          description: Space uid
+        title:
+          type: string
+          description: Space title
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        archived:
+          type: boolean
+          description: Space archived flag
+        access:
+          type: string
+          description: Space access
+        for_everyone_access_role_id:
+          type: string
+          description: Role id for everyone access
+        entity_type:
+          type: string
+          description: Entity type
+        path:
+          type: string
+          description: Inner path to entity
+        sort_order:
+          type: number
+          description: Space sort order
+        parent_entity_uid:
+          type:
+          - string
+          - 'null'
+          description: Parent entity uid
+        company_id:
+          type: integer
+          description: Company id
+        allowed_card_type_ids:
+          type: array
+          items:
+            type:
+            - object
+            - 'null'
+          description: Allowed card types for this space
+        external_id:
+          type:
+          - string
+          - 'null'
+          description: External id
+        settings:
+          type: object
+          description: Space settings
+        boards:
+          type: array
+          items:
+            type: object
+          description: Space boards
+        entity_uid:
+          type: string
+          description: Entity uid
+        user_id:
+          type: integer
+          description: User id
+        access_mod:
+          type: string
+          description: User access modifier
+    Comment:
+      type: object
+      properties:
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        id:
+          type: integer
+          description: Comment id
+        uid:
+          type: integer
+          description: Comment uid
+        text:
+          type: string
+          description: Comment text
+        type:
+          type: string
+          description: 1-markdown, 2-html
+        edited:
+          type: boolean
+          description: Is comment edited
+        card_id:
+          type: integer
+          description: Card id
+        author_id:
+          type: integer
+          description: Author id
+        email_addresses_to:
+          type: string
+          description: Mail addresses to send comment
+        internal:
+          type: boolean
+          description: Internal flag
+        deleted:
+          type: boolean
+          description: Deleted flag
+        sd_external_recipients_cc:
+          type:
+          - string
+          - 'null'
+          description: Service desk external recipients
+        sd_description:
+          type: boolean
+          description: Flag indicating that the comment is used as a request description when the card is a service desk request
+        notification_sent:
+          type:
+          - string
+          - 'null'
+          description: Notification sent date
+        attacments:
+          type: array
+          items:
+            type: object
+          description: Comment attacments
+        author:
+          type: object
+          description: Author info
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: User id
+        full_name:
+          type: string
+          description: User full name
+        email:
+          type: string
+          description: User email
+        username:
+          type: string
+          description: Username for mentions and login
+        avatar_initials_url:
+          type: string
+          description: Default user avatar
+        avatar_uploaded_url:
+          type:
+          - string
+          - 'null'
+          description: User uploaded avatar url
+        initials:
+          type: string
+          description: User initials
+        avatar_type:
+          type: string
+          description: 1 – gravatar, 2 – initials, 3 - uploaded
+        lng:
+          type: string
+          description: Language
+        timezone:
+          type: string
+          description: Time zone
+        theme:
+          type: string
+          description: light - light color theme, dark - dark color theme, auto - color theme based on OS settings
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        activated:
+          type: boolean
+          description: User activated flag
+        ui_version:
+          type: string
+          description: 1 - old ui. 2 - new ui
+        company_id:
+          type: integer
+          description: Company id
+        telegram_id:
+          type: integer
+          description: Telegram id
+        telegram_settings:
+          type: object
+          description: Telegram settings
+        user_id:
+          type: integer
+          description: User id
+        default_space_id:
+          type:
+          - integer
+          - 'null'
+          description: Default space
+        permissions:
+          type: integer
+          description: User company permissions
+        role:
+          type: string
+          description: User role in company:\n 1 - owner,\n 2 - user,\n 3 - deactivated
+        email_frequency:
+          type: string
+          description: 1 - never, 2 – instantly
+        email_settings:
+          type: object
+          description: Email settings
+        slack_id:
+          type:
+          - string
+          - 'null'
+          description: User slack id
+        slack_settings:
+          type:
+          - string
+          - 'null'
+          description: Slack settings
+        notification_settings:
+          type:
+          - string
+          - 'null'
+          description: Notification settings
+        notification_enabled_channels:
+          type: array
+          items:
+            type: object
+          description: List of enabled channels for notifications
+        slack_private_channel_id:
+          type:
+          - integer
+          - 'null'
+          description: User slack private channel id
+        telegram_sd_bot_enabled:
+          type: boolean
+          description: Telegram bot enable flag
+        invite_last_sent_at:
+          type: string
+          description: Last invite date
+        apps_permissions:
+          type: string
+          description: 0 - no access,\n 1 - full access to {{projectName}}, access to service desk denied.\n 2 - guest access
+            to {{projectName}}, access to service desk denied.\n 4 - access only to service desk.\n 5 - full access to {{projectName}}
+            and service desk.\n 6 - guest access to {{projectName}}, access to service desk
+        external:
+          type: boolean
+          description: Is user external
+        last_request_date:
+          type:
+          - string
+          - 'null'
+          description: Date of last request
+        last_request_method:
+          type:
+          - string
+          - 'null'
+          description: Type of last request
+        has_password:
+          type: boolean
+          description: Has user password flag
+    CustomProperty:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Custom property name
+        type:
+          type: string
+          description: Custom property type
+        show_on_facade:
+          type: string
+          description: Should show property on card's facade
+        multiline:
+          type: string
+          description: Should render multiline text field
+        fields_settings:
+          type:
+          - object
+          - 'null'
+          description: Field settings for catalog type
+        author_id:
+          type: integer
+          description: Author_id
+        company_id:
+          type: integer
+          description: Company_id
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        id:
+          type: integer
+          description: Custom property id
+        condition:
+          type: string
+          description: Custom property condition
+        colorful:
+          type: boolean
+          description: Used for select properties. Determines should select color when creating new select value.
+        multi_select:
+          type: boolean
+          description: Used for select properties. Determines is select property used as multi select
+        values_creatable_by_users:
+          type: boolean
+          description: Used for select properties. Determines if users with writer role are able to create new select property
+            values.
+        data:
+          type:
+          - object
+          - 'null'
+          description: Additional custom property data
+        values_type:
+          type:
+          - string
+          - 'null'
+          description: Type of values
+        vote_variant:
+          type:
+          - string
+          - 'null'
+          description: Type of vote or collective vote custom properties
+        protected:
+          type: boolean
+          description: Protected flag
+        color:
+          type:
+          - integer
+          - 'null'
+          description: Color of catalog custom property
+        external_id:
+          type:
+          - string
+          - 'null'
+          description: External id
+    Checklist:
+      type: object
+      properties:
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        id:
+          type: integer
+          description: Card checklist id
+        name:
+          type: string
+          description: Checklist name
+        policy_id:
+          type:
+          - integer
+          - 'null'
+          description: Template checklist id
+        items:
+          type: array
+          items:
+            type: object
+          description: Checklist items
+    CardTag:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Card tag id
+        name:
+          type: string
+          description: Card tag name
+        color:
+          type: integer
+          description: Card tag color number
+        card_id:
+          type: integer
+          description: Card id
+        tag_id:
+          type: integer
+          description: Card tag id
+    CompanyTag:
+      type: object
+      properties:
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        id:
+          type: integer
+          description: Tag id
+        name:
+          type: string
+          description: Tag name
+        company_id:
+          type: integer
+          description: Company id
+        color:
+          type: integer
+          description: Color number
+        archived:
+          type: boolean
+          description: Archived flag
+    Member:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: User id
+        full_name:
+          type: string
+          description: User full name
+        email:
+          type: string
+          description: User email
+        username:
+          type: string
+          description: Username for mentions and login
+        avatar_initials_url:
+          type: string
+          description: Default user avatar
+        avatar_uploaded_url:
+          type:
+          - string
+          - 'null'
+          description: User uploaded avatar url
+        initials:
+          type: string
+          description: User initials
+        avatar_type:
+          type: string
+          description: 1 – gravatar, 2 – initials, 3 - uploaded
+        lng:
+          type: string
+          description: Language
+        timezone:
+          type: string
+          description: Time zone
+        theme:
+          type: string
+          description: light - light color theme, dark - dark color theme, auto - color theme based on OS settings
+        updated:
+          type: string
+          description: Last update timestamp
+        type:
+          type: integer
+          description: 1 - member
+    MemberDetailed:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: User id
+        full_name:
+          type: string
+          description: User full name
+        email:
+          type: string
+          description: User email
+        username:
+          type: string
+          description: Username for mentions and login
+        avatar_initials_url:
+          type: string
+          description: Default user avatar
+        avatar_uploaded_url:
+          type:
+          - string
+          - 'null'
+          description: User uploaded avatar url
+        initials:
+          type: string
+          description: User initials
+        avatar_type:
+          type: string
+          description: 1 – gravatar, 2 – initials, 3 - uploaded
+        lng:
+          type: string
+          description: Language
+        timezone:
+          type: string
+          description: Time zone
+        theme:
+          type: string
+          description: light - light color theme, dark - dark color theme, auto - color theme based on OS settings
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        activated:
+          type: boolean
+          description: User activated flag
+        ui_version:
+          type: string
+          description: 1 - old ui. 2 - new ui
+        virtual:
+          type: boolean
+          description: Virtual user flag
+        card_id:
+          type: integer
+          description: Card id
+        user_id:
+          type: integer
+          description: User id
+        type:
+          type: string
+          description: 1 - member, 2 - responsible
+    MemberRole:
+      type: object
+      properties:
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        card_id:
+          type: integer
+          description: Card id
+        user_id:
+          type: integer
+          description: User id
+        type:
+          type: integer
+          description: 2 - responsible
+    BoardInSpace:
+      type: object
+      properties:
+        created:
+          type: string
+          description: Create date
+        updated:
+          type: string
+          description: Last update timestamp
+        id:
+          type: integer
+          description: Board  id
+        title:
+          type: string
+          description: Board title
+        cell_wip_limits:
+          type: array
+          items:
+            type:
+            - object
+            - 'null'
+          description: JSON containing wip limits rules for cells
+        external_id:
+          type:
+          - string
+          - 'null'
+          description: External id
+        default_card_type_id:
+          type: integer
+          description: Default card type for new cards on board
+        description:
+          type: string
+          description: Board description
+        email_key:
+          type: string
+          description: Email key
+        move_parents_to_done:
+          type: boolean
+          description: Automatically move parent cards to done when their children cards on this board is done
+        default_tags:
+          type:
+          - string
+          - 'null'
+          description: Default tags
+        first_image_is_cover:
+          type: boolean
+          description: Automatically mark first uploaded card's image as card's cover
+        reset_lane_spent_time:
+          type: boolean
+          description: Reset lane spent time when card changed lane
+        backward_moves_enabled:
+          type: boolean
+          description: Allow automatic backward movement for summary boards
+        hide_done_policies:
+          type: boolean
+          description: Hide done checklist policies
+        hide_done_policies_in_done_column:
+          type: boolean
+          description: Hide done checklist policies only in done column
+        automove_cards:
+          type: boolean
+          description: Automatically move cards depending on their children state
+        auto_assign_enabled:
+          type: boolean
+          description: Automatically assign a user to the card when he/she moves the card if the user is not a member of the
+            card
+        card_properties:
+          type: array
+          items:
+            type:
+            - object
+            - 'null'
+          description: 'Properties of the board cards suggested for filling '
+        columns:
+          type: array
+          items:
+            type: object
+          description: Board columns
+        lanes:
+          type: array
+          items:
+            type: object
+          description: Board lanes
+        top:
+          type: integer
+          description: Y coordinate of the board on space
+        left:
+          type: integer
+          description: X coordinate of the board on space
+        sort_order:
+          type: number
+          description: Position
+        type:
+          type: integer
+          description: 1 - place on space with coordinates (top, left), 5 - attach to space as sidebar
+    UserInList:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: User id
+        full_name:
+          type: string
+          description: User full name
+        email:
+          type: string
+          description: User email
+        username:
+          type: string
+          description: Username for mentions and login
+        avatar_initials_url:
+          type: string
+          description: Default user avatar
+        avatar_uploaded_url:
+          type:
+          - string
+          - 'null'
+          description: User uploaded avatar url
+        initials:
+          type: string
+          description: User initials
+        avatar_type:
+          type: string
+          description: 1 – gravatar, 2 – initials, 3 - uploaded
+        lng:
+          type: string
+          description: Language
+        timezone:
+          type: string
+          description: Time zone
+        theme:
+          type: string
+          description: light - light color theme, dark - dark color theme, auto - color theme based on OS settings
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        activated:
+          type: boolean
+          description: User activated flag
+        ui_version:
+          type: string
+          description: 1 - old ui. 2 - new ui
+        company_id:
+          type: integer
+          description: Company id
+        user_id:
+          type: integer
+          description: User id
+        default_space_id:
+          type:
+          - integer
+          - 'null'
+          description: Default space
+        permissions:
+          type: integer
+          description: User company permissions
+        role:
+          type: string
+          description: User role in company:\n 1 - owner,\n 2 - user,\n 3 - deactivated
+        email_frequency:
+          type: string
+          description: 1 - never, 2 – instantly
+        email_settings:
+          type: object
+          description: Email settings
+        slack_id:
+          type:
+          - string
+          - 'null'
+          description: User slack id
+        slack_settings:
+          type:
+          - string
+          - 'null'
+          description: Slack settings
+        notification_settings:
+          type:
+          - string
+          - 'null'
+          description: Notification settings
+        notification_enabled_channels:
+          type: array
+          items:
+            type: object
+          description: List of enabled channels for notifications
+        slack_private_channel_id:
+          type:
+          - integer
+          - 'null'
+          description: User slack private channel id
+        telegram_sd_bot_enabled:
+          type: boolean
+          description: Telegram bot enable flag
+        invite_last_sent_at:
+          type: string
+          description: Last invite date
+        apps_permissions:
+          type: string
+          description: 0 - no access,\n 1 - full access to {{projectName}}, access to service desk denied.\n 2 - guest access
+            to {{projectName}}, access to service desk denied.\n 4 - access only to service desk.\n 5 - full access to {{projectName}}
+            and service desk.\n 6 - guest access to {{projectName}}, access to service desk
+        external:
+          type: boolean
+          description: Is user external
+        last_request_date:
+          type:
+          - string
+          - 'null'
+          description: Date of last request
+        last_request_method:
+          type:
+          - string
+          - 'null'
+          description: Type of last request
+        include_inactive:
+          type: boolean
+          description: Includes in the list of deactivated users


### PR DESCRIPTION
## Summary

Extract 15 repeated inline schema definitions into `components/schemas` and replace with `$ref` references.

### New schemas
- Column, Lane, Board, BoardInSpace
- Space, Comment, Checklist
- User, UserInList, Member, MemberDetailed, MemberRole
- CustomProperty, CardTag, CompanyTag

### Existing schemas (untouched)
- Card, CardMember, Tag

Reduces duplication by ~100 lines and makes the spec easier to maintain and generate SDKs from.