### PR TITLE
Fix CardBoardSummary.card_properties: object → array

### DIFF
--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -2197,8 +2197,12 @@ components:
           description: External id
         card_properties:
           type:
-          - object
+          - array
           - 'null'
+          items:
+            type:
+            - object
+            - 'null'
           description: Board card properties
         settings:
           type:


### PR DESCRIPTION
Closes [#182](https://github.com/AllDmeat/kaiten-sdk/issues/182)

## Problem

`CardBoardSummary.card_properties` was defined as `object | null` in the OpenAPI spec, but the Kaiten API returns an **array** of card property objects. This caused `typeMismatch` decoding errors for any card belonging to a board with non-empty `card_properties`.

Combined with [#183](https://github.com/AllDmeat/kaiten-sdk/issues/183) (fixed in [#184](https://github.com/AllDmeat/kaiten-sdk/pull/184)), this manifested as silently empty results.

## Fix

Changed `card_properties` type from `object | null` to `array | null` with `items: object | null`, matching the existing `Board` and `BoardInSpace` schema definitions.

## Verification

Needs live data verification after merge (per verification workflow). Test with:
```bash
kaiten list-cards --member-ids 14664 --states 2 --limit 17
kaiten get-card --id 2776166
```