### PR TITLE
Type columns/lanes/cards arrays in Board and BoardInSpace

### DIFF
--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -932,17 +932,17 @@ components:
         columns:
           type: array
           items:
-            type: object
+            $ref: '#/components/schemas/Column'
           description: Board columns
         lanes:
           type: array
           items:
-            type: object
+            $ref: '#/components/schemas/Lane'
           description: Board lanes
         cards:
           type: array
           items:
-            type: object
+            $ref: '#/components/schemas/Card'
           description: Board cards
     Space:
       type: object
@@ -1298,12 +1298,12 @@ components:
         columns:
           type: array
           items:
-            type: object
+            $ref: '#/components/schemas/Column'
           description: Board columns
         lanes:
           type: array
           items:
-            type: object
+            $ref: '#/components/schemas/Lane'
           description: Board lanes
         top:
           type: integer


### PR DESCRIPTION
Closes #147

## What
Replace bare `type: object` array items in Board and BoardInSpace with `$ref` to existing schemas:
- `columns` → `Column`
- `lanes` → `Lane`
- `cards` → `Card` (Board only)

## Why
These arrays were generating `OpenAPIObjectContainer` — no type safety. The schemas already exist in the spec, just weren't referenced.

## Verification needed
- CI green (compilation + tests)
- Download binary, test `get-board` and `list-boards` against live API