### PR TITLE
Add Linux arm64 binary to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
           - os: ubuntu-latest
             install-swift: true
             archive-suffix: linux_x86_64
+          - os: ubuntu-24.04-arm
+            install-swift: true
+            archive-suffix: linux_arm64
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Adds `ubuntu-24.04-arm` runner to the release matrix to produce a Linux arm64 binary.

Closes #56