### PR TITLE
Complete Tag schema with all fields from Kaiten docs

### DIFF
--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -694,12 +694,25 @@ components:
       properties:
         id:
           type: integer
+          description: Card tag id
         name:
           type: string
+          description: Card tag name
+        company_id:
+          type: integer
+          description: Company id
         color:
-          type:
-          - integer
-          - 'null'
+          type: integer
+          description: Card tag color number
+        archived:
+          type: boolean
+          description: Archived flag
+        created:
+          type: string
+          description: Create date
+        updated:
+          type: string
+          description: Last update timestamp
     Column:
       type: object
       properties:


### PR DESCRIPTION
Closes #141

## What
- Add missing fields to `Tag` schema: `company_id`, `archived`, `created`, `updated`
- Fix `color`: was `integer | null`, docs say plain `integer`
- Add descriptions to all fields

## Source
https://developers.kaiten.ru/cards/retrieve-card → Schema button for `tags`