### PR TITLE
Fix callList silently swallowing decoding errors

### DIFF
--- a/Tests/KaitenSDKTests/ListCardsTests.swift
+++ b/Tests/KaitenSDKTests/ListCardsTests.swift
@@ -52,6 +52,17 @@ struct ListCardsTests {
         #expect(page.items.isEmpty)
     }
 
+    @Test("200 with invalid JSON throws decodingError (#183)")
+    func invalidJsonThrowsDecodingError() async throws {
+        // Simulate a schema mismatch: body is present but not a valid card array.
+        let transport = MockClientTransport.returning(statusCode: 200, body: "{\"not\": \"an array\"}")
+        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+        await #expect(throws: KaitenError.self) {
+            _ = try await client.listCards(boardId: 10)
+        }
+    }
+
     @Test("401 throws unauthorized")
     func unauthorized() async throws {
         let transport = MockClientTransport.returning(statusCode: 401)


### PR DESCRIPTION
Closes [#183](https://github.com/AllDmeat/kaiten-sdk/issues/183)

## Problem

`callList` caught **any** `ClientError` with HTTP 200 and returned `nil`, which callers interpreted as an empty page. This silently hid schema mismatches (like [#182](https://github.com/AllDmeat/kaiten-sdk/issues/182)) — the CLI would return `{"items": [], "hasMore": false}` with no error.

## Fix

Check if the underlying error is a `DecodingError`. If so, propagate it as `KaitenError.decodingError` instead of returning nil. Empty-body responses (the original intent) still return nil correctly.

## Test

Added test: HTTP 200 with invalid JSON body (schema mismatch) now throws `KaitenError` instead of returning an empty page.