### PR TITLE
Use human-readable job names in CI and release workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,10 +17,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: macOS
+          - name: macOS ARM64
             os: macos-26
             install-swift: false
-          - name: Linux
+          - name: Linux x86_64
             os: ubuntu-latest
             install-swift: true
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,21 @@ jobs:
       matrix:
         include:
           - os: macos-26
+            name: macOS ARM64
             install-swift: false
             archive-suffix: darwin_arm64
             static-swift-stdlib: false
           - os: ubuntu-latest
+            name: Linux x86_64
             install-swift: true
             archive-suffix: linux_x86_64
             static-swift-stdlib: true
           - os: ubuntu-24.04-arm
+            name: Linux ARM64
             install-swift: true
             archive-suffix: linux_arm64
             static-swift-stdlib: true
+    name: Build (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Consistent with KaitenMCP #34.

CI: `macOS ARM64`, `Linux x86_64`
Release: `Build (macOS ARM64)`, `Build (Linux x86_64)`, `Build (Linux ARM64)`