### PR TITLE
Use typed throws(KaitenError) on all public SDK methods

### DIFF
--- a/Sources/KaitenSDK/KaitenError.swift
+++ b/Sources/KaitenSDK/KaitenError.swift
@@ -16,6 +16,8 @@ public enum KaitenError: Error, Sendable {
     case serverError(statusCode: Int, body: String?)
     /// A network-level error occurred.
     case networkError(underlying: any Error)
+    /// A decoding error occurred while parsing the response.
+    case decodingError(underlying: any Error)
     /// The API returned an unexpected HTTP status code.
     case unexpectedResponse(statusCode: Int)
 }
@@ -43,6 +45,8 @@ extension KaitenError: LocalizedError {
             "Server error \(statusCode)" + (body.map { ": \($0)" } ?? "")
         case .networkError(let underlying):
             "Network error: \(underlying.localizedDescription)"
+        case .decodingError(let underlying):
+            "Decoding error: \(underlying.localizedDescription)"
         case .unexpectedResponse(let statusCode):
             "Unexpected HTTP response: \(statusCode)"
         }

--- a/specs/001-kaiten-sdk-core/spec.md
+++ b/specs/001-kaiten-sdk-core/spec.md
@@ -96,7 +96,7 @@
 - **FR-001**: SDK MUST генерировать клиентский код из OpenAPI-спеки через `swift-openapi-generator`
 - **FR-002**: SDK MUST поддерживать авторизацию через Bearer token
 - **FR-003**: SDK MUST предоставлять типизированные модели для Card, Board, Column, Lane, Space, Member, CustomProperty
-- **FR-004**: SDK MUST возвращать типизированные ошибки для всех failure cases (network, auth, not found, rate limit)
+- **FR-004**: SDK MUST возвращать типизированные ошибки для всех failure cases (network, auth, not found, rate limit). Все публичные методы MUST использовать typed throws (`throws(KaitenError)`) вместо untyped `throws`.
 - **FR-005**: SDK MUST принимать `baseURL` и `token` как
   явные параметры инициализации. SDK не читает конфигурацию
   самостоятельно — это ответственность вызывающего кода.


### PR DESCRIPTION
Closes relates to #91

## Changes

- All public methods on `KaitenClient` now use `throws(KaitenError)` instead of untyped `throws`
- Added `KaitenError.decodingError(underlying:)` case for response parsing failures
- Wrapped all `try await client.xxx()` calls to convert `ClientError` → `KaitenError.networkError`
- Wrapped all `try ok.body.json` calls to convert `DecodingError` → `KaitenError.decodingError`
- Updated `Optional.orThrow` helper to use typed `throws(KaitenError)`
- Updated FR-004 in spec to require typed throws
- Internal init also uses `throws(KaitenError)`

Note: Does NOT close #91 — awaiting CI verification.