### PR TITLE
Use mise for Swift on all platforms including macOS

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,16 +19,13 @@ jobs:
         include:
           - name: macOS ARM64
             os: macos-26
-            install-swift: false
           - name: Linux x86_64
             os: ubuntu-latest
-            install-swift: true
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
 
       - name: Install mise
-        if: matrix.install-swift
         uses: jdx/mise-action@v3
 
       - name: Install system dependencies (Linux)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,17 +14,14 @@ jobs:
         include:
           - os: macos-26
             name: macOS ARM64
-            install-swift: false
             archive-suffix: darwin_arm64
             static-swift-stdlib: false
           - os: ubuntu-latest
             name: Linux x86_64
-            install-swift: true
             archive-suffix: linux_x86_64
             static-swift-stdlib: true
           - os: ubuntu-24.04-arm
             name: Linux ARM64
-            install-swift: true
             archive-suffix: linux_arm64
             static-swift-stdlib: true
     name: Build (${{ matrix.name }})
@@ -34,7 +31,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install mise
-        if: matrix.install-swift
         uses: jdx/mise-action@v3
 
       - name: Install system dependencies (Linux)


### PR DESCRIPTION
Closes #126

- Remove `install-swift` matrix flag — mise now runs on all platforms
- Swift version pinned in `mise.toml` (6.2.3) — single source of truth
- macOS no longer depends on Xcode-bundled Swift
- Both CI and Release workflows use identical setup steps