### PR TITLE
docs: constitution v2.0.0 — remove implementation details

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,28 +1,3 @@
-<!--
-Sync Impact Report
-===================
-Version change: 1.0.0 → 1.1.0
-Bump rationale: MINOR — expanded Governance section with amendment
-procedure, versioning policy, and compliance review expectations.
-
-Modified principles: none (titles and content unchanged)
-Added sections: none (Governance expanded in-place)
-Removed sections: none
-
-Templates requiring updates:
-  - .specify/templates/plan-template.md — ✅ no update needed
-    (Constitution Check section references constitution generically)
-  - .specify/templates/spec-template.md — ✅ no update needed
-    (no direct constitution references)
-  - .specify/templates/tasks-template.md — ✅ no update needed
-    (no direct constitution references)
-  - .specify/templates/checklist-template.md — ✅ no update needed
-  - .specify/templates/agent-file-template.md — ✅ no update needed
-  - No command files exist in .specify/templates/commands/
-
-Follow-up TODOs: none
--->
-
 # KaitenSDK Constitution
 
 ## Core Principles
@@ -30,44 +5,29 @@ Follow-up TODOs: none
 ### I. OpenAPI-First
 
 OpenAPI-спека — единственный источник правды для API-контракта.
-Клиентский код генерируется из неё через `swift-openapi-generator`.
-Ручной код HTTP-запросов запрещён.
+Клиентский код генерируется из неё. Ручной код HTTP-запросов
+запрещён.
 
-### II. Cross-Platform
-
-Код MUST компилироваться и работать на macOS, Linux и Windows.
-Никаких `#if os(...)` для бизнес-логики.
-Platform-specific код допустим только в транспортном слое.
-
-### III. Generated Over Handwritten
+### II. Generated Over Handwritten
 
 Предпочитаем генерацию кода ручному написанию. Если что-то можно
 сгенерировать из спеки — генерируем. Обёртки поверх сгенерированного
 кода MUST быть минимальными и служить исключительно удобству API.
 
-### IV. Configuration as Code
+### III. Configuration as Code
 
-URL и другие настройки — через `swift-configuration`
-(environment variables, конфиг-файлы). Токены — через secrets
-provider. Захардкоженные значения запрещены.
+Настройки — через конфиг-файлы или аргументы.
+Захардкоженные значения запрещены.
 
-### V. Simplicity
+### IV. Simplicity
 
 YAGNI. Реализуем только то, что нужно прямо сейчас.
 Новые эндпоинты добавляются в OpenAPI-спеку → клиент
 перегенерируется автоматически. Преждевременные абстракции запрещены.
 
-## Technology Stack
-
-- **Swift 6.2**, Swift Package Manager
-- **`apple/swift-openapi-generator`** + `swift-openapi-runtime` — генерация клиента
-- **`apple/swift-configuration`** — конфигурация
-- **Swift Testing** — тесты
-- **GitHub Actions** — CI, матрица macOS/Linux/Windows
-
 ## Quality Gates
 
-- CI MUST проходить на всех трёх платформах
+- CI MUST проходить
 - OpenAPI-спека MUST быть валидна
 - Сгенерированный код MUST компилироваться без ошибок
 - Тесты MUST проходить
@@ -97,4 +57,4 @@ YAGNI. Реализуем только то, что нужно прямо сей
 - Нарушения допустимы только с явным обоснованием в Complexity
   Tracking секции плана.
 
-**Version**: 1.1.0 | **Ratified**: 2026-02-14 | **Last Amended**: 2026-02-16
+**Version**: 2.0.0 | **Ratified**: 2026-02-14 | **Last Amended**: 2026-02-16


### PR DESCRIPTION
## Summary
- Remove Cross-Platform principle (platforms defined in specs, not constitution)
- Remove Technology Stack section (dependencies are implementation details)
- Remove specific library refs from remaining principles (swift-openapi-generator, swift-configuration)
- Renumber principles: I–IV

MAJOR version bump (2.0.0): principle removed.

## Test plan
- [x] No remaining platform/dependency references in constitution
- [x] Principles are abstract and implementation-agnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)