### PR TITLE
Add getCardComments endpoint

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -133,6 +133,24 @@ public struct KaitenClient: Sendable {
             throw .unexpectedResponse(statusCode: code)
         }
     }
+
+
+    /// Fetches comments for a card.
+    public func getCardComments(cardId: Int) async throws(KaitenError) -> [Components.Schemas.Comment] {
+        let response = try await call { try await client.retrieve_card_comments(path: .init(card_id: cardId)) }
+        switch response {
+        case .ok(let ok):
+            return try decode { try ok.body.json }
+        case .unauthorized(_):
+            throw .unauthorized
+        case .forbidden(_):
+            throw .unexpectedResponse(statusCode: 403)
+        case .notFound(_):
+            throw .notFound(resource: "card", id: cardId)
+        case .undocumented(statusCode: let code, _):
+            throw .unexpectedResponse(statusCode: code)
+        }
+    }
 }
 
 // MARK: - Custom Properties

--- a/Sources/kaiten/CardCommands.swift
+++ b/Sources/kaiten/CardCommands.swift
@@ -45,6 +45,24 @@ struct GetCard: AsyncParsableCommand {
     }
 }
 
+struct GetCardComments: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "get-card-comments",
+        abstract: "Get comments on a card"
+    )
+
+    @OptionGroup var global: GlobalOptions
+
+    @Option(name: .long, help: "Card ID")
+    var cardId: Int
+
+    func run() async throws {
+        let client = try await global.makeClient()
+        let comments = try await client.getCardComments(cardId: cardId)
+        try printJSON(comments)
+    }
+}
+
 struct GetCardMembers: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "get-card-members",

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -17,6 +17,7 @@ struct Kaiten: AsyncParsableCommand {
             GetBoardLanes.self,
             ListCards.self,
             GetCard.self,
+            GetCardComments.self,
             GetCardMembers.self,
             ListCustomProperties.self,
             GetCustomProperty.self,

--- a/Tests/KaitenSDKTests/CardCommentsTests.swift
+++ b/Tests/KaitenSDKTests/CardCommentsTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("CardComments")
+struct CardCommentsTests {
+
+    @Test("getCardComments 200 returns array")
+    func listSuccess() async throws {
+        let json = """
+            [{"id": 1, "uid": 1, "text": "Hello", "type": 1, "edited": false, "card_id": 100, "author_id": 5, "internal": false, "deleted": false, "sd_description": false, "updated": "2025-01-01", "created": "2025-01-01"}]
+            """
+        let transport = MockClientTransport.returning(statusCode: 200, body: json)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+        let comments = try await client.getCardComments(cardId: 100)
+        #expect(comments.count == 1)
+        #expect(comments[0].text == "Hello")
+    }
+
+    @Test("getCardComments 404 throws notFound")
+    func notFound() async throws {
+        let transport = MockClientTransport.returning(statusCode: 404)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+        await #expect(throws: KaitenError.self) {
+            _ = try await client.getCardComments(cardId: 999)
+        }
+    }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -175,6 +175,32 @@ paths:
           description: Invalid token
         '403':
           description: Forbidden
+  /cards/{card_id}/comments:
+    get:
+      summary: Retrieve card comments
+      operationId: retrieve_card_comments
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Comment'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
   /company/custom-properties:
     get:
       summary: Get list of properties
@@ -390,7 +416,9 @@ components:
           type: integer
           description: Card condition
         last_moved_at:
-          type: string
+          type:
+          - string
+          - 'null'
           description: Last moved timestamp
         external_id:
           type:
@@ -398,10 +426,14 @@ components:
           - 'null'
           description: External ID
         lane_changed_at:
-          type: string
+          type:
+          - string
+          - 'null'
           description: Lane change timestamp
         column_changed_at:
-          type: string
+          type:
+          - string
+          - 'null'
           description: Column change timestamp
         first_moved_to_in_progress_at:
           type:
@@ -419,7 +451,9 @@ components:
           - 'null'
           description: Service ID
         properties:
-          type: object
+          type:
+          - object
+          - 'null'
           description: Custom properties values
           additionalProperties: true
         planned_start:
@@ -848,7 +882,9 @@ components:
           description: Board title
         cell_wip_limits:
           description: JSON containing wip limits rules for cells. Object with "limits" array, not an array itself.
-          type: object
+          type:
+          - object
+          - 'null'
           additionalProperties: true
         external_id:
           type:
@@ -1081,6 +1117,56 @@ components:
           - string
           - 'null'
           description: Calculation method
+    Comment:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Comment ID
+        uid:
+          type: integer
+          description: Comment UID
+        text:
+          type: string
+          description: Comment text
+        type:
+          type: integer
+          description: "Comment type: 1-markdown, 2-html"
+        edited:
+          type: boolean
+          description: Whether comment was edited
+        card_id:
+          type: integer
+          description: Card ID
+        author_id:
+          type: integer
+          description: Author ID
+        email_addresses_to:
+          type: string
+          description: Mail addresses to send comment
+        internal:
+          type: boolean
+          description: Internal flag
+        deleted:
+          type: boolean
+          description: Deleted flag
+        sd_external_recipients_cc:
+          type: string
+          nullable: true
+          description: Service desk external recipients
+        sd_description:
+          type: boolean
+          description: Flag indicating comment is used as request description
+        notification_sent:
+          type: string
+          nullable: true
+          description: Notification sent date
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
     MemberDetailed:
       type: object
       properties:
@@ -1160,7 +1246,9 @@ components:
           description: Board title
         cell_wip_limits:
           description: JSON containing wip limits rules for cells. Object with "limits" array, not an array itself.
-          type: object
+          type:
+          - object
+          - 'null'
           additionalProperties: true
         external_id:
           type:


### PR DESCRIPTION
Closes #130

- OpenAPI spec: `GET /cards/{card_id}/comments` with `Comment` schema
- `KaitenClient.getCardComments(cardId:)` method
- CLI: `get-card-comments` command
- Tests: 200 success and 404 not found

Comment fields verified against Kaiten API docs. Nullable fields: `sd_external_recipients_cc`, `notification_sent`.