### PR TITLE
feat: add create card endpoint (#174)

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -429,6 +429,78 @@ public struct KaitenClient: Sendable {
         return try decodeResponse(response.toCase(), notFoundResource: ("card", id)) { try $0.json }
     }
 
+    /// Creates a new card on a board.
+    ///
+    /// - Parameters:
+    ///   - title: Card title (required, max 1024 characters).
+    ///   - boardId: Board ID where the card will be created (required).
+    ///   - columnId: Column ID. If omitted the board's default column is used.
+    ///   - laneId: Lane ID. If omitted the board's default lane is used.
+    ///   - description: Card description (max 32768 characters).
+    ///   - asap: ASAP marker.
+    ///   - dueDate: Deadline in ISO 8601 format.
+    ///   - dueDateTimePresent: Whether deadline includes hours and minutes.
+    ///   - sortOrder: Position in the cell.
+    ///   - expiresLater: Fixed deadline flag.
+    ///   - sizeText: Size text (e.g. "1", "S", "XL").
+    ///   - ownerId: Owner user ID.
+    ///   - responsibleId: Responsible user ID.
+    ///   - ownerEmail: Owner email address (only works if email belongs to company user).
+    ///   - position: 1 = first in cell, 2 = last in cell. Overrides sort_order if present.
+    ///   - typeId: Card type ID.
+    ///   - externalId: External identifier.
+    ///   - textFormatTypeId: 1 = markdown, 2 = html, 3 = jira wiki.
+    ///   - properties: Custom properties object.
+    /// - Returns: The created card.
+    /// - Throws: ``KaitenError``
+    public func createCard(
+        title: String,
+        boardId: Int,
+        columnId: Int? = nil,
+        laneId: Int? = nil,
+        description: String? = nil,
+        asap: Bool? = nil,
+        dueDate: String? = nil,
+        dueDateTimePresent: Bool? = nil,
+        sortOrder: Double? = nil,
+        expiresLater: Bool? = nil,
+        sizeText: String? = nil,
+        ownerId: Int? = nil,
+        responsibleId: Int? = nil,
+        ownerEmail: String? = nil,
+        position: Int? = nil,
+        typeId: Int? = nil,
+        externalId: String? = nil,
+        textFormatTypeId: Int? = nil,
+        properties: Components.Schemas.CreateCardRequest.propertiesPayload? = nil
+    ) async throws(KaitenError) -> Components.Schemas.Card {
+        let body = Components.Schemas.CreateCardRequest(
+            title: title,
+            board_id: boardId,
+            column_id: columnId,
+            lane_id: laneId,
+            description: description,
+            asap: asap,
+            due_date: dueDate,
+            due_date_time_present: dueDateTimePresent,
+            sort_order: sortOrder,
+            expires_later: expiresLater,
+            size_text: sizeText,
+            owner_id: ownerId,
+            responsible_id: responsibleId,
+            owner_email: ownerEmail,
+            position: position,
+            type_id: typeId,
+            external_id: externalId,
+            text_format_type_id: textFormatTypeId,
+            properties: properties
+        )
+        let response = try await call {
+            try await client.create_card(body: .json(body))
+        }
+        return try decodeResponse(response.toCase()) { try $0.json }
+    }
+
     /// Updates a card by its identifier.
     ///
     /// All fields in the request body are optional — only provided values are changed.

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -14,6 +14,18 @@ extension Operations.get_cards.Output {
     }
 }
 
+extension Operations.create_card.Output {
+    func toCase() -> KaitenClient.ResponseCase<Operations.create_card.Output.Ok.Body> {
+        switch self {
+        case .ok(let ok): .ok(ok.body)
+        case .badRequest: .undocumented(statusCode: 400)
+        case .unauthorized: .unauthorized
+        case .forbidden: .forbidden
+        case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+        }
+    }
+}
+
 extension Operations.get_card.Output {
     func toCase() -> KaitenClient.ResponseCase<Operations.get_card.Output.Ok.Body> {
         switch self {

--- a/Sources/kaiten/CardCommands.swift
+++ b/Sources/kaiten/CardCommands.swift
@@ -211,6 +211,94 @@ struct ListCards: AsyncParsableCommand {
     }
 }
 
+struct CreateCard: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "create-card",
+        abstract: "Create a new card on a board"
+    )
+
+    @OptionGroup var global: GlobalOptions
+
+    @Option(name: .long, help: "Board ID (required)")
+    var boardId: Int
+
+    @Option(name: .long, help: "Card title (required)")
+    var title: String
+
+    @Option(name: .long, help: "Column ID")
+    var columnId: Int?
+
+    @Option(name: .long, help: "Lane ID")
+    var laneId: Int?
+
+    @Option(name: .long, help: "Card description")
+    var description: String?
+
+    @Option(name: .long, help: "ASAP marker")
+    var asap: Bool?
+
+    @Option(name: .long, help: "Deadline (ISO 8601)")
+    var dueDate: String?
+
+    @Option(name: .long, help: "Deadline includes hours and minutes")
+    var dueDateTimePresent: Bool?
+
+    @Option(name: .long, help: "Position in the cell")
+    var sortOrder: Double?
+
+    @Option(name: .long, help: "Fixed deadline flag")
+    var expiresLater: Bool?
+
+    @Option(name: .long, help: "Size text (e.g. '1', 'S', 'XL')")
+    var sizeText: String?
+
+    @Option(name: .long, help: "Owner user ID")
+    var ownerId: Int?
+
+    @Option(name: .long, help: "Responsible user ID")
+    var responsibleId: Int?
+
+    @Option(name: .long, help: "Owner email address")
+    var ownerEmail: String?
+
+    @Option(name: .long, help: "1 - first in cell, 2 - last in cell")
+    var position: Int?
+
+    @Option(name: .long, help: "Card type ID")
+    var typeId: Int?
+
+    @Option(name: .long, help: "External ID")
+    var externalId: String?
+
+    @Option(name: .long, help: "Text format: 1 - markdown, 2 - html, 3 - jira wiki")
+    var textFormatTypeId: Int?
+
+    func run() async throws {
+        let client = try await global.makeClient()
+        let card = try await client.createCard(
+            title: title,
+            boardId: boardId,
+            columnId: columnId,
+            laneId: laneId,
+            description: description,
+            asap: asap,
+            dueDate: dueDate,
+            dueDateTimePresent: dueDateTimePresent,
+            sortOrder: sortOrder,
+            expiresLater: expiresLater,
+            sizeText: sizeText,
+            ownerId: ownerId,
+            responsibleId: responsibleId,
+            ownerEmail: ownerEmail,
+            position: position,
+            typeId: typeId,
+            externalId: externalId,
+            textFormatTypeId: textFormatTypeId
+        )
+        try printJSON(card)
+    }
+}
+
 struct GetCard: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "get-card",

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -16,6 +16,7 @@ struct Kaiten: AsyncParsableCommand {
             GetBoardColumns.self,
             GetBoardLanes.self,
             ListCards.self,
+            CreateCard.self,
             GetCard.self,
             UpdateCard.self,
             GetCardComments.self,

--- a/Tests/KaitenSDKTests/CreateCardTests.swift
+++ b/Tests/KaitenSDKTests/CreateCardTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("CreateCard")
+struct CreateCardTests {
+
+    @Test("200 returns created Card")
+    func success() async throws {
+        let json = """
+            {"id": 123, "title": "New card", "board_id": 1}
+            """
+        let transport = MockClientTransport.returning(statusCode: 200, body: json)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+        let card = try await client.createCard(title: "New card", boardId: 1)
+        #expect(card.id == 123)
+        #expect(card.title == "New card")
+    }
+
+    @Test("401 throws unauthorized")
+    func unauthorized() async throws {
+        let transport = MockClientTransport.returning(statusCode: 401)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+        await #expect(throws: KaitenError.self) {
+            _ = try await client.createCard(title: "Test", boardId: 1)
+        }
+    }
+
+    @Test("400 throws unexpectedResponse")
+    func badRequest() async throws {
+        let transport = MockClientTransport.returning(statusCode: 400)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+        await #expect(throws: KaitenError.self) {
+            _ = try await client.createCard(title: "Test", boardId: 1)
+        }
+    }
+
+    @Test("403 throws unexpectedResponse")
+    func forbidden() async throws {
+        let transport = MockClientTransport.returning(statusCode: 403)
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+        await #expect(throws: KaitenError.self) {
+            _ = try await client.createCard(title: "Test", boardId: 1)
+        }
+    }
+}


### PR DESCRIPTION
Add POST /cards endpoint support.

## Changes
- OpenAPI spec: added `POST /cards` path and `CreateCardRequest` schema with all documented request fields
- `KaitenClient.createCard()` method with required `title` and `boardId` params, plus all optional fields
- CLI command `create-card` with `--board-id` and `--title` required args
- Response mapping for `create_card` operation
- Unit tests for 200, 401, 400, 403 responses

Closes #174