### PR TITLE
Fix test isolation from env vars

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -37,15 +37,16 @@ public struct KaitenClient: Sendable {
     // MARK: - Initialization
 
     /// Internal initializer for testing with a custom transport.
-    init(transport: any ClientTransport) throws {
-        self.config = try KaitenConfiguration.resolve()
-        let url = try URL(string: config.baseURL)
-            .orThrow(KaitenError.invalidURL(config.baseURL))
+    /// Internal initializer for testing with a custom transport and explicit config.
+    init(baseURL: String, token: String, transport: any ClientTransport) throws {
+        self.config = KaitenConfiguration(baseURL: baseURL, token: token)
+        let url = try URL(string: baseURL)
+            .orThrow(KaitenError.invalidURL(baseURL))
         self.client = Client(
             serverURL: url,
             transport: transport,
             middlewares: [
-                AuthenticationMiddleware(token: config.token),
+                AuthenticationMiddleware(token: token),
                 RetryMiddleware(),
             ]
         )

--- a/Tests/KaitenSDKTests/CustomPropertiesTests.swift
+++ b/Tests/KaitenSDKTests/CustomPropertiesTests.swift
@@ -7,10 +7,6 @@ import Testing
 @Suite("CustomProperties")
 struct CustomPropertiesTests {
 
-    init() {
-        setenv("KAITEN_URL", "https://test.kaiten.ru/api/latest", 1)
-        setenv("KAITEN_TOKEN", "test-token", 1)
-    }
 
     @Test("listCustomProperties 200 returns array")
     func listSuccess() async throws {
@@ -18,7 +14,7 @@ struct CustomPropertiesTests {
             [{"id": 1, "name": "Priority", "type": "select"}, {"id": 2, "name": "Effort", "type": "number"}]
             """
         let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         let props = try await client.listCustomProperties()
         #expect(props.count == 2)
@@ -31,7 +27,7 @@ struct CustomPropertiesTests {
             {"id": 1, "name": "Priority", "type": "select"}
             """
         let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         let prop = try await client.getCustomProperty(id: 1)
         #expect(prop.name == "Priority")
@@ -40,7 +36,7 @@ struct CustomPropertiesTests {
     @Test("getCustomProperty 404 throws notFound")
     func notFound() async throws {
         let transport = MockClientTransport.returning(statusCode: 404)
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         await #expect(throws: KaitenError.self) {
             _ = try await client.getCustomProperty(id: 999)

--- a/Tests/KaitenSDKTests/GetBoardColumnsTests.swift
+++ b/Tests/KaitenSDKTests/GetBoardColumnsTests.swift
@@ -7,10 +7,6 @@ import Testing
 @Suite("GetBoardColumns")
 struct GetBoardColumnsTests {
 
-    init() {
-        setenv("KAITEN_URL", "https://test.kaiten.ru/api/latest", 1)
-        setenv("KAITEN_TOKEN", "test-token", 1)
-    }
 
     @Test("200 returns columns")
     func success() async throws {
@@ -18,7 +14,7 @@ struct GetBoardColumnsTests {
             [{"id": 10, "title": "To Do", "board_id": 1}, {"id": 11, "title": "Done", "board_id": 1}]
             """
         let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         let columns = try await client.getBoardColumns(boardId: 1)
         #expect(columns.count == 2)
@@ -29,7 +25,7 @@ struct GetBoardColumnsTests {
     @Test("200 empty array returns empty")
     func emptyArray() async throws {
         let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         let columns = try await client.getBoardColumns(boardId: 1)
         #expect(columns.isEmpty)

--- a/Tests/KaitenSDKTests/GetBoardLanesTests.swift
+++ b/Tests/KaitenSDKTests/GetBoardLanesTests.swift
@@ -7,10 +7,6 @@ import Testing
 @Suite("GetBoardLanes")
 struct GetBoardLanesTests {
 
-    init() {
-        setenv("KAITEN_URL", "https://test.kaiten.ru/api/latest", 1)
-        setenv("KAITEN_TOKEN", "test-token", 1)
-    }
 
     @Test("200 returns lanes")
     func success() async throws {
@@ -18,7 +14,7 @@ struct GetBoardLanesTests {
             [{"id": "20", "title": "Default Lane", "board_id": 1}, {"id": "21", "title": "Urgent", "board_id": 1}]
             """
         let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         let lanes = try await client.getBoardLanes(boardId: 1)
         #expect(lanes.count == 2)
@@ -29,7 +25,7 @@ struct GetBoardLanesTests {
     @Test("200 empty array returns empty")
     func emptyArray() async throws {
         let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         let lanes = try await client.getBoardLanes(boardId: 1)
         #expect(lanes.isEmpty)

--- a/Tests/KaitenSDKTests/GetBoardTests.swift
+++ b/Tests/KaitenSDKTests/GetBoardTests.swift
@@ -7,10 +7,6 @@ import Testing
 @Suite("GetBoard")
 struct GetBoardTests {
 
-    init() {
-        setenv("KAITEN_URL", "https://test.kaiten.ru/api/latest", 1)
-        setenv("KAITEN_TOKEN", "test-token", 1)
-    }
 
     @Test("200 returns Board")
     func success() async throws {
@@ -18,7 +14,7 @@ struct GetBoardTests {
             {"id": 1, "title": "My Board"}
             """
         let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         let board = try await client.getBoard(id: 1)
         #expect(board.id == 1)
@@ -28,7 +24,7 @@ struct GetBoardTests {
     @Test("404 throws notFound")
     func notFound() async throws {
         let transport = MockClientTransport.returning(statusCode: 404)
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         await #expect(throws: KaitenError.self) {
             _ = try await client.getBoard(id: 999)
@@ -38,7 +34,7 @@ struct GetBoardTests {
     @Test("401 throws unauthorized")
     func unauthorized() async throws {
         let transport = MockClientTransport.returning(statusCode: 401)
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         await #expect(throws: KaitenError.self) {
             _ = try await client.getBoard(id: 1)

--- a/Tests/KaitenSDKTests/GetCardMembersTests.swift
+++ b/Tests/KaitenSDKTests/GetCardMembersTests.swift
@@ -7,10 +7,6 @@ import Testing
 @Suite("GetCardMembers")
 struct GetCardMembersTests {
 
-    init() {
-        setenv("KAITEN_URL", "https://test.kaiten.ru/api/latest", 1)
-        setenv("KAITEN_TOKEN", "test-token", 1)
-    }
 
     @Test("200 returns members")
     func success() async throws {
@@ -18,7 +14,7 @@ struct GetCardMembersTests {
             [{"id": 1, "full_name": "Alice"}, {"id": 2, "full_name": "Bob"}]
             """
         let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         let members = try await client.getCardMembers(cardId: 42)
         #expect(members.count == 2)
@@ -28,7 +24,7 @@ struct GetCardMembersTests {
     @Test("200 empty returns empty")
     func emptyArray() async throws {
         let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         let members = try await client.getCardMembers(cardId: 42)
         #expect(members.isEmpty)

--- a/Tests/KaitenSDKTests/GetCardTests.swift
+++ b/Tests/KaitenSDKTests/GetCardTests.swift
@@ -7,10 +7,6 @@ import Testing
 @Suite("GetCard")
 struct GetCardTests {
 
-    init() {
-        setenv("KAITEN_URL", "https://test.kaiten.ru/api/latest", 1)
-        setenv("KAITEN_TOKEN", "test-token", 1)
-    }
 
     @Test("200 returns Card")
     func success() async throws {
@@ -18,7 +14,7 @@ struct GetCardTests {
             {"id": 42, "title": "Test card"}
             """
         let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         let card = try await client.getCard(id: 42)
         #expect(card.id == 42)
@@ -28,7 +24,7 @@ struct GetCardTests {
     @Test("404 throws notFound")
     func notFound() async throws {
         let transport = MockClientTransport.returning(statusCode: 404)
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         await #expect(throws: KaitenError.self) {
             _ = try await client.getCard(id: 999)
@@ -38,7 +34,7 @@ struct GetCardTests {
     @Test("401 throws unauthorized")
     func unauthorized() async throws {
         let transport = MockClientTransport.returning(statusCode: 401)
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         await #expect(throws: KaitenError.self) {
             _ = try await client.getCard(id: 1)

--- a/Tests/KaitenSDKTests/KaitenClientTests.swift
+++ b/Tests/KaitenSDKTests/KaitenClientTests.swift
@@ -1,11 +1,31 @@
+import Foundation
 import Testing
+
 @testable import KaitenSDK
 
-@Suite("KaitenClient Configuration")
+@Suite("KaitenClient Configuration", .serialized)
 struct KaitenClientConfigurationTests {
 
     @Test("Fails fast when KAITEN_URL is missing")
     func missingURL() {
+        // Clear any env vars set by other tests
+        unsetenv("KAITEN_URL")
+        unsetenv("KAITEN_TOKEN")
+
+        #expect(throws: KaitenError.self) {
+            _ = try KaitenClient()
+        }
+    }
+
+    @Test("Fails fast when KAITEN_TOKEN is missing")
+    func missingToken() {
+        setenv("KAITEN_URL", "https://test.kaiten.ru/api/latest", 1)
+        unsetenv("KAITEN_TOKEN")
+
+        defer {
+            unsetenv("KAITEN_URL")
+        }
+
         #expect(throws: KaitenError.self) {
             _ = try KaitenClient()
         }

--- a/Tests/KaitenSDKTests/ListBoardsTests.swift
+++ b/Tests/KaitenSDKTests/ListBoardsTests.swift
@@ -7,10 +7,6 @@ import Testing
 @Suite("ListBoards")
 struct ListBoardsTests {
 
-    init() {
-        setenv("KAITEN_URL", "https://test.kaiten.ru/api/latest", 1)
-        setenv("KAITEN_TOKEN", "test-token", 1)
-    }
 
     @Test("200 returns boards")
     func success() async throws {
@@ -18,7 +14,7 @@ struct ListBoardsTests {
             [{"id": 1, "title": "Sprint Board"}, {"id": 2, "title": "Kanban"}]
             """
         let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         let boards = try await client.listBoards(spaceId: 5)
         #expect(boards.count == 2)
@@ -29,7 +25,7 @@ struct ListBoardsTests {
     @Test("200 empty array returns empty")
     func emptyArray() async throws {
         let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         let boards = try await client.listBoards(spaceId: 5)
         #expect(boards.isEmpty)

--- a/Tests/KaitenSDKTests/ListCardsTests.swift
+++ b/Tests/KaitenSDKTests/ListCardsTests.swift
@@ -7,10 +7,6 @@ import Testing
 @Suite("ListCards")
 struct ListCardsTests {
 
-    init() {
-        setenv("KAITEN_URL", "https://test.kaiten.ru/api/latest", 1)
-        setenv("KAITEN_TOKEN", "test-token", 1)
-    }
 
     @Test("200 with array returns cards")
     func success() async throws {
@@ -18,7 +14,7 @@ struct ListCardsTests {
             [{"id": 1, "title": "Card A"}, {"id": 2, "title": "Card B"}]
             """
         let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         let cards = try await client.listCards(boardId: 10)
         #expect(cards.count == 2)
@@ -29,7 +25,7 @@ struct ListCardsTests {
     @Test("200 empty array returns empty")
     func emptyArray() async throws {
         let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         let cards = try await client.listCards(boardId: 10)
         #expect(cards.isEmpty)
@@ -38,7 +34,7 @@ struct ListCardsTests {
     @Test("401 throws unauthorized")
     func unauthorized() async throws {
         let transport = MockClientTransport.returning(statusCode: 401)
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         await #expect(throws: KaitenError.self) {
             _ = try await client.listCards(boardId: 10)

--- a/Tests/KaitenSDKTests/ListSpacesTests.swift
+++ b/Tests/KaitenSDKTests/ListSpacesTests.swift
@@ -7,10 +7,6 @@ import Testing
 @Suite("ListSpaces")
 struct ListSpacesTests {
 
-    init() {
-        setenv("KAITEN_URL", "https://test.kaiten.ru/api/latest", 1)
-        setenv("KAITEN_TOKEN", "test-token", 1)
-    }
 
     @Test("200 returns spaces")
     func success() async throws {
@@ -18,7 +14,7 @@ struct ListSpacesTests {
             [{"id": 1, "title": "Engineering"}, {"id": 2, "title": "Design"}]
             """
         let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         let spaces = try await client.listSpaces()
         #expect(spaces.count == 2)
@@ -29,7 +25,7 @@ struct ListSpacesTests {
     @Test("200 empty array returns empty")
     func emptyArray() async throws {
         let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         let spaces = try await client.listSpaces()
         #expect(spaces.isEmpty)
@@ -38,7 +34,7 @@ struct ListSpacesTests {
     @Test("401 throws unauthorized")
     func unauthorized() async throws {
         let transport = MockClientTransport.returning(statusCode: 401)
-        let client = try KaitenClient(transport: transport)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
         await #expect(throws: KaitenError.self) {
             _ = try await client.listSpaces()


### PR DESCRIPTION
- Add KaitenClient(baseURL:token:transport:) init for testing
- Remove setenv pollution from API tests
- Fix KaitenClientTests to properly unset env vars
- Use Mutex instead of nonisolated(unsafe) (FR-014)