### PR TITLE
Add English-only language policy to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,16 @@
 # KaitenSDK — Development Guidelines
 
+## Language Policy
+
+**English only.** All content in this repository MUST be in English:
+- Code, comments, documentation
+- Commit messages, PR titles and descriptions
+- Issue titles and descriptions
+- Specs, READMEs, and any other markdown files
+- YAML descriptions in OpenAPI spec
+
+No exceptions. Existing Russian content will be translated (see #163).
+
 ## Spec-First Development
 
 Спецификации в `specs/` — единственный источник правды о том,


### PR DESCRIPTION
Adds a language policy section: all repository content must be in English — code, commits, PRs, issues, specs, docs, OpenAPI descriptions.

Existing Russian content will be translated in #163.