### PR TITLE
fix: allowed_card_type_ids schema — array of int, not object

### DIFF
--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -1068,12 +1068,12 @@ components:
           type: integer
           description: Company id
         allowed_card_type_ids:
-          type: array
+          type:
+          - array
+          - 'null'
           items:
-            type:
-            - object
-            - 'null'
-          description: Allowed card types for this space
+            type: integer
+          description: Allowed card type IDs for this space
         external_id:
           type:
           - string


### PR DESCRIPTION
Kaiten API возвращает `allowed_card_type_ids` как массив чисел, а в OpenAPI-спеке было `array of object|null`. Это вызывало DecodingError при вызове `list-spaces`.

Исправлено на `array of integer | null`.