### PR TITLE
Use Board ref for inline board in Card

### DIFF
--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -613,8 +613,7 @@ components:
           type: object
           description: Inline column summary
         board:
-          type: object
-          description: Inline board summary
+          $ref: '#/components/schemas/Board'
         type:
           $ref: '#/components/schemas/CardType'
         owner:


### PR DESCRIPTION
Closes #140

## What
Replace bare `type: object` for `Card.board` with `$ref: Board`.

## Why
[Kaiten docs](https://developers.kaiten.ru/cards/retrieve-card) (Schema button for `board`) confirm the inline board has the same fields as the standalone Board schema.

## Risk
This creates a **circular reference**: `Board.cards` → `Card`, `Card.board` → `Board`. CI will tell us if swift-openapi-generator handles this. If it doesn't compile, we'll need a separate `CardBoardSummary` schema instead.

## Verification
- CI compilation (key test — circular ref support)
- Download binary, test `get-card` against live API