### PR TITLE
Fix CardComments test: use correct types for uid and dates

### DIFF
--- a/Tests/KaitenSDKTests/CardCommentsTests.swift
+++ b/Tests/KaitenSDKTests/CardCommentsTests.swift
@@ -10,7 +10,7 @@ struct CardCommentsTests {
     @Test("getCardComments 200 returns array")
     func listSuccess() async throws {
         let json = """
-            [{"id": 1, "uid": 1, "text": "Hello", "type": 1, "edited": false, "card_id": 100, "author_id": 5, "internal": false, "deleted": false, "sd_description": false, "updated": "2025-01-01", "created": "2025-01-01"}]
+            [{"id": 1, "uid": "abc-123", "text": "Hello", "type": 1, "edited": false, "card_id": 100, "author_id": 5, "internal": false, "deleted": false, "sd_description": false, "updated": "2025-01-01T00:00:00Z", "created": "2025-01-01T00:00:00Z"}]
             """
         let transport = MockClientTransport.returning(statusCode: 200, body: json)
         let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)


### PR DESCRIPTION
**Problem:** `getCardComments 200 returns array` test fails on main — uid was integer `1` but OpenAPI spec defines it as `string`, and dates lacked ISO 8601 time component required for `date-time` format.

**Fix:** Use string uid (`"abc-123"`) and full ISO 8601 dates (`2025-01-01T00:00:00Z`).