### PR TITLE
Add CardType schema for type field in Card

### DIFF
--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -616,8 +616,7 @@ components:
           type: object
           description: Inline board summary
         type:
-          type: object
-          description: Inline card type summary
+          $ref: '#/components/schemas/CardType'
         owner:
           $ref: '#/components/schemas/User'
         key:
@@ -1382,6 +1381,54 @@ components:
           - string
           - 'null'
           description: Delete request timestamp
+        created:
+          type: string
+          description: Create date
+        updated:
+          type: string
+          description: Last update timestamp
+    CardType:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Card type id
+        name:
+          type: string
+          description: Card type name
+        color:
+          type: integer
+          description: Color number
+        letter:
+          type: string
+          description: Card type letter
+        description_template:
+          type:
+          - string
+          - 'null'
+          description: Card type description template
+        company_id:
+          type: integer
+          description: Company id
+        properties:
+          type:
+          - object
+          - 'null'
+          description: Card type properties (preset and custom)
+        archived:
+          type: boolean
+          description: Archived flag
+        suggest_fields:
+          type: boolean
+          description: Suggest fields flag
+        uid:
+          type: string
+          description: Card type uid
+        author_uid:
+          type:
+          - string
+          - 'null'
+          description: Author uid
         created:
           type: string
           description: Create date


### PR DESCRIPTION
Closes #139

## What
- Add `CardType` schema with all fields from [Kaiten docs](https://developers.kaiten.ru/cards/retrieve-card) (Schema button for `type`)
- Replace bare `type: object` for Card's `type` field with `$ref: CardType`

## Fields
id, name, color, letter, description_template (nullable), company_id, properties (nullable object), archived, suggest_fields, uid, author_uid (nullable), created, updated

## Notes
- `suggest_fields`, `uid`, `author_uid` are present in real API responses but not in docs Schema button. Added based on live API data for completeness.
- `properties` remains `nullable object` — its internal structure varies per card type configuration