### PR TITLE
Upload CI build artifacts with 1-day retention

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,3 +42,10 @@ jobs:
 
       - name: Test
         run: swift test
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: kaiten-${{ matrix.name }}
+          path: .build/debug/kaiten
+          retention-days: 1


### PR DESCRIPTION
Upload debug binary as artifact after each CI run (1-day retention).

Closes #111