### PR TITLE
Fix cell_wip_limits deserialization: object not array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.xcodeproj/
 *.xcworkspace/
 .claude/
+Sources/KaitenSDK/GeneratedSources/

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -836,12 +836,9 @@ components:
           type: string
           description: Board title
         cell_wip_limits:
-          type: array
-          items:
-            type:
-            - object
-            - 'null'
-          description: JSON containing wip limits rules for cells
+          description: JSON containing wip limits rules for cells. Object with "limits" array, not an array itself.
+          type: object
+          additionalProperties: true
         external_id:
           type:
           - string
@@ -1151,12 +1148,9 @@ components:
           type: string
           description: Board title
         cell_wip_limits:
-          type: array
-          items:
-            type:
-            - object
-            - 'null'
-          description: JSON containing wip limits rules for cells
+          description: JSON containing wip limits rules for cells. Object with "limits" array, not an array itself.
+          type: object
+          additionalProperties: true
         external_id:
           type:
           - string


### PR DESCRIPTION
API returns `cell_wip_limits` as an object (`{"limits": [...]}`), not an array. Fixes deserialization failure on `list-boards`.

Closes #109