### PR TITLE
#5 Retry middleware for 429

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -24,7 +24,10 @@ public struct KaitenClient: Sendable {
         self.client = Client(
             serverURL: url,
             transport: URLSessionTransport(),
-            middlewares: [AuthenticationMiddleware(token: config.token)]
+            middlewares: [
+                AuthenticationMiddleware(token: config.token),
+                RetryMiddleware(),
+            ]
         )
     }
 }

--- a/Sources/KaitenSDK/RetryMiddleware.swift
+++ b/Sources/KaitenSDK/RetryMiddleware.swift
@@ -1,0 +1,40 @@
+import Foundation
+import HTTPTypes
+import OpenAPIRuntime
+
+/// A middleware that retries requests receiving HTTP 429 (Too Many Requests),
+/// respecting the `Retry-After` header.
+struct RetryMiddleware: ClientMiddleware {
+    private let maxAttempts: Int
+
+    init(maxAttempts: Int = 3) {
+        self.maxAttempts = maxAttempts
+    }
+
+    func intercept(
+        _ request: HTTPRequest,
+        body: HTTPBody?,
+        baseURL: URL,
+        operationID: String,
+        next: @Sendable (HTTPRequest, HTTPBody?, URL) async throws -> (HTTPResponse, HTTPBody?)
+    ) async throws -> (HTTPResponse, HTTPBody?) {
+        var lastRetryAfter: TimeInterval?
+
+        for _ in 0..<maxAttempts {
+            let (response, responseBody) = try await next(request, body, baseURL)
+
+            guard response.status == .tooManyRequests else {
+                return (response, responseBody)
+            }
+
+            let retryAfter = response.headerFields[HTTPField.Name("Retry-After")!]
+                .flatMap(TimeInterval.init)
+                ?? 1.0
+            lastRetryAfter = retryAfter
+
+            try await Task.sleep(for: .seconds(retryAfter))
+        }
+
+        throw KaitenError.rateLimited(retryAfter: lastRetryAfter)
+    }
+}


### PR DESCRIPTION
Adds `RetryMiddleware` that intercepts HTTP 429 responses, respects `Retry-After` header (defaults to 1s), retries up to 3 times, then throws `KaitenError.rateLimited(retryAfter:)`.

Middleware is wired into `KaitenClient.init()` after `AuthenticationMiddleware`.