### PR TITLE
Add Page<T> pagination for listCards

### DIFF
--- a/Sources/KaitenSDK/Page.swift
+++ b/Sources/KaitenSDK/Page.swift
@@ -1,0 +1,22 @@
+/// A page of results from a paginated API endpoint.
+public struct Page<T: Sendable>: Sendable {
+    /// The items in this page.
+    public let items: [T]
+    /// The offset used to fetch this page.
+    public let offset: Int
+    /// The limit used to fetch this page.
+    public let limit: Int
+    /// Whether there are likely more results available.
+    /// Determined by `items.count == limit`.
+    public let hasMore: Bool
+
+    public init(items: [T], offset: Int, limit: Int) {
+        self.items = items
+        self.offset = offset
+        self.limit = limit
+        self.hasMore = items.count == limit
+    }
+}
+
+extension Page: Equatable where T: Equatable {}
+extension Page: Encodable where T: Encodable {}

--- a/Sources/kaiten/CardCommands.swift
+++ b/Sources/kaiten/CardCommands.swift
@@ -6,7 +6,7 @@ import KaitenSDK
 struct ListCards: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "list-cards",
-        abstract: "List all cards on a board"
+        abstract: "List cards on a board (paginated)"
     )
 
     @OptionGroup var global: GlobalOptions
@@ -14,10 +14,16 @@ struct ListCards: AsyncParsableCommand {
     @Option(name: .long, help: "Board ID")
     var boardId: Int
 
+    @Option(name: .long, help: "Offset for pagination (default: 0)")
+    var offset: Int = 0
+
+    @Option(name: .long, help: "Limit for pagination (default/max: 100)")
+    var limit: Int = 100
+
     func run() async throws {
         let client = try await global.makeClient()
-        let cards = try await client.listCards(boardId: boardId)
-        try printJSON(cards)
+        let page = try await client.listCards(boardId: boardId, offset: offset, limit: limit)
+        try printJSON(page)
     }
 }
 

--- a/Tests/KaitenSDKTests/ListCardsTests.swift
+++ b/Tests/KaitenSDKTests/ListCardsTests.swift
@@ -16,10 +16,13 @@ struct ListCardsTests {
         let transport = MockClientTransport.returning(statusCode: 200, body: json)
         let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-        let cards = try await client.listCards(boardId: 10)
-        #expect(cards.count == 2)
-        #expect(cards[0].id == 1)
-        #expect(cards[1].title == "Card B")
+        let page = try await client.listCards(boardId: 10)
+        #expect(page.items.count == 2)
+        #expect(page.items[0].id == 1)
+        #expect(page.items[1].title == "Card B")
+        #expect(page.offset == 0)
+        #expect(page.limit == 100)
+        #expect(page.hasMore == false)
     }
 
     @Test("200 empty array returns empty")
@@ -27,8 +30,8 @@ struct ListCardsTests {
         let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
         let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-        let cards = try await client.listCards(boardId: 10)
-        #expect(cards.isEmpty)
+        let page = try await client.listCards(boardId: 10)
+        #expect(page.items.isEmpty)
     }
 
     @Test("200 with empty body returns empty array (#84)")
@@ -36,8 +39,8 @@ struct ListCardsTests {
         let transport = MockClientTransport.returning(statusCode: 200, body: nil)
         let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-        let cards = try await client.listCards(boardId: 10)
-        #expect(cards.isEmpty)
+        let page = try await client.listCards(boardId: 10)
+        #expect(page.items.isEmpty)
     }
 
     @Test("200 with empty string body returns empty array (#84)")
@@ -45,8 +48,8 @@ struct ListCardsTests {
         let transport = MockClientTransport.returning(statusCode: 200, body: "")
         let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-        let cards = try await client.listCards(boardId: 10)
-        #expect(cards.isEmpty)
+        let page = try await client.listCards(boardId: 10)
+        #expect(page.items.isEmpty)
     }
 
     @Test("401 throws unauthorized")


### PR DESCRIPTION
## Summary

Add `Page<T>` pagination support for `listCards`.

### Changes:
- **`Page<T>`** struct: `items`, `offset`, `limit`, `hasMore` (where `hasMore = items.count == limit`)
- **`listCards(boardId:offset:limit:)`** → returns `Page<Card>` instead of `[Card]`
  - Defaults: `offset = 0`, `limit = 100` (matches API max)
- **CLI** `list-cards` gains `--offset` and `--limit` flags
- Tests updated for `Page` return type

### Breaking change
`listCards` return type: `[Card]` → `Page<Card>`. Acceptable pre-1.0.

Closes #101
Part of #41