### PR TITLE
Type children/parents as recursive Card references

### DIFF
--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -641,12 +641,12 @@ components:
         children:
           type: array
           items:
-            type: object
+            $ref: '#/components/schemas/Card'
           description: Child cards
         parents:
           type: array
           items:
-            type: object
+            $ref: '#/components/schemas/Card'
           description: Parent cards
         files:
           type: array


### PR DESCRIPTION
Closes #146

Replace bare `type: object` for `children` and `parents` array items with `$ref: Card`.

Kaiten docs confirm these are full Card objects. Circular refs already proven to work in PR #156 (Card.board → Board → Card).