### PR TITLE
Add ExternalLink schema for external_links in Card

### DIFF
--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -657,7 +657,7 @@ components:
         external_links:
           type: array
           items:
-            type: object
+            $ref: '#/components/schemas/ExternalLink'
           description: External links
         blocked_by_card_ids:
           type: array
@@ -1442,6 +1442,30 @@ components:
           - string
           - 'null'
           description: Author uid
+        created:
+          type: string
+          description: Create date
+        updated:
+          type: string
+          description: Last update timestamp
+    ExternalLink:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: External link id
+        url:
+          type: string
+          description: External link url
+        description:
+          type: string
+          description: External link description
+        card_id:
+          type: integer
+          description: Card id
+        external_link_id:
+          type: integer
+          description: External link id
         created:
           type: string
           description: Create date


### PR DESCRIPTION
Closes #143

## What
- Add `ExternalLink` schema with all fields from [Kaiten docs](https://developers.kaiten.ru/cards/retrieve-card) (Schema button for `external_links`)
- Replace bare `type: object` array items with `$ref: ExternalLink`

## Fields
id, url, description, card_id, external_link_id, created, updated

## Notes
- `id` listed as `number` in docs but using `integer` for consistency (all other IDs in the API are integers)
- `card_id` had no type in docs, using `integer` by convention