### PR TITLE
feat: add create comment endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Every command accepts `--url` and `--token` flags to override the config file.
 | `get-board-lanes` | `--board-id` | Get lanes of a board |
 | `list-cards` | `--board-id` | List all cards on a board |
 | `get-card` | `--id` | Get a card by ID |
+| `get-card-comments` | `--card-id` | Get comments on a card |
+| `add-comment` | `--card-id`, `--text` | Add a comment to a card |
 | `get-card-members` | `--card-id` | Get members of a card |
 | `list-custom-properties` | — | List all custom property definitions |
 | `get-custom-property` | `--id` | Get a custom property by ID |
@@ -120,6 +122,8 @@ All output is pretty-printed JSON.
 |--------|-------------|
 | `getCard(id:)` | Fetch a single card by ID |
 | `listCards(boardId:)` | List all cards on a board |
+| `getCardComments(cardId:)` | Get comments on a card |
+| `createComment(cardId:text:)` | Add a comment to a card |
 | `getCardMembers(cardId:)` | Get members of a card |
 | `listCustomProperties()` | List all custom property definitions |
 | `getCustomProperty(id:)` | Get a single custom property definition |

--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -443,6 +443,23 @@ public struct KaitenClient: Sendable {
         return try decodeResponse(response.toCase()) { try $0.json }
     }
 
+    /// Creates a comment on a card.
+    ///
+    /// - Parameters:
+    ///   - cardId: The card identifier.
+    ///   - text: Comment text (markdown).
+    /// - Returns: The created comment.
+    /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card does not exist.
+    public func createComment(cardId: Int, text: String) async throws(KaitenError) -> Components.Schemas.Comment {
+        let response = try await call {
+            try await client.create_card_comment(
+                path: .init(card_id: cardId),
+                body: .json(.init(text: text))
+            )
+        }
+        return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) { try $0.json }
+    }
+
     /// Fetches all comments on a card.
     ///
     /// - Parameter cardId: The card identifier.

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -50,6 +50,18 @@ extension Operations.retrieve_card_comments.Output {
     }
 }
 
+extension Operations.create_card_comment.Output {
+    func toCase() -> KaitenClient.ResponseCase<Operations.create_card_comment.Output.Ok.Body> {
+        switch self {
+        case .ok(let ok): .ok(ok.body)
+        case .unauthorized: .unauthorized
+        case .forbidden: .forbidden
+        case .notFound: .notFound
+        case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+        }
+    }
+}
+
 // MARK: - Custom Properties
 
 extension Operations.get_list_of_properties.Output {

--- a/Sources/kaiten/CardCommands.swift
+++ b/Sources/kaiten/CardCommands.swift
@@ -247,6 +247,27 @@ struct GetCardComments: AsyncParsableCommand {
     }
 }
 
+struct CreateComment: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "create-comment",
+        abstract: "Add a comment to a card"
+    )
+
+    @OptionGroup var global: GlobalOptions
+
+    @Option(name: .long, help: "Card ID")
+    var cardId: Int
+
+    @Option(name: .long, help: "Comment text (markdown)")
+    var text: String
+
+    func run() async throws {
+        let client = try await global.makeClient()
+        let comment = try await client.createComment(cardId: cardId, text: text)
+        try printJSON(comment)
+    }
+}
+
 struct GetCardMembers: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "get-card-members",
@@ -262,5 +283,26 @@ struct GetCardMembers: AsyncParsableCommand {
         let client = try await global.makeClient()
         let members = try await client.getCardMembers(cardId: cardId)
         try printJSON(members)
+    }
+}
+
+struct AddComment: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "add-comment",
+        abstract: "Create a comment on a card"
+    )
+
+    @OptionGroup var global: GlobalOptions
+
+    @Option(name: .long, help: "Card ID")
+    var cardId: Int
+
+    @Option(name: .long, help: "Comment text (markdown)")
+    var text: String
+
+    func run() async throws {
+        let client = try await global.makeClient()
+        let comment = try await client.createComment(cardId: cardId, text: text)
+        try printJSON(comment)
     }
 }

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -18,7 +18,9 @@ struct Kaiten: AsyncParsableCommand {
             ListCards.self,
             GetCard.self,
             GetCardComments.self,
+            CreateComment.self,
             GetCardMembers.self,
+            AddComment.self,
             ListCustomProperties.self,
             GetCustomProperty.self,
         ]

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -434,6 +434,70 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+    post:
+      summary: Add comment
+      operationId: create_card_comment
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCommentRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Comment'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    post:
+      summary: Create a card comment
+      operationId: create_card_comment
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - text
+              properties:
+                text:
+                  type: string
+                  description: Comment text (markdown)
+      responses:
+        '200':
+          description: Created comment
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Comment'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Card not found
   /company/custom-properties:
     get:
       summary: Get list of properties
@@ -1402,6 +1466,14 @@ components:
           - string
           - 'null'
           description: Calculation method
+    CreateCommentRequest:
+      type: object
+      required:
+      - text
+      properties:
+        text:
+          type: string
+          description: Comment text (markdown)
     Comment:
       type: object
       properties:

--- a/specs/001-kaiten-sdk-core/spec.md
+++ b/specs/001-kaiten-sdk-core/spec.md
@@ -131,6 +131,22 @@ A developer requests all spaces and boards — for navigation.
 - **Member**: id, userId, fullName, role
 - **CustomProperty**: id, name, type, value (typed: string, number, select, multiselect, date, user)
 
+### User Story 7 — Create a Comment on a Card (Priority: P2)
+
+A developer creates a new comment on a card with markdown text.
+
+**Why this priority**: Write operations extend the SDK beyond read-only use, enabling automation workflows.
+
+**Independent Test**: Call `client.createComment(cardId: 123, text: "Hello")`, receive a `Comment` with the created fields.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid card ID and text, **When** I call `createComment(cardId:text:)`, **Then** I receive a `Comment` with the created text
+2. **Given** an invalid card ID, **When** I call `createComment(cardId:text:)`, **Then** I receive a `notFound` error
+3. **Given** an invalid token, **When** I call `createComment(cardId:text:)`, **Then** I receive an `unauthorized` error
+
+---
+
 ## Success Criteria
 
 ### Measurable Outcomes


### PR DESCRIPTION
Add POST /cards/{card_id}/comments — first write operation in the SDK.

- OpenAPI spec: POST endpoint with text request body
- SDK: `createComment(cardId:text:)` method with doc comments
- CLI: `kaiten add-comment --card-id <id> --text <text>`
- Verified against real Kaiten API

Closes #170