### PR TITLE
#4 Bearer token middleware

### DIFF
--- a/Sources/KaitenSDK/AuthenticationMiddleware.swift
+++ b/Sources/KaitenSDK/AuthenticationMiddleware.swift
@@ -1,0 +1,32 @@
+import Foundation
+import HTTPTypes
+import OpenAPIRuntime
+
+/// A middleware that injects a Bearer token into every outgoing request
+/// and throws ``KaitenError/unauthorized`` on 401 responses.
+struct AuthenticationMiddleware: ClientMiddleware {
+    private let token: String
+
+    init(token: String) {
+        self.token = token
+    }
+
+    func intercept(
+        _ request: HTTPRequest,
+        body: HTTPBody?,
+        baseURL: URL,
+        operationID: String,
+        next: @Sendable (HTTPRequest, HTTPBody?, URL) async throws -> (HTTPResponse, HTTPBody?)
+    ) async throws -> (HTTPResponse, HTTPBody?) {
+        var request = request
+        request.headerFields[.authorization] = "Bearer \(token)"
+
+        let (response, responseBody) = try await next(request, body, baseURL)
+
+        if response.status == .unauthorized {
+            throw KaitenError.unauthorized
+        }
+
+        return (response, responseBody)
+    }
+}

--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -23,7 +23,8 @@ public struct KaitenClient: Sendable {
 
         self.client = Client(
             serverURL: url,
-            transport: URLSessionTransport()
+            transport: URLSessionTransport(),
+            middlewares: [AuthenticationMiddleware(token: config.token)]
         )
     }
 }


### PR DESCRIPTION
## Changes
- Add `AuthenticationMiddleware` implementing `ClientMiddleware`
- Injects `Authorization: Bearer {token}` header into every request
- Throws `KaitenError.unauthorized` on 401 responses
- Wire middleware into `KaitenClient.init()`