### PR TITLE
chore: translate all Russian content to English

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -4,57 +4,57 @@
 
 ### I. OpenAPI-First
 
-OpenAPI-спека — единственный источник правды для API-контракта.
-Клиентский код генерируется из неё. Ручной код HTTP-запросов
-запрещён.
+The OpenAPI spec is the single source of truth for the API contract.
+Client code is generated from it. Hand-written HTTP request code
+is prohibited.
 
 ### II. Generated Over Handwritten
 
-Предпочитаем генерацию кода ручному написанию. Если что-то можно
-сгенерировать из спеки — генерируем. Обёртки поверх сгенерированного
-кода MUST быть минимальными и служить исключительно удобству API.
+Prefer code generation over hand-writing. If something can be
+generated from the spec — generate it. Wrappers over generated
+code MUST be minimal and serve solely for API convenience.
 
 ### III. Configuration as Code
 
-Настройки — через конфиг-файлы или аргументы.
-Захардкоженные значения запрещены.
+Settings — via config files or arguments.
+Hard-coded values are prohibited.
 
 ### IV. Simplicity
 
-YAGNI. Реализуем только то, что нужно прямо сейчас.
-Новые эндпоинты добавляются в OpenAPI-спеку → клиент
-перегенерируется автоматически. Преждевременные абстракции запрещены.
+YAGNI. Implement only what is needed right now.
+New endpoints are added to the OpenAPI spec → the client
+is regenerated automatically. Premature abstractions are prohibited.
 
 ## Quality Gates
 
-- CI MUST проходить
-- OpenAPI-спека MUST быть валидна
-- Сгенерированный код MUST компилироваться без ошибок
-- Тесты MUST проходить
+- CI MUST pass
+- OpenAPI spec MUST be valid
+- Generated code MUST compile without errors
+- Tests MUST pass
 
 ## Governance
 
-Конституция имеет приоритет над всеми другими практиками проекта.
+The constitution takes priority over all other project practices.
 
 ### Amendment Procedure
 
-1. Предложение изменения оформляется с обоснованием.
-2. Изменение документируется в этом файле.
-3. Версия обновляется по правилам семантического версионирования.
+1. A change proposal is submitted with justification.
+2. The change is documented in this file.
+3. The version is updated following semantic versioning rules.
 
 ### Versioning Policy
 
-- **MAJOR**: обратно несовместимые изменения принципов (удаление,
-  переопределение).
-- **MINOR**: добавление нового принципа или существенное расширение
-  существующего раздела.
-- **PATCH**: уточнения формулировок, исправление опечаток,
-  несемантические правки.
+- **MAJOR**: backward-incompatible changes to principles (removal,
+  redefinition).
+- **MINOR**: addition of a new principle or significant expansion
+  of an existing section.
+- **PATCH**: wording clarifications, typo fixes,
+  non-semantic edits.
 
 ### Compliance Review
 
-- Каждый PR MUST проверяться на соответствие принципам конституции.
-- Нарушения допустимы только с явным обоснованием в Complexity
-  Tracking секции плана.
+- Every PR MUST be reviewed for compliance with constitution principles.
+- Violations are acceptable only with explicit justification in the
+  Complexity Tracking section of the plan.
 
 **Version**: 2.0.0 | **Ratified**: 2026-02-14 | **Last Amended**: 2026-02-16

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,50 +13,50 @@ No exceptions. Existing Russian content will be translated (see #163).
 
 ## Spec-First Development
 
-Спецификации в `specs/` — единственный источник правды о том,
-что и как делается в проекте.
+Specifications in `specs/` are the single source of truth for what
+is being built and how.
 
-### Порядок работы
+### Workflow
 
-1. **Сначала спека** — перед реализацией нового функционала
-   обновить или создать спецификацию в `specs/`.
-2. **Потом реализация** — код пишется строго по спеке.
-3. **Каждое изменение** функционала MUST сопровождаться
-   обновлением соответствующей спеки.
+1. **Spec first** — before implementing new functionality,
+   update or create a specification in `specs/`.
+2. **Then implement** — code is written strictly according to the spec.
+3. **Every change** to functionality MUST be accompanied by
+   an update to the corresponding spec.
 
-### Структура спек
+### Spec Structure
 
-- `specs/001-kaiten-sdk-core/spec.md` — SDK: OpenAPI-генерация,
-  типизированные ошибки, convenience-обёртки
-- `specs/002-kaiten-cli/spec.md` — CLI: тонкая обёртка над SDK,
-  конфиг-файл, подкоманды
+- `specs/001-kaiten-sdk-core/spec.md` — SDK: OpenAPI generation,
+  typed errors, convenience wrappers
+- `specs/002-kaiten-cli/spec.md` — CLI: thin wrapper over SDK,
+  config file, subcommands
 
-### Конституция
+### Constitution
 
-Архитектурные принципы и ограничения зафиксированы в
-`.specify/memory/constitution.md`. Конституция имеет приоритет
-над всеми другими практиками.
+Architectural principles and constraints are documented in
+`.specify/memory/constitution.md`. The constitution takes priority
+over all other project practices.
 
-### Правила для агентов
+### Rules for Agents
 
-- НЕ реализовывать функционал, не описанный в спеке.
-- При обнаружении расхождения между кодом и спекой —
-  уточнить у пользователя, что является правильным.
-- При добавлении нового функционала — сначала обновить спеку,
-  получить подтверждение, затем реализовать.
+- DO NOT implement functionality not described in the spec.
+- If a discrepancy between code and spec is found,
+  clarify with the user which is correct.
+- When adding new functionality — update the spec first,
+  get confirmation, then implement.
 - Always update READMEs when public APIs change. Any PR that
   modifies public API surface must include corresponding README
   updates.
 
 ## Kaiten API Documentation
 
-Подробный гайд по парсингу документации Kaiten API: [docs/kaiten-docs-parsing.md](docs/kaiten-docs-parsing.md)
+Detailed guide for parsing Kaiten API documentation: [docs/kaiten-docs-parsing.md](docs/kaiten-docs-parsing.md)
 
-### Обязательное правило
+### Mandatory Rule
 
-**Перед любым изменением OpenAPI спеки** (`openapi/kaiten.yaml`) — обязательно проверить по документации Kaiten API (https://developers.kaiten.ru), как эндпоинт выглядит на самом деле:
-- Какие query/path параметры принимает
-- Какие поля в ответе обязательные (`integer`, `string`), а какие nullable (`null | string`)
-- Есть ли пагинация (`offset`/`limit`)
+**Before any change to the OpenAPI spec** (`openapi/kaiten.yaml`) — you must verify against the Kaiten API documentation (https://developers.kaiten.ru) how the endpoint actually works:
+- Which query/path parameters it accepts
+- Which response fields are required (`integer`, `string`) and which are nullable (`null | string`)
+- Whether pagination is supported (`offset`/`limit`)
 
-Не менять спеку по догадкам или на основе эмпирических данных. Только по документации.
+Do not modify the spec based on guesses or empirical data. Only based on documentation.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ let card = try await client.getCard(id: 123)
 
 #### mise (recommended)
 
-[mise](https://mise.jdx.dev) — менеджер инструментов. Установит нужную версию автоматически:
+[mise](https://mise.jdx.dev) — a tool version manager. It will install the required version automatically:
 
 ```bash
 mise use -g ubi:AllDmeat/KaitenSDK --rename kaiten
@@ -56,13 +56,13 @@ mise use -g ubi:AllDmeat/KaitenSDK --rename kaiten
 
 #### GitHub Release
 
-Скачайте бинарь для вашей платформы со [страницы релизов](https://github.com/AllDmeat/KaitenSDK/releases).
+Download the binary for your platform from the [releases page](https://github.com/AllDmeat/KaitenSDK/releases).
 
-#### Из исходников
+#### From Source
 
 ```bash
 swift build -c release
-# Бинарь: .build/release/kaiten
+# Binary: .build/release/kaiten
 ```
 
 ### As a CLI

--- a/docs/sdk-review.md
+++ b/docs/sdk-review.md
@@ -1,98 +1,98 @@
 # SDK Review & Improvement Plan
 
-Issue #41. Полный ревью кодовой базы KaitenSDK.
+Issue #41. Full review of the KaitenSDK codebase.
 
 ---
 
 ## P1 — API Design
 
 ### 1. MockTransport: NSLock → Mutex
-`MockClientTransport` помечен `@unchecked Sendable` с `NSLock`. По правилу FR-014 — нужен `Mutex` из `Synchronization`.
+`MockClientTransport` is marked `@unchecked Sendable` with `NSLock`. Per rule FR-014 — should use `Mutex` from `Synchronization`.
 
-### 2. Write-операции отсутствуют
-В OpenAPI-спеке есть, но не реализованы в SDK:
-- `create_card` — создание карточки
-- `update_card` — обновление карточки
-- `delete_card` — удаление карточки
-- `add_comment` — добавление комментария
-- `retrieve_card_comments` — чтение комментариев
-- `add_member_to_card` — добавление участника
-- `update_member_role` — обновление роли участника
-- `remove_member_from_card` — удаление участника
+### 2. Write operations are missing
+Present in OpenAPI spec but not implemented in SDK:
+- `create_card` — create a card
+- `update_card` — update a card
+- `delete_card` — delete a card
+- `add_comment` — add a comment
+- `retrieve_card_comments` — read comments
+- `add_member_to_card` — add a member
+- `update_member_role` — update member role
+- `remove_member_from_card` — remove a member
 
-Для MCP write-tools это блокер.
+This is a blocker for MCP write-tools.
 
-### 3. Недостающие read-операции
-Есть в спеке, не реализованы:
-- `retrieve_space` — получить пространство по id
-- `retrieve_card_comments` — комментарии карточки
-- `retrieve_card_checklist` — чеклист карточки
-- `rertrieve_list_of_tags` — теги карточки
-- `retrieve_list_of_tags` — все теги
-- `get_list_of_subcolumns` — подколонки
+### 3. Missing read operations
+Present in spec, not implemented:
+- `retrieve_space` — get a space by id
+- `retrieve_card_comments` — card comments
+- `retrieve_card_checklist` — card checklist
+- `rertrieve_list_of_tags` — card tags
+- `retrieve_list_of_tags` — all tags
+- `get_list_of_subcolumns` — subcolumns
 
-### 4. KaitenConfiguration — сделать public
-Сейчас конфиг резолвится только через env. Для гибкости — дать возможность передавать конфиг явно (internal init уже есть, нужен public).
+### 4. KaitenConfiguration — make public
+Currently config is resolved only via env. For flexibility — allow passing config explicitly (internal init already exists, need public).
 
 ---
 
 ## P2 — Error Handling
 
-### 5. Унифицировать обработку ответов через fromHTTPStatus
-`KaitenError.fromHTTPStatus()` — хороший хелпер, но в `KaitenClient` каждый метод вручную матчит response cases. Можно унифицировать, уменьшив дублирование.
+### 5. Unify response handling via fromHTTPStatus
+`KaitenError.fromHTTPStatus()` is a good helper, but in `KaitenClient` each method manually matches response cases. Can be unified to reduce duplication.
 
-### 6. Добавить KaitenError.forbidden
-403 маппится в `unexpectedResponse(statusCode: 403)` в нескольких методах. Стоит добавить отдельный case `.forbidden`.
+### 6. Add KaitenError.forbidden
+403 maps to `unexpectedResponse(statusCode: 403)` in several methods. Should add a separate `.forbidden` case.
 
 ---
 
 ## P3 — Test Coverage
 
-### 7. RetryMiddleware: тест на парсинг Retry-After
-Тест проверяет что retry происходит, но не проверяет что `Retry-After` header реально парсится.
+### 7. RetryMiddleware: test Retry-After parsing
+Test verifies that retry occurs, but doesn't verify that the `Retry-After` header is actually parsed.
 
-### 8. Тесты на fromHTTPStatus
-Утилитный метод без тестов.
+### 8. Tests for fromHTTPStatus
+Utility method without tests.
 
-### 9. Edge case тесты
-- Пустой JSON-ответ
-- Невалидный JSON
-- Пустой массив (listCards с пустой доской)
+### 9. Edge case tests
+- Empty JSON response
+- Invalid JSON
+- Empty array (listCards with an empty board)
 
 ---
 
 ## P4 — Documentation & Ergonomics
 
-### 10. README: примеры кода
-Нет Swift code snippet с `import KaitenSDK` и вызовом метода.
+### 10. README: code examples
+No Swift code snippet with `import KaitenSDK` and a method call.
 
 ### 11. DocC documentation target
-Публичные методы имеют doc-comments, но нет DocC каталога.
+Public methods have doc-comments, but no DocC catalog.
 
 ---
 
 ## P5 — Performance
 
-### 12. Exponential backoff в RetryMiddleware
-Дефолт 1 секунда ок, но стоит добавить exponential backoff для последовательных retry.
+### 12. Exponential backoff in RetryMiddleware
+Default 1 second is ok, but should add exponential backoff for sequential retries.
 
 ---
 
 ## Summary
 
-| # | Приоритет | Предложение | Effort |
-|---|-----------|-------------|--------|
+| # | Priority | Proposal | Effort |
+|---|----------|----------|--------|
 | 1 | P1 | NSLock → Mutex | S |
-| 2 | P1 | Write-операции (CRUD cards, comments, members) | L |
-| 3 | P1 | Недостающие read-операции | M |
+| 2 | P1 | Write operations (CRUD cards, comments, members) | L |
+| 3 | P1 | Missing read operations | M |
 | 4 | P1 | Public config init | S |
-| 5 | P2 | Унифицировать error handling через fromHTTPStatus | M |
-| 6 | P2 | Добавить KaitenError.forbidden | S |
-| 7 | P3 | Тест retry с Retry-After | S |
-| 8 | P3 | Тесты fromHTTPStatus | S |
-| 9 | P3 | Edge case тесты | M |
+| 5 | P2 | Unify error handling via fromHTTPStatus | M |
+| 6 | P2 | Add KaitenError.forbidden | S |
+| 7 | P3 | Test retry with Retry-After | S |
+| 8 | P3 | Tests for fromHTTPStatus | S |
+| 9 | P3 | Edge case tests | M |
 | 10 | P4 | README code examples | S |
 | 11 | P4 | DocC target | M |
 | 12 | P5 | Exponential backoff | S |
 
-Жду одобрения — одобренные пункты заведу отдельными issues/задачами.
+Awaiting approval — approved items will be filed as separate issues/tasks.

--- a/specs/001-kaiten-sdk-core/spec.md
+++ b/specs/001-kaiten-sdk-core/spec.md
@@ -3,120 +3,120 @@
 **Feature Branch**: `001-kaiten-sdk-core`
 **Created**: 2026-02-14
 **Status**: Draft
-**Input**: Swift-библиотека для работы с Kaiten API. Получение карточек, досок, полей (assignees, команды, платформы). Будет использоваться как зависимость в MCP-сервере.
+**Input**: A Swift library for working with the Kaiten API. Fetching cards, boards, fields (assignees, teams, platforms). Will be used as a dependency in the MCP server.
 
 ## User Scenarios & Testing
 
-### User Story 1 — Получить карточку по ID (Priority: P1)
+### User Story 1 — Get a Card by ID (Priority: P1)
 
-Разработчик (или MCP-сервер) запрашивает детали карточки по её ID. Получает все поля: название, описание, статус, assignees, custom properties (команда, платформа).
+A developer (or MCP server) requests card details by its ID. Receives all fields: title, description, status, assignees, custom properties (team, platform).
 
-**Why this priority**: Это базовая операция — без неё ничего не работает.
+**Why this priority**: This is the fundamental operation — nothing works without it.
 
-**Independent Test**: Вызвать `client.getCard(id: 123)`, получить структуру `Card` со всеми полями.
+**Independent Test**: Call `client.getCard(id: 123)`, receive a `Card` struct with all fields.
 
 **Acceptance Scenarios**:
 
-1. **Given** валидный токен и ID карточки, **When** вызываю `getCard(id:)`, **Then** получаю `Card` со всеми полями включая custom properties
-2. **Given** невалидный ID, **When** вызываю `getCard(id:)`, **Then** получаю типизированную ошибку (не крэш)
-3. **Given** невалидный токен, **When** вызываю `getCard(id:)`, **Then** получаю ошибку авторизации
+1. **Given** a valid token and card ID, **When** I call `getCard(id:)`, **Then** I receive a `Card` with all fields including custom properties
+2. **Given** an invalid ID, **When** I call `getCard(id:)`, **Then** I receive a typed error (no crash)
+3. **Given** an invalid token, **When** I call `getCard(id:)`, **Then** I receive an authorization error
 
 ---
 
-### User Story 2 — Получить список карточек на доске (Priority: P1)
+### User Story 2 — Get a List of Cards on a Board (Priority: P1)
 
-Разработчик запрашивает все карточки конкретной доски. Получает список с базовыми полями + assignees.
+A developer requests all cards for a specific board. Receives a list with basic fields + assignees.
 
-**Why this priority**: Нужно для обзора доски — кто чем занят, что в каком статусе.
+**Why this priority**: Needed for board overview — who is working on what, what status things are in.
 
-**Independent Test**: Вызвать `client.listCards(boardId: 456)`, получить массив `[Card]`.
+**Independent Test**: Call `client.listCards(boardId: 456)`, receive an array `[Card]`.
 
 **Acceptance Scenarios**:
 
-1. **Given** валидный board ID, **When** вызываю `listCards(boardId:)`, **Then** получаю массив карточек с полями
-2. **Given** доска без карточек, **When** вызываю `listCards(boardId:)`, **Then** получаю пустой массив
-3. **Given** невалидный board ID, **When** вызываю `listCards(boardId:)`, **Then** получаю типизированную ошибку
+1. **Given** a valid board ID, **When** I call `listCards(boardId:)`, **Then** I receive an array of cards with fields
+2. **Given** a board with no cards, **When** I call `listCards(boardId:)`, **Then** I receive an empty array
+3. **Given** an invalid board ID, **When** I call `listCards(boardId:)`, **Then** I receive a typed error
 
 ---
 
-### User Story 3 — Получить members и custom properties карточки (Priority: P1)
+### User Story 3 — Get Members and Custom Properties of a Card (Priority: P1)
 
-Разработчик получает информацию о том, на кого назначена карточка (members), какой команде принадлежит, на какой платформе (через custom properties).
+A developer retrieves information about who is assigned to a card (members), which team it belongs to, and which platform it's on (via custom properties).
 
-**Why this priority**: Ключевое для планирования — понять загрузку людей и команд.
+**Why this priority**: Key for planning — understanding people and team workload.
 
-**Independent Test**: Из полученной `Card` прочитать `members`, `customProperties` и получить типизированные значения.
+**Independent Test**: From a fetched `Card`, read `members`, `customProperties` and get typed values.
 
 **Acceptance Scenarios**:
 
-1. **Given** карточка с members, **When** читаю `card.members`, **Then** получаю массив `[Member]` с `userId`, `fullName`, `role`
-2. **Given** карточка с custom properties, **When** читаю `card.customProperties`, **Then** получаю словарь с типизированными значениями
-3. **Given** карточка без members, **When** читаю `card.members`, **Then** получаю пустой массив
+1. **Given** a card with members, **When** I read `card.members`, **Then** I receive an array `[Member]` with `userId`, `fullName`, `role`
+2. **Given** a card with custom properties, **When** I read `card.customProperties`, **Then** I receive a dictionary with typed values
+3. **Given** a card without members, **When** I read `card.members`, **Then** I receive an empty array
 
 ---
 
-### User Story 4 — Получить структуру доски (Priority: P2)
+### User Story 4 — Get Board Structure (Priority: P2)
 
-Разработчик запрашивает доску с её колонками и lanes — чтобы понять в каком столбце какая карточка.
+A developer requests a board with its columns and lanes — to understand which column each card is in.
 
-**Why this priority**: Нужно для визуализации и понимания flow, но не блокирует основную работу.
+**Why this priority**: Needed for visualization and understanding the flow, but does not block core work.
 
-**Independent Test**: Вызвать `client.getBoard(id:)`, получить `Board` с `columns` и `lanes`.
+**Independent Test**: Call `client.getBoard(id:)`, receive a `Board` with `columns` and `lanes`.
 
 **Acceptance Scenarios**:
 
-1. **Given** валидный board ID, **When** вызываю `getBoard(id:)`, **Then** получаю `Board` с массивами `columns` и `lanes`
+1. **Given** a valid board ID, **When** I call `getBoard(id:)`, **Then** I receive a `Board` with `columns` and `lanes` arrays
 
 ---
 
-### User Story 5 — Получить список пространств и досок (Priority: P2)
+### User Story 5 — Get List of Spaces and Boards (Priority: P2)
 
-Разработчик запрашивает все пространства и доски — для навигации.
+A developer requests all spaces and boards — for navigation.
 
-**Why this priority**: Вспомогательная навигация, не критично для первой версии.
+**Why this priority**: Auxiliary navigation, not critical for the first version.
 
-**Independent Test**: Вызвать `client.listSpaces()`, затем `client.listBoards(spaceId:)`.
+**Independent Test**: Call `client.listSpaces()`, then `client.listBoards(spaceId:)`.
 
 **Acceptance Scenarios**:
 
-1. **Given** валидный токен, **When** вызываю `listSpaces()`, **Then** получаю массив `[Space]`
-2. **Given** валидный space ID, **When** вызываю `listBoards(spaceId:)`, **Then** получаю массив `[Board]`
+1. **Given** a valid token, **When** I call `listSpaces()`, **Then** I receive an array `[Space]`
+2. **Given** a valid space ID, **When** I call `listBoards(spaceId:)`, **Then** I receive an array `[Board]`
 
 ### Edge Cases
 
-- Что происходит при сетевой ошибке (timeout, DNS)? → типизированная ошибка, без крэша
-- Что если API вернул неизвестные поля? → игнорируются (forward compatibility)
-- Что если API вернул 429 (rate limit)? → автоматический retry с задержкой через `Task.retrying`
-- Что если custom property имеет неизвестный тип? → сохраняется как raw value
+- What happens on a network error (timeout, DNS)? → typed error, no crash
+- What if the API returns unknown fields? → they are ignored (forward compatibility)
+- What if the API returns 429 (rate limit)? → automatic retry with delay via `Task.retrying`
+- What if a custom property has an unknown type? → stored as raw value
 
 ## Requirements
 
 ### Functional Requirements
 
-- **FR-001**: SDK MUST генерировать клиентский код из OpenAPI-спеки через `swift-openapi-generator`
-- **FR-002**: SDK MUST поддерживать авторизацию через Bearer token
-- **FR-003**: SDK MUST предоставлять типизированные модели для Card, Board, Column, Lane, Space, Member, CustomProperty
-- **FR-004**: SDK MUST возвращать типизированные ошибки для всех failure cases (network, auth, not found, rate limit). Все публичные методы MUST использовать typed throws (`throws(KaitenError)`) вместо untyped `throws`.
-- **FR-005**: SDK MUST принимать `baseURL` и `token` как
-  явные параметры инициализации. SDK не читает конфигурацию
-  самостоятельно — это ответственность вызывающего кода.
-- **FR-006**: SDK MUST выбрасывать ошибку при инициализации
-  (fail fast) если `baseURL` невалиден.
-- **FR-007**: SDK MUST компилироваться на macOS (ARM) и Linux (x86-64 и ARM)
-- **FR-008**: SDK MUST поддерживать async/await
-- **FR-009**: SDK MUST использовать `swift-tools-version: 6.2` с `.swiftLanguageMode(.v6)` на каждом таргете
-- **FR-010**: SDK MUST автоматически ретраить запросы при 429 (rate limit) с задержкой (configurable max retries и delay). Реализация через `ClientMiddleware`.
-- **FR-012**: GitHub Actions workflows MUST иметь явные имена, описывающие что они делают (например `build-and-test.yml`, не `ci.yml`)
-- **FR-013**: CI MUST кешировать SPM-зависимости между запусками для ускорения сборки
-- **FR-014**: Код НЕ ДОЛЖЕН использовать `nonisolated(unsafe)`. Для мутабельного состояния в Sendable контексте использовать `Mutex` из `import Synchronization`
-- **FR-015**: OpenAPI-спека MUST содержать только эндпоинты (`paths`), которые реально используются в SDK. Секция `components/schemas` MUST содержать все модели данных, необходимые для полного описания ответов этих эндпоинтов — включая вложенные объекты (User, Checklist, SLA и т.д.), даже если SDK не имеет специальной бизнес-логики для них. Пока у Kaiten нет официальной OpenAPI-спеки, мы поддерживаем минимальную hand-crafted спеку — только используемые эндпоинты + полные модели их ответов. Когда Kaiten предоставит официальную спеку, можно перейти на неё целиком.
-- **FR-016**: OpenAPI-спека собирается **вручную** — у Kaiten нет публичной OpenAPI-спецификации. Спека MUST точно отражать реальное поведение API:
-  - **Документация Kaiten — отправная точка**, но не абсолютная истина. Доки могут расходиться с реальным API.
-  - **При расхождении доки vs API — приоритет у реального API.** Проверять поля, типы, nullable/required через реальные запросы. Пример: доки показывают полный Board для Card.board, но API возвращает только 6 полей → в спеке отдельная схема CardBoardSummary.
-  - **Расхождения MUST быть задокументированы** комментарием в YAML прямо над полем/схемой (например `# NOTE: Kaiten docs show X, but API returns Y`).
-  - **Разные ответы = разные схемы** — если два эндпоинта возвращают похожие, но не идентичные данные, в спеке MUST быть отдельные схемы (Board vs BoardInSpace vs CardBoardSummary).
-  - **Nullable и required строго по реальному API** — проверять через запросы, а не только по докам.
-  - **Перепроверка обязательна** — при любом изменении спеки сверяться с документацией + проверять реальный API. Гайд по парсингу документации: [docs/kaiten-docs-parsing.md](../../docs/kaiten-docs-parsing.md).
+- **FR-001**: SDK MUST generate client code from the OpenAPI spec via `swift-openapi-generator`
+- **FR-002**: SDK MUST support authorization via Bearer token
+- **FR-003**: SDK MUST provide typed models for Card, Board, Column, Lane, Space, Member, CustomProperty
+- **FR-004**: SDK MUST return typed errors for all failure cases (network, auth, not found, rate limit). All public methods MUST use typed throws (`throws(KaitenError)`) instead of untyped `throws`.
+- **FR-005**: SDK MUST accept `baseURL` and `token` as
+  explicit initialization parameters. The SDK does not read
+  configuration on its own — that is the caller's responsibility.
+- **FR-006**: SDK MUST throw an error on initialization
+  (fail fast) if `baseURL` is invalid.
+- **FR-007**: SDK MUST compile on macOS (ARM) and Linux (x86-64 and ARM)
+- **FR-008**: SDK MUST support async/await
+- **FR-009**: SDK MUST use `swift-tools-version: 6.2` with `.swiftLanguageMode(.v6)` on each target
+- **FR-010**: SDK MUST automatically retry requests on 429 (rate limit) with a delay (configurable max retries and delay). Implementation via `ClientMiddleware`.
+- **FR-012**: GitHub Actions workflows MUST have explicit names describing what they do (e.g. `build-and-test.yml`, not `ci.yml`)
+- **FR-013**: CI MUST cache SPM dependencies between runs to speed up builds
+- **FR-014**: Code MUST NOT use `nonisolated(unsafe)`. For mutable state in a Sendable context, use `Mutex` from `import Synchronization`
+- **FR-015**: The OpenAPI spec MUST contain only endpoints (`paths`) that are actually used in the SDK. The `components/schemas` section MUST contain all data models needed to fully describe responses of these endpoints — including nested objects (User, Checklist, SLA, etc.), even if the SDK has no special business logic for them. Since Kaiten does not yet have an official OpenAPI spec, we maintain a minimal hand-crafted spec — only used endpoints + complete models of their responses. When Kaiten provides an official spec, we can switch to it entirely.
+- **FR-016**: The OpenAPI spec is assembled **manually** — Kaiten does not have a public OpenAPI specification. The spec MUST accurately reflect real API behavior:
+  - **Kaiten documentation is the starting point**, but not absolute truth. Docs may diverge from the real API.
+  - **When docs diverge from API — the real API takes priority.** Verify fields, types, nullable/required through real requests. Example: docs show a full Board for Card.board, but the API returns only 6 fields → the spec uses a separate CardBoardSummary schema.
+  - **Divergences MUST be documented** with a YAML comment directly above the field/schema (e.g. `# NOTE: Kaiten docs show X, but API returns Y`).
+  - **Different responses = different schemas** — if two endpoints return similar but not identical data, the spec MUST have separate schemas (Board vs BoardInSpace vs CardBoardSummary).
+  - **Nullable and required strictly per the real API** — verify through requests, not just docs.
+  - **Cross-checking is mandatory** — for any spec change, compare with documentation + verify against the real API. Documentation parsing guide: [docs/kaiten-docs-parsing.md](../../docs/kaiten-docs-parsing.md).
 
 ### Key Entities
 
@@ -132,7 +132,7 @@
 
 ### Measurable Outcomes
 
-- **SC-001**: MCP-сервер может получить все карточки доски с assignees и custom properties одним вызовом SDK
-- **SC-002**: SDK компилируется без ошибок на macOS (ARM) и Linux (x86-64 и ARM) в CI
-- **SC-003**: Все P1 user stories покрыты тестами
-- **SC-004**: Добавление нового эндпоинта = добавление в OpenAPI-спеку (код перегенерируется автоматически)
+- **SC-001**: The MCP server can fetch all board cards with assignees and custom properties in a single SDK call
+- **SC-002**: SDK compiles without errors on macOS (ARM) and Linux (x86-64 and ARM) in CI
+- **SC-003**: All P1 user stories are covered by tests
+- **SC-004**: Adding a new endpoint = adding it to the OpenAPI spec (code is regenerated automatically)

--- a/specs/002-kaiten-cli/spec.md
+++ b/specs/002-kaiten-cli/spec.md
@@ -3,103 +3,101 @@
 **Feature Branch**: `002-kaiten-cli`
 **Created**: 2026-02-16
 **Status**: Draft
-**Input**: User description: "Executable-таргет — тонкая обёртка над SDK без логики, пробрасывает команды в SDK"
+**Input**: User description: "An executable target — a thin wrapper over the SDK with no logic, forwards commands to the SDK"
 
 ## User Scenarios & Testing *(mandatory)*
 
-### User Story 1 - CLI-доступ к Kaiten (Priority: P1)
+### User Story 1 - CLI Access to Kaiten (Priority: P1)
 
-DevOps-инженер или разработчик использует CLI для доступа к
-данным Kaiten без написания кода. CLI является тонкой обёрткой
-над SDK — парсит CLI-аргументы и конфиг-файл, собирает из них
-единый набор параметров и передаёт в SDK. Никакой бизнес-логики.
+A DevOps engineer or developer uses the CLI to access Kaiten data
+without writing code. The CLI is a thin wrapper over the SDK — it
+parses CLI arguments and the config file, assembles a unified set
+of parameters, and passes them to the SDK. No business logic.
 
-**Why this priority**: Единственная задача этой фичи — дать
-CLI-доступ к SDK.
+**Why this priority**: The sole purpose of this feature is to
+provide CLI access to the SDK.
 
-**Independent Test**: Запустить бинарник с `--url`, `--token`
-и подкомандой (например `list-spaces`). Структурированный вывод
-в stdout подтверждает работоспособность.
+**Independent Test**: Run the binary with `--url`, `--token`
+and a subcommand (e.g. `list-spaces`). Structured output in
+stdout confirms it works.
 
 **Acceptance Scenarios**:
 
-1. **Given** валидные `--url` и `--token` флаги, **When**
-   пользователь запускает подкоманду (например `list-spaces`),
-   **Then** CLI выводит структурированные данные в stdout.
-2. **Given** существует валидный конфиг-файл
-   `~/.config/kaiten-mcp/config.json`, **When** пользователь
-   запускает подкоманду без флагов, **Then** CLI читает
-   параметры из конфиг-файла.
-3. **Given** присутствуют и флаги и конфиг-файл с разными
-   значениями, **When** пользователь указывает `--url` или
-   `--token`, **Then** флаги имеют приоритет над конфиг-файлом.
-4. **Given** ни флаги, ни конфиг-файл не предоставляют
-   обязательный параметр, **When** пользователь запускает
-   подкоманду, **Then** CLI выходит с понятным сообщением об
-   ошибке, указывающим какой параметр отсутствует и где его
-   можно задать (флаг или конфиг-файл).
-5. **Given** SDK возвращает ошибку, **When** пользователь
-   запускает подкоманду, **Then** CLI выводит человекочитаемое
-   сообщение об ошибке в stderr и завершается с ненулевым
-   кодом возврата.
+1. **Given** valid `--url` and `--token` flags, **When** the
+   user runs a subcommand (e.g. `list-spaces`), **Then** the
+   CLI outputs structured data to stdout.
+2. **Given** a valid config file exists at
+   `~/.config/kaiten-mcp/config.json`, **When** the user runs
+   a subcommand without flags, **Then** the CLI reads parameters
+   from the config file.
+3. **Given** both flags and a config file with different values
+   are present, **When** the user specifies `--url` or `--token`,
+   **Then** flags take priority over the config file.
+4. **Given** neither flags nor the config file provide a required
+   parameter, **When** the user runs a subcommand, **Then** the
+   CLI exits with a clear error message indicating which parameter
+   is missing and where it can be set (flag or config file).
+5. **Given** the SDK returns an error, **When** the user runs a
+   subcommand, **Then** the CLI outputs a human-readable error
+   message to stderr and exits with a non-zero exit code.
 
 ---
 
 ### Edge Cases
 
-- Что если CLI запущен без подкоманды? CLI MUST вывести справку
-  и завершиться с ненулевым кодом.
-- Что если конфиг-файл существует, но содержит невалидный JSON?
-  CLI MUST вывести ошибку с описанием проблемы конфигурации.
-- Что если конфиг-файл не существует и флаги не переданы?
-  CLI MUST вывести ошибку с инструкцией: передать флаги или
-  создать `~/.config/kaiten-mcp/config.json`.
+- What if the CLI is run without a subcommand? The CLI MUST print
+  help and exit with a non-zero code.
+- What if the config file exists but contains invalid JSON? The CLI
+  MUST output an error describing the configuration problem.
+- What if the config file does not exist and no flags are passed?
+  The CLI MUST output an error with instructions: pass flags or
+  create `~/.config/kaiten-mcp/config.json`.
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
-- **FR-001**: CLI MUST быть тонкой обёрткой над SDK без
-  собственной бизнес-логики. CLI парсит аргументы и
-  конфиг-файл, собирает единый Input и передаёт в SDK.
-- **FR-002**: CLI MUST предоставлять подкоманду для каждого
-  convenience-метода SDK с соответствующими аргументами.
-- **FR-003**: CLI MUST резолвить параметры подключения в
-  порядке приоритета: флаги командной строки > конфиг-файл.
-  Переменные окружения НЕ используются.
-- **FR-004**: CLI MUST выводить структурированные данные в
-  stdout и ошибки в stderr.
-- **FR-005**: CLI MUST завершаться с кодом 0 при успехе и
-  ненулевым при ошибке.
-- **FR-006**: CLI MUST компилироваться и работать на macOS (ARM)
-  и Linux (x86-64 и ARM).
-- **FR-007**: Конфигурация хранится в двух файлах в общей
-  директории `~/.config/kaiten-mcp/` (все платформы):
-  - **`config.json`** — подключение (url, token):
+- **FR-001**: The CLI MUST be a thin wrapper over the SDK with no
+  business logic of its own. The CLI parses arguments and the
+  config file, assembles a unified Input, and passes it to the SDK.
+- **FR-002**: The CLI MUST provide a subcommand for each SDK
+  convenience method with corresponding arguments.
+- **FR-003**: The CLI MUST resolve connection parameters in
+  priority order: command-line flags > config file.
+  Environment variables are NOT used.
+- **FR-004**: The CLI MUST output structured data to stdout and
+  errors to stderr.
+- **FR-005**: The CLI MUST exit with code 0 on success and
+  non-zero on error.
+- **FR-006**: The CLI MUST compile and run on macOS (ARM) and
+  Linux (x86-64 and ARM).
+- **FR-007**: Configuration is stored in two files in a shared
+  directory `~/.config/kaiten-mcp/` (all platforms):
+  - **`config.json`** — connection settings (url, token):
     ```json
     {
       "url": "https://company.kaiten.ru/api/latest",
       "token": "your-api-token"
     }
     ```
-  - **`preferences.json`** — пользовательские настройки
-    (избранные доски, пространства). Управляется KaitenMCP.
-    CLI не читает и не пишет этот файл.
+  - **`preferences.json`** — user preferences (favorite boards,
+    spaces). Managed by KaitenMCP. The CLI does not read or write
+    this file.
 
-  CLI читает только `config.json`.
-- **FR-008**: CLI MUST использовать `swift-configuration`
-  (`ConfigReader` + `FileProvider<JSONSnapshot>`) для чтения
-  конфиг-файла. `swift-configuration` — зависимость только
-  CLI-таргета, не SDK.
+  The CLI reads only `config.json`.
+- **FR-008**: The CLI MUST use `swift-configuration`
+  (`ConfigReader` + `FileProvider<JSONSnapshot>`) to read the
+  config file. `swift-configuration` is a dependency of the CLI
+  target only, not the SDK.
 
 ## Success Criteria *(mandatory)*
 
 ### Measurable Outcomes
 
-- **SC-001**: CLI можно использовать в скриптах автоматизации —
-  каждая подкоманда принимает все входные данные через флаги
-  или конфиг-файл и выдаёт машиночитаемый вывод.
-- **SC-002**: CLI не содержит дублирования логики SDK — каждая
-  подкоманда только вызывает соответствующий метод SDK.
-- **SC-003**: CLI компилируется и работает на macOS (ARM) и
-  Linux (x86-64 и ARM).
+- **SC-001**: The CLI can be used in automation scripts — each
+  subcommand accepts all input via flags or config file and
+  produces machine-readable output.
+- **SC-002**: The CLI contains no duplication of SDK logic — each
+  subcommand only calls the corresponding SDK method.
+- **SC-003**: The CLI compiles and runs on macOS (ARM) and
+  Linux (x86-64 and ARM).


### PR DESCRIPTION
Translate all markdown files from Russian to English to comply with the English-only language policy.

## Changes
- **AGENTS.md** — Spec-First Development and Kaiten API Documentation sections
- **README.md** — CLI installation section headings and descriptions
- **specs/001-kaiten-sdk-core/spec.md** — all user stories, descriptions, requirements, edge cases, success criteria
- **specs/002-kaiten-cli/spec.md** — all user stories, edge cases, requirements, success criteria
- **.specify/memory/constitution.md** — all principles, quality gates, governance
- **docs/sdk-review.md** — full review document
- **docs/kaiten-docs-parsing.md** — full parsing guide

Also renamed GitHub issues:
- #43: Недостающие read-операции → Missing read operations
- #42: Write-операции: CRUD cards, comments, members → Write operations: CRUD cards, comments, members

Closes #163