### PR TITLE
Install libcurl-dev on Linux in CI and Release workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,6 +31,10 @@ jobs:
         if: matrix.install-swift
         uses: jdx/mise-action@v3
 
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
+
       - name: Cache SPM
         uses: actions/cache@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,10 @@ jobs:
         if: matrix.install-swift
         uses: jdx/mise-action@v3
 
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
+
       - name: Build release binary
         id: build
         run: |


### PR DESCRIPTION
Ensures both CI and Release workflows install `libcurl4-openssl-dev` on Linux runners. Required for `--static-swift-stdlib` linking (Foundation's URL session references curl symbols).

Keeps build environments identical between CI and Release per project convention.