### PR TITLE
Use static Swift stdlib for Linux release binaries (#96)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,15 @@ jobs:
           - os: macos-26
             install-swift: false
             archive-suffix: darwin_arm64
+            static-swift-stdlib: false
           - os: ubuntu-latest
             install-swift: true
             archive-suffix: linux_x86_64
+            static-swift-stdlib: true
           - os: ubuntu-24.04-arm
             install-swift: true
             archive-suffix: linux_arm64
+            static-swift-stdlib: true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
@@ -33,8 +36,12 @@ jobs:
       - name: Build release binary
         id: build
         run: |
-          swift build -c release --product "$PRODUCT_NAME"
-          echo "bin-path=$(swift build -c release --product "$PRODUCT_NAME" --show-bin-path)" >> $GITHUB_OUTPUT
+          STATIC_FLAG=""
+          if [ "${{ matrix.static-swift-stdlib }}" = "true" ]; then
+            STATIC_FLAG="--static-swift-stdlib"
+          fi
+          swift build -c release --product "$PRODUCT_NAME" $STATIC_FLAG
+          echo "bin-path=$(swift build -c release --product "$PRODUCT_NAME" $STATIC_FLAG --show-bin-path)" >> $GITHUB_OUTPUT
 
       - name: Package binary
         id: package

--- a/Sources/KaitenSDK/KaitenError.swift
+++ b/Sources/KaitenSDK/KaitenError.swift
@@ -19,7 +19,7 @@ public enum KaitenError: Error, Sendable {
     /// A decoding error occurred while parsing the response.
     case decodingError(underlying: any Error)
     /// The API returned an unexpected HTTP status code.
-    case unexpectedResponse(statusCode: Int)
+    case unexpectedResponse(statusCode: Int, body: String? = nil)
 }
 
 // MARK: - LocalizedError
@@ -47,8 +47,8 @@ extension KaitenError: LocalizedError {
             "Network error: \(underlying.localizedDescription)"
         case .decodingError(let underlying):
             "Decoding error: \(underlying.localizedDescription)"
-        case .unexpectedResponse(let statusCode):
-            "Unexpected HTTP response: \(statusCode)"
+        case .unexpectedResponse(let statusCode, let body):
+            "Unexpected HTTP response: \(statusCode)" + (body.map { ": \($0)" } ?? "")
         }
     }
 }


### PR DESCRIPTION
Linux release binaries currently require `libswiftCore.so` at runtime. This adds `--static-swift-stdlib` for Linux builds, making binaries portable.

Closes #96