### PR TITLE
Update Kaiten docs parsing guide: Schema button support

### DIFF
--- a/docs/kaiten-docs-parsing.md
+++ b/docs/kaiten-docs-parsing.md
@@ -79,7 +79,51 @@ section = content[max(0, idx-100) : idx+2000]
 В Path parameters поле помечено `required` явно (например `board_id required integer`).
 В Query parameters `required` указан как constraint, если не указан — параметр опциональный.
 
-### 7. Batch-парсинг нескольких эндпоинтов
+### 7. Раскрытие вложенных схем (Schema buttons)
+
+Поля с типом `object Schema` или `array Schema` имеют кнопку **Schema** (MUI Button), которая открывает **модальное окно** (MUI Dialog) с описанием вложенных полей. `text_content('body')` **НЕ** показывает содержимое этих схем — нужно кликнуть по кнопке и прочитать диалог.
+
+```python
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True, args=['--no-sandbox'])
+    page = browser.new_page()
+    page.goto(url, wait_until='networkidle', timeout=30000)
+    page.wait_for_timeout(3000)
+
+    # Найти все кнопки Schema
+    buttons = page.query_selector_all('button.MuiButton-root')
+    schema_buttons = [b for b in buttons if b.text_content().strip() == 'Schema']
+
+    for btn in schema_buttons:
+        # Имя поля из строки таблицы
+        field_info = btn.evaluate(
+            'el => el.closest("tr")?.textContent || "unknown"'
+        )
+
+        btn.click(timeout=3000)
+        page.wait_for_timeout(1000)
+
+        # Прочитать содержимое диалога
+        dialog = page.query_selector('.MuiDialog-root')
+        if dialog:
+            schema_text = dialog.text_content()
+            print(f"{field_info}: {schema_text}")
+
+            # Закрыть диалог перед следующим кликом
+            page.keyboard.press('Escape')
+            page.wait_for_timeout(500)
+
+    browser.close()
+```
+
+**Важно:**
+- Диалог блокирует клики по остальным элементам — **обязательно закрывать** через `Escape` перед переходом к следующей кнопке
+- Вложенные схемы могут содержать свои кнопки Schema (рекурсивные типы, например `children` → Card)
+- Формат текста в диалоге: `FieldNameType: typeNameTypeDescriptionfield1type1desc1field2type2desc2...`
+
+### 8. Batch-парсинг нескольких эндпоинтов
 ```python
 urls = {
     'columns': 'https://developers.kaiten.ru/columns/get-list-of-columns',
@@ -97,7 +141,7 @@ with sync_playwright() as p:
     browser.close()
 ```
 
-### 8. Важные нюансы
+### 9. Важные нюансы
 - **Один браузер, много page.goto()** — не создавай новый браузер на каждый URL
 - **wait_for_timeout(3000)** — иногда нужен после networkidle для полного рендера
 - **text_content('body')** — возвращает весь текст без HTML тегов


### PR DESCRIPTION
Updates the parsing guide with instructions for extracting nested schema definitions.

**Problem:** Fields with `object Schema` or `array Schema` types have a Schema button that opens a MUI Dialog with nested field definitions. `text_content('body')` does NOT capture this content — you need to click the button and read the dialog.

**Added:**
- Section 7: How to find and click Schema buttons (`button.MuiButton-root`)
- How to read MUI Dialog content (`.MuiDialog-root`)
- How to close dialog (Escape) before proceeding to next button
- Complete code example
- Caveats: dialog blocks clicks, recursive schemas possible