### PR TITLE
Add swift-format linter and format all code

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  swift-format:
+    name: swift-format
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mise
+        uses: jdx/mise-action@v2
+
+      - name: Lint
+        run: swift format lint --strict --recursive Sources/ Tests/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,3 +60,15 @@ Detailed guide for parsing Kaiten API documentation: [docs/kaiten-docs-parsing.m
 - Whether pagination is supported (`offset`/`limit`)
 
 Do not modify the spec based on guesses or empirical data. Only based on documentation.
+
+## Code Formatting
+
+This project uses [swift-format](https://github.com/swiftlang/swift-format) (bundled with the Swift toolchain) with default configuration.
+
+**Before every commit**, run:
+
+```bash
+swift format format --in-place --recursive Sources/ Tests/
+```
+
+CI runs `swift format lint --strict --recursive Sources/ Tests/` on every PR. Unformatted code will fail the lint check.

--- a/Sources/KaitenSDK/AuthenticationMiddleware.swift
+++ b/Sources/KaitenSDK/AuthenticationMiddleware.swift
@@ -4,21 +4,21 @@ import OpenAPIRuntime
 
 /// A middleware that injects a Bearer token into every outgoing request.
 struct AuthenticationMiddleware: ClientMiddleware {
-    private let token: String
+  private let token: String
 
-    init(token: String) {
-        self.token = token
-    }
+  init(token: String) {
+    self.token = token
+  }
 
-    func intercept(
-        _ request: HTTPRequest,
-        body: HTTPBody?,
-        baseURL: URL,
-        operationID: String,
-        next: @Sendable (HTTPRequest, HTTPBody?, URL) async throws -> (HTTPResponse, HTTPBody?)
-    ) async throws -> (HTTPResponse, HTTPBody?) {
-        var request = request
-        request.headerFields[.authorization] = "Bearer \(token)"
-        return try await next(request, body, baseURL)
-    }
+  func intercept(
+    _ request: HTTPRequest,
+    body: HTTPBody?,
+    baseURL: URL,
+    operationID: String,
+    next: @Sendable (HTTPRequest, HTTPBody?, URL) async throws -> (HTTPResponse, HTTPBody?)
+  ) async throws -> (HTTPResponse, HTTPBody?) {
+    var request = request
+    request.headerFields[.authorization] = "Bearer \(token)"
+    return try await next(request, body, baseURL)
+  }
 }

--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -6,777 +6,832 @@ import OpenAPIURLSession
 ///
 /// Accepts explicit `baseURL` and `token` parameters.
 public struct KaitenClient: Sendable {
-    private let client: Client
+  private let client: Client
 
-    // MARK: - Initialization
+  // MARK: - Initialization
 
-    /// Creates a client with a custom transport (for testing).
-    ///
-    /// - Parameters:
-    ///   - baseURL: Full Kaiten API base URL (e.g. `https://mycompany.kaiten.ru/api/latest`).
-    ///   - token: API bearer token.
-    ///   - transport: Custom `ClientTransport` implementation.
-    /// - Throws: ``KaitenError/invalidURL(_:)`` if `baseURL` cannot be parsed.
-    init(baseURL: String, token: String, transport: any ClientTransport) throws(KaitenError) {
-        let url = try URL(string: baseURL)
-            .orThrow(KaitenError.invalidURL(baseURL))
-        self.client = Client(
-            serverURL: url,
-            transport: transport,
-            middlewares: [
-                AuthenticationMiddleware(token: token),
-                RetryMiddleware(),
-            ]
-        )
+  /// Creates a client with a custom transport (for testing).
+  ///
+  /// - Parameters:
+  ///   - baseURL: Full Kaiten API base URL (e.g. `https://mycompany.kaiten.ru/api/latest`).
+  ///   - token: API bearer token.
+  ///   - transport: Custom `ClientTransport` implementation.
+  /// - Throws: ``KaitenError/invalidURL(_:)`` if `baseURL` cannot be parsed.
+  init(baseURL: String, token: String, transport: any ClientTransport) throws(KaitenError) {
+    let url = try URL(string: baseURL)
+      .orThrow(KaitenError.invalidURL(baseURL))
+    self.client = Client(
+      serverURL: url,
+      transport: transport,
+      middlewares: [
+        AuthenticationMiddleware(token: token),
+        RetryMiddleware(),
+      ]
+    )
+  }
+
+  /// Creates a new Kaiten API client.
+  ///
+  /// - Parameters:
+  ///   - baseURL: Full Kaiten API base URL (e.g. `https://mycompany.kaiten.ru/api/latest`).
+  ///   - token: API bearer token.
+  /// - Throws: ``KaitenError/invalidURL(_:)`` if `baseURL` cannot be parsed.
+  public init(baseURL: String, token: String) throws(KaitenError) {
+    let url = try URL(string: baseURL)
+      .orThrow(KaitenError.invalidURL(baseURL))
+
+    self.client = Client(
+      serverURL: url,
+      transport: URLSessionTransport(),
+      middlewares: [
+        AuthenticationMiddleware(token: token),
+        RetryMiddleware(),
+      ]
+    )
+  }
+
+  // MARK: - Private Helpers
+
+  /// Executes an API call, wrapping non-KaitenError into `.networkError`.
+  private func call<T>(_ operation: () async throws -> T) async throws(KaitenError) -> T {
+    do {
+      return try await operation()
+    } catch let error as KaitenError {
+      throw error
+    } catch {
+      throw .networkError(underlying: error)
     }
+  }
 
-    /// Creates a new Kaiten API client.
-    ///
-    /// - Parameters:
-    ///   - baseURL: Full Kaiten API base URL (e.g. `https://mycompany.kaiten.ru/api/latest`).
-    ///   - token: API bearer token.
-    /// - Throws: ``KaitenError/invalidURL(_:)`` if `baseURL` cannot be parsed.
-    public init(baseURL: String, token: String) throws(KaitenError) {
-        let url = try URL(string: baseURL)
-            .orThrow(KaitenError.invalidURL(baseURL))
-
-        self.client = Client(
-            serverURL: url,
-            transport: URLSessionTransport(),
-            middlewares: [
-                AuthenticationMiddleware(token: token),
-                RetryMiddleware(),
-            ]
-        )
-    }
-
-    // MARK: - Private Helpers
-
-    /// Executes an API call, wrapping non-KaitenError into `.networkError`.
-    private func call<T>(_ operation: () async throws -> T) async throws(KaitenError) -> T {
-        do {
-            return try await operation()
-        } catch let error as KaitenError {
-            throw error
-        } catch {
-            throw .networkError(underlying: error)
+  /// Executes an API call for list endpoints.
+  /// Returns `nil` when Kaiten returns HTTP 200 with an empty body (no JSON),
+  /// allowing callers to fall back to an empty array.
+  /// Propagates decoding errors instead of silently returning nil.
+  private func callList<T>(_ operation: () async throws -> T) async throws(KaitenError) -> T? {
+    do {
+      return try await operation()
+    } catch let error as ClientError where error.response?.status == .ok {
+      // If the underlying error is a schema mismatch (typeMismatch or
+      // keyNotFound), the body was valid JSON but didn't match the
+      // expected schema — propagate instead of hiding.
+      // Other DecodingErrors (dataCorrupted from empty/invalid body)
+      // are treated as "no data" and return nil.
+      if let decodingError = error.underlyingError as? DecodingError {
+        switch decodingError {
+        case .typeMismatch, .keyNotFound, .valueNotFound:
+          throw .decodingError(underlying: error)
+        case .dataCorrupted:
+          break  // treat as empty body
+        @unknown default:
+          throw .decodingError(underlying: error)
         }
+      }
+      return nil
+    } catch let error as KaitenError {
+      throw error
+    } catch {
+      throw .networkError(underlying: error)
     }
+  }
 
-    /// Executes an API call for list endpoints.
-    /// Returns `nil` when Kaiten returns HTTP 200 with an empty body (no JSON),
-    /// allowing callers to fall back to an empty array.
-    /// Propagates decoding errors instead of silently returning nil.
-    private func callList<T>(_ operation: () async throws -> T) async throws(KaitenError) -> T? {
-        do {
-            return try await operation()
-        } catch let error as ClientError where error.response?.status == .ok {
-            // If the underlying error is a schema mismatch (typeMismatch or
-            // keyNotFound), the body was valid JSON but didn't match the
-            // expected schema — propagate instead of hiding.
-            // Other DecodingErrors (dataCorrupted from empty/invalid body)
-            // are treated as "no data" and return nil.
-            if let decodingError = error.underlyingError as? DecodingError {
-                switch decodingError {
-                case .typeMismatch, .keyNotFound, .valueNotFound:
-                    throw .decodingError(underlying: error)
-                case .dataCorrupted:
-                    break  // treat as empty body
-                @unknown default:
-                    throw .decodingError(underlying: error)
-                }
-            }
-            return nil
-        } catch let error as KaitenError {
-            throw error
-        } catch {
-            throw .networkError(underlying: error)
-        }
+  /// Decodes a value, wrapping errors into `.decodingError`.
+  private func decode<T>(_ extract: () throws -> T) throws(KaitenError) -> T {
+    do {
+      return try extract()
+    } catch {
+      throw .decodingError(underlying: error)
     }
+  }
 
-    /// Decodes a value, wrapping errors into `.decodingError`.
-    private func decode<T>(_ extract: () throws -> T) throws(KaitenError) -> T {
-        do {
-            return try extract()
-        } catch {
-            throw .decodingError(underlying: error)
-        }
+  /// Standard response case from an OpenAPI-generated Output enum.
+  /// Used by `handleResponse` to eliminate switch boilerplate.
+  enum ResponseCase<OKBody> {
+    case ok(OKBody)
+    case unauthorized
+    case forbidden
+    case notFound
+    case undocumented(statusCode: Int)
+  }
+
+  /// Handles a standard response by extracting the ok body or throwing the appropriate error.
+  /// The `ok` closure receives the body and should extract the JSON value.
+  private func handleResponse<OKBody, JSONBody, T>(
+    _ responseCase: ResponseCase<OKBody>,
+    notFoundResource: (name: String, id: Int)? = nil,
+    extract: (OKBody) -> JSONBody,
+    transform: (JSONBody) throws(KaitenError) -> T
+  ) throws(KaitenError) -> T {
+    switch responseCase {
+    case .ok(let body):
+      return try transform(extract(body))
+    case .unauthorized:
+      throw .unauthorized
+    case .forbidden:
+      throw .unexpectedResponse(statusCode: 403)
+    case .notFound:
+      if let res = notFoundResource {
+        throw .notFound(resource: res.name, id: res.id)
+      }
+      throw .unexpectedResponse(statusCode: 404)
+    case .undocumented(let code):
+      throw .unexpectedResponse(statusCode: code)
     }
+  }
 
-    /// Standard response case from an OpenAPI-generated Output enum.
-    /// Used by `handleResponse` to eliminate switch boilerplate.
-    enum ResponseCase<OKBody> {
-        case ok(OKBody)
-        case unauthorized
-        case forbidden
-        case notFound
-        case undocumented(statusCode: Int)
+  /// Convenience: handle response, decode JSON body.
+  private func decodeResponse<OKBody, T: Sendable>(
+    _ responseCase: ResponseCase<OKBody>,
+    notFoundResource: (name: String, id: Int)? = nil,
+    json: (OKBody) throws -> T
+  ) throws(KaitenError) -> T {
+    switch responseCase {
+    case .ok(let body):
+      return try decode { try json(body) }
+    case .unauthorized:
+      throw .unauthorized
+    case .forbidden:
+      throw .unexpectedResponse(statusCode: 403)
+    case .notFound:
+      if let res = notFoundResource {
+        throw .notFound(resource: res.name, id: res.id)
+      }
+      throw .unexpectedResponse(statusCode: 404)
+    case .undocumented(let code):
+      throw .unexpectedResponse(statusCode: code)
     }
+  }
 
-    /// Handles a standard response by extracting the ok body or throwing the appropriate error.
-    /// The `ok` closure receives the body and should extract the JSON value.
-    private func handleResponse<OKBody, JSONBody, T>(
-        _ responseCase: ResponseCase<OKBody>,
-        notFoundResource: (name: String, id: Int)? = nil,
-        extract: (OKBody) -> JSONBody,
-        transform: (JSONBody) throws(KaitenError) -> T
-    ) throws(KaitenError) -> T {
-        switch responseCase {
-        case .ok(let body):
-            return try transform(extract(body))
-        case .unauthorized:
-            throw .unauthorized
-        case .forbidden:
-            throw .unexpectedResponse(statusCode: 403)
-        case .notFound:
-            if let res = notFoundResource {
-                throw .notFound(resource: res.name, id: res.id)
-            }
-            throw .unexpectedResponse(statusCode: 404)
-        case .undocumented(let code):
-            throw .unexpectedResponse(statusCode: code)
-        }
+  // MARK: - Cards
+
+  /// Filters for listing cards.
+  ///
+  /// All fields are optional. Only non-nil values are sent to the API.
+  /// Every query parameter supported by GET /cards is exposed here.
+  public struct CardFilter: Sendable {
+    // MARK: - Date filters
+
+    /// Filter cards created before this date.
+    public let createdBefore: Date?
+    /// Filter cards created after this date.
+    public let createdAfter: Date?
+    /// Filter cards updated before this date.
+    public let updatedBefore: Date?
+    /// Filter cards updated after this date.
+    public let updatedAfter: Date?
+    /// Filter cards first moved to in-progress after this date.
+    public let firstMovedInProgressAfter: Date?
+    /// Filter cards first moved to in-progress before this date.
+    public let firstMovedInProgressBefore: Date?
+    /// Filter cards last moved to done after this date.
+    public let lastMovedToDoneAtAfter: Date?
+    /// Filter cards last moved to done before this date.
+    public let lastMovedToDoneAtBefore: Date?
+    /// Filter cards with due date after this date.
+    public let dueDateAfter: Date?
+    /// Filter cards with due date before this date.
+    public let dueDateBefore: Date?
+
+    // MARK: - Text search
+
+    /// Text search query.
+    public let query: String?
+    /// Comma-separated fields to search in.
+    public let searchFields: String?
+
+    // MARK: - Tags
+
+    /// Filter by tag name.
+    public let tag: String?
+    /// Comma-separated tag IDs.
+    public let tagIds: String?
+
+    // MARK: - ID filters
+
+    /// Filter by card type ID.
+    public let typeId: Int?
+    /// Comma-separated card type IDs.
+    public let typeIds: String?
+    /// Comma-separated member user IDs.
+    public let memberIds: String?
+    /// Filter by owner user ID.
+    public let ownerId: Int?
+    /// Comma-separated owner user IDs.
+    public let ownerIds: String?
+    /// Filter by responsible user ID.
+    public let responsibleId: Int?
+    /// Comma-separated responsible user IDs.
+    public let responsibleIds: String?
+    /// Comma-separated column IDs.
+    public let columnIds: String?
+    /// Filter by space ID.
+    public let spaceId: Int?
+    /// Filter by external ID.
+    public let externalId: String?
+    /// Comma-separated organization IDs.
+    public let organizationsIds: String?
+
+    // MARK: - Exclude filters
+
+    /// Comma-separated board IDs to exclude.
+    public let excludeBoardIds: String?
+    /// Comma-separated lane IDs to exclude.
+    public let excludeLaneIds: String?
+    /// Comma-separated column IDs to exclude.
+    public let excludeColumnIds: String?
+    /// Comma-separated owner IDs to exclude.
+    public let excludeOwnerIds: String?
+    /// Comma-separated card IDs to exclude.
+    public let excludeCardIds: String?
+
+    // MARK: - State filters
+
+    /// Card condition: 1 = on board, 2 = archived.
+    public let condition: Int?
+    /// Comma-separated states: 1 = queued, 2 = in progress, 3 = done.
+    public let states: String?
+    /// Filter by archived status.
+    public let archived: Bool?
+    /// Filter ASAP cards.
+    public let asap: Bool?
+    /// Filter overdue cards.
+    public let overdue: Bool?
+    /// Filter cards done on time.
+    public let doneOnTime: Bool?
+    /// Filter cards that have a due date.
+    public let withDueDate: Bool?
+    /// Filter service desk request cards.
+    public let isRequest: Bool?
+
+    // MARK: - Sorting
+
+    /// Field to order by.
+    public let orderBy: String?
+    /// Order direction: asc or desc.
+    public let orderDirection: String?
+    /// Space ID for ordering context.
+    public let orderSpaceId: Int?
+
+    // MARK: - Extra
+
+    /// Comma-separated additional fields to include.
+    public let additionalCardFields: String?
+
+    /// Creates a new card filter with all fields defaulting to `nil`.
+    public init(
+      createdBefore: Date? = nil,
+      createdAfter: Date? = nil,
+      updatedBefore: Date? = nil,
+      updatedAfter: Date? = nil,
+      firstMovedInProgressAfter: Date? = nil,
+      firstMovedInProgressBefore: Date? = nil,
+      lastMovedToDoneAtAfter: Date? = nil,
+      lastMovedToDoneAtBefore: Date? = nil,
+      dueDateAfter: Date? = nil,
+      dueDateBefore: Date? = nil,
+      query: String? = nil,
+      searchFields: String? = nil,
+      tag: String? = nil,
+      tagIds: String? = nil,
+      typeId: Int? = nil,
+      typeIds: String? = nil,
+      memberIds: String? = nil,
+      ownerId: Int? = nil,
+      ownerIds: String? = nil,
+      responsibleId: Int? = nil,
+      responsibleIds: String? = nil,
+      columnIds: String? = nil,
+      spaceId: Int? = nil,
+      externalId: String? = nil,
+      organizationsIds: String? = nil,
+      excludeBoardIds: String? = nil,
+      excludeLaneIds: String? = nil,
+      excludeColumnIds: String? = nil,
+      excludeOwnerIds: String? = nil,
+      excludeCardIds: String? = nil,
+      condition: Int? = nil,
+      states: String? = nil,
+      archived: Bool? = nil,
+      asap: Bool? = nil,
+      overdue: Bool? = nil,
+      doneOnTime: Bool? = nil,
+      withDueDate: Bool? = nil,
+      isRequest: Bool? = nil,
+      orderBy: String? = nil,
+      orderDirection: String? = nil,
+      orderSpaceId: Int? = nil,
+      additionalCardFields: String? = nil
+    ) {
+      self.createdBefore = createdBefore
+      self.createdAfter = createdAfter
+      self.updatedBefore = updatedBefore
+      self.updatedAfter = updatedAfter
+      self.firstMovedInProgressAfter = firstMovedInProgressAfter
+      self.firstMovedInProgressBefore = firstMovedInProgressBefore
+      self.lastMovedToDoneAtAfter = lastMovedToDoneAtAfter
+      self.lastMovedToDoneAtBefore = lastMovedToDoneAtBefore
+      self.dueDateAfter = dueDateAfter
+      self.dueDateBefore = dueDateBefore
+      self.query = query
+      self.searchFields = searchFields
+      self.tag = tag
+      self.tagIds = tagIds
+      self.typeId = typeId
+      self.typeIds = typeIds
+      self.memberIds = memberIds
+      self.ownerId = ownerId
+      self.ownerIds = ownerIds
+      self.responsibleId = responsibleId
+      self.responsibleIds = responsibleIds
+      self.columnIds = columnIds
+      self.spaceId = spaceId
+      self.externalId = externalId
+      self.organizationsIds = organizationsIds
+      self.excludeBoardIds = excludeBoardIds
+      self.excludeLaneIds = excludeLaneIds
+      self.excludeColumnIds = excludeColumnIds
+      self.excludeOwnerIds = excludeOwnerIds
+      self.excludeCardIds = excludeCardIds
+      self.condition = condition
+      self.states = states
+      self.archived = archived
+      self.asap = asap
+      self.overdue = overdue
+      self.doneOnTime = doneOnTime
+      self.withDueDate = withDueDate
+      self.isRequest = isRequest
+      self.orderBy = orderBy
+      self.orderDirection = orderDirection
+      self.orderSpaceId = orderSpaceId
+      self.additionalCardFields = additionalCardFields
     }
+  }
 
-    /// Convenience: handle response, decode JSON body.
-    private func decodeResponse<OKBody, T: Sendable>(
-        _ responseCase: ResponseCase<OKBody>,
-        notFoundResource: (name: String, id: Int)? = nil,
-        json: (OKBody) throws -> T
-    ) throws(KaitenError) -> T {
-        switch responseCase {
-        case .ok(let body):
-            return try decode { try json(body) }
-        case .unauthorized:
-            throw .unauthorized
-        case .forbidden:
-            throw .unexpectedResponse(statusCode: 403)
-        case .notFound:
-            if let res = notFoundResource {
-                throw .notFound(resource: res.name, id: res.id)
-            }
-            throw .unexpectedResponse(statusCode: 404)
-        case .undocumented(let code):
-            throw .unexpectedResponse(statusCode: code)
-        }
+  /// Returns a page of cards, optionally filtered.
+  ///
+  /// - Parameters:
+  ///   - boardId: Filter by board identifier (optional).
+  ///   - columnId: Filter by column identifier (optional).
+  ///   - laneId: Filter by lane identifier (optional).
+  ///   - offset: Number of cards to skip (default `0`).
+  ///   - limit: Maximum number of cards to return (default `100`).
+  ///   - filter: Optional ``CardFilter`` with additional query parameters.
+  /// - Returns: A ``Page`` of cards. Returns an empty page when no cards match.
+  /// - Throws: ``KaitenError``
+  public func listCards(
+    boardId: Int? = nil, columnId: Int? = nil, laneId: Int? = nil, offset: Int = 0,
+    limit: Int = 100, filter: CardFilter? = nil
+  ) async throws(KaitenError) -> Page<Components.Schemas.Card> {
+    let f = filter
+    let queryParams = Operations.get_cards.Input.Query(
+      board_id: boardId,
+      column_id: columnId,
+      lane_id: laneId,
+      offset: offset,
+      limit: limit,
+      created_before: f?.createdBefore,
+      created_after: f?.createdAfter,
+      updated_before: f?.updatedBefore,
+      updated_after: f?.updatedAfter,
+      first_moved_in_progress_after: f?.firstMovedInProgressAfter,
+      first_moved_in_progress_before: f?.firstMovedInProgressBefore,
+      last_moved_to_done_at_after: f?.lastMovedToDoneAtAfter,
+      last_moved_to_done_at_before: f?.lastMovedToDoneAtBefore,
+      due_date_after: f?.dueDateAfter,
+      due_date_before: f?.dueDateBefore,
+      query: f?.query,
+      search_fields: f?.searchFields,
+      tag: f?.tag,
+      tag_ids: f?.tagIds,
+      type_id: f?.typeId,
+      type_ids: f?.typeIds,
+      member_ids: f?.memberIds,
+      owner_id: f?.ownerId,
+      owner_ids: f?.ownerIds,
+      responsible_id: f?.responsibleId,
+      responsible_ids: f?.responsibleIds,
+      column_ids: f?.columnIds,
+      space_id: f?.spaceId,
+      external_id: f?.externalId,
+      organizations_ids: f?.organizationsIds,
+      exclude_board_ids: f?.excludeBoardIds,
+      exclude_lane_ids: f?.excludeLaneIds,
+      exclude_column_ids: f?.excludeColumnIds,
+      exclude_owner_ids: f?.excludeOwnerIds,
+      exclude_card_ids: f?.excludeCardIds,
+      condition: f?.condition,
+      states: f?.states,
+      archived: f?.archived,
+      asap: f?.asap,
+      overdue: f?.overdue,
+      done_on_time: f?.doneOnTime,
+      with_due_date: f?.withDueDate,
+      is_request: f?.isRequest,
+      order_by: f?.orderBy,
+      order_direction: f?.orderDirection,
+      order_space_id: f?.orderSpaceId,
+      additional_card_fields: f?.additionalCardFields
+    )
+    guard let response = try await callList({ try await client.get_cards(query: queryParams) })
+    else {
+      return Page(items: [], offset: offset, limit: limit)
     }
+    let items: [Components.Schemas.Card] = try decodeResponse(response.toCase()) { try $0.json }
+    return Page(items: items, offset: offset, limit: limit)
+  }
 
-    // MARK: - Cards
+  /// Fetches a single card by its identifier.
+  ///
+  /// - Parameter id: The card identifier.
+  /// - Returns: The full card object with all fields including custom properties.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card does not exist.
+  public func getCard(id: Int) async throws(KaitenError) -> Components.Schemas.Card {
+    let response = try await call { try await client.get_card(path: .init(card_id: id)) }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", id)) { try $0.json }
+  }
 
-    /// Filters for listing cards.
-    ///
-    /// All fields are optional. Only non-nil values are sent to the API.
-    /// Every query parameter supported by GET /cards is exposed here.
-    public struct CardFilter: Sendable {
-        // MARK: - Date filters
-
-        /// Filter cards created before this date.
-        public let createdBefore: Date?
-        /// Filter cards created after this date.
-        public let createdAfter: Date?
-        /// Filter cards updated before this date.
-        public let updatedBefore: Date?
-        /// Filter cards updated after this date.
-        public let updatedAfter: Date?
-        /// Filter cards first moved to in-progress after this date.
-        public let firstMovedInProgressAfter: Date?
-        /// Filter cards first moved to in-progress before this date.
-        public let firstMovedInProgressBefore: Date?
-        /// Filter cards last moved to done after this date.
-        public let lastMovedToDoneAtAfter: Date?
-        /// Filter cards last moved to done before this date.
-        public let lastMovedToDoneAtBefore: Date?
-        /// Filter cards with due date after this date.
-        public let dueDateAfter: Date?
-        /// Filter cards with due date before this date.
-        public let dueDateBefore: Date?
-
-        // MARK: - Text search
-
-        /// Text search query.
-        public let query: String?
-        /// Comma-separated fields to search in.
-        public let searchFields: String?
-
-        // MARK: - Tags
-
-        /// Filter by tag name.
-        public let tag: String?
-        /// Comma-separated tag IDs.
-        public let tagIds: String?
-
-        // MARK: - ID filters
-
-        /// Filter by card type ID.
-        public let typeId: Int?
-        /// Comma-separated card type IDs.
-        public let typeIds: String?
-        /// Comma-separated member user IDs.
-        public let memberIds: String?
-        /// Filter by owner user ID.
-        public let ownerId: Int?
-        /// Comma-separated owner user IDs.
-        public let ownerIds: String?
-        /// Filter by responsible user ID.
-        public let responsibleId: Int?
-        /// Comma-separated responsible user IDs.
-        public let responsibleIds: String?
-        /// Comma-separated column IDs.
-        public let columnIds: String?
-        /// Filter by space ID.
-        public let spaceId: Int?
-        /// Filter by external ID.
-        public let externalId: String?
-        /// Comma-separated organization IDs.
-        public let organizationsIds: String?
-
-        // MARK: - Exclude filters
-
-        /// Comma-separated board IDs to exclude.
-        public let excludeBoardIds: String?
-        /// Comma-separated lane IDs to exclude.
-        public let excludeLaneIds: String?
-        /// Comma-separated column IDs to exclude.
-        public let excludeColumnIds: String?
-        /// Comma-separated owner IDs to exclude.
-        public let excludeOwnerIds: String?
-        /// Comma-separated card IDs to exclude.
-        public let excludeCardIds: String?
-
-        // MARK: - State filters
-
-        /// Card condition: 1 = on board, 2 = archived.
-        public let condition: Int?
-        /// Comma-separated states: 1 = queued, 2 = in progress, 3 = done.
-        public let states: String?
-        /// Filter by archived status.
-        public let archived: Bool?
-        /// Filter ASAP cards.
-        public let asap: Bool?
-        /// Filter overdue cards.
-        public let overdue: Bool?
-        /// Filter cards done on time.
-        public let doneOnTime: Bool?
-        /// Filter cards that have a due date.
-        public let withDueDate: Bool?
-        /// Filter service desk request cards.
-        public let isRequest: Bool?
-
-        // MARK: - Sorting
-
-        /// Field to order by.
-        public let orderBy: String?
-        /// Order direction: asc or desc.
-        public let orderDirection: String?
-        /// Space ID for ordering context.
-        public let orderSpaceId: Int?
-
-        // MARK: - Extra
-
-        /// Comma-separated additional fields to include.
-        public let additionalCardFields: String?
-
-        /// Creates a new card filter with all fields defaulting to `nil`.
-        public init(
-            createdBefore: Date? = nil,
-            createdAfter: Date? = nil,
-            updatedBefore: Date? = nil,
-            updatedAfter: Date? = nil,
-            firstMovedInProgressAfter: Date? = nil,
-            firstMovedInProgressBefore: Date? = nil,
-            lastMovedToDoneAtAfter: Date? = nil,
-            lastMovedToDoneAtBefore: Date? = nil,
-            dueDateAfter: Date? = nil,
-            dueDateBefore: Date? = nil,
-            query: String? = nil,
-            searchFields: String? = nil,
-            tag: String? = nil,
-            tagIds: String? = nil,
-            typeId: Int? = nil,
-            typeIds: String? = nil,
-            memberIds: String? = nil,
-            ownerId: Int? = nil,
-            ownerIds: String? = nil,
-            responsibleId: Int? = nil,
-            responsibleIds: String? = nil,
-            columnIds: String? = nil,
-            spaceId: Int? = nil,
-            externalId: String? = nil,
-            organizationsIds: String? = nil,
-            excludeBoardIds: String? = nil,
-            excludeLaneIds: String? = nil,
-            excludeColumnIds: String? = nil,
-            excludeOwnerIds: String? = nil,
-            excludeCardIds: String? = nil,
-            condition: Int? = nil,
-            states: String? = nil,
-            archived: Bool? = nil,
-            asap: Bool? = nil,
-            overdue: Bool? = nil,
-            doneOnTime: Bool? = nil,
-            withDueDate: Bool? = nil,
-            isRequest: Bool? = nil,
-            orderBy: String? = nil,
-            orderDirection: String? = nil,
-            orderSpaceId: Int? = nil,
-            additionalCardFields: String? = nil
-        ) {
-            self.createdBefore = createdBefore
-            self.createdAfter = createdAfter
-            self.updatedBefore = updatedBefore
-            self.updatedAfter = updatedAfter
-            self.firstMovedInProgressAfter = firstMovedInProgressAfter
-            self.firstMovedInProgressBefore = firstMovedInProgressBefore
-            self.lastMovedToDoneAtAfter = lastMovedToDoneAtAfter
-            self.lastMovedToDoneAtBefore = lastMovedToDoneAtBefore
-            self.dueDateAfter = dueDateAfter
-            self.dueDateBefore = dueDateBefore
-            self.query = query
-            self.searchFields = searchFields
-            self.tag = tag
-            self.tagIds = tagIds
-            self.typeId = typeId
-            self.typeIds = typeIds
-            self.memberIds = memberIds
-            self.ownerId = ownerId
-            self.ownerIds = ownerIds
-            self.responsibleId = responsibleId
-            self.responsibleIds = responsibleIds
-            self.columnIds = columnIds
-            self.spaceId = spaceId
-            self.externalId = externalId
-            self.organizationsIds = organizationsIds
-            self.excludeBoardIds = excludeBoardIds
-            self.excludeLaneIds = excludeLaneIds
-            self.excludeColumnIds = excludeColumnIds
-            self.excludeOwnerIds = excludeOwnerIds
-            self.excludeCardIds = excludeCardIds
-            self.condition = condition
-            self.states = states
-            self.archived = archived
-            self.asap = asap
-            self.overdue = overdue
-            self.doneOnTime = doneOnTime
-            self.withDueDate = withDueDate
-            self.isRequest = isRequest
-            self.orderBy = orderBy
-            self.orderDirection = orderDirection
-            self.orderSpaceId = orderSpaceId
-            self.additionalCardFields = additionalCardFields
-        }
+  /// Creates a new card on a board.
+  ///
+  /// - Parameters:
+  ///   - title: Card title (required, max 1024 characters).
+  ///   - boardId: Board ID where the card will be created (required).
+  ///   - columnId: Column ID. If omitted the board's default column is used.
+  ///   - laneId: Lane ID. If omitted the board's default lane is used.
+  ///   - description: Card description (max 32768 characters).
+  ///   - asap: ASAP marker.
+  ///   - dueDate: Deadline in ISO 8601 format.
+  ///   - dueDateTimePresent: Whether deadline includes hours and minutes.
+  ///   - sortOrder: Position in the cell.
+  ///   - expiresLater: Fixed deadline flag.
+  ///   - sizeText: Size text (e.g. "1", "S", "XL").
+  ///   - ownerId: Owner user ID.
+  ///   - responsibleId: Responsible user ID.
+  ///   - ownerEmail: Owner email address (only works if email belongs to company user).
+  ///   - position: 1 = first in cell, 2 = last in cell. Overrides sort_order if present.
+  ///   - typeId: Card type ID.
+  ///   - externalId: External identifier.
+  ///   - textFormatTypeId: 1 = markdown, 2 = html, 3 = jira wiki.
+  ///   - properties: Custom properties object.
+  /// - Returns: The created card.
+  /// - Throws: ``KaitenError``
+  public func createCard(
+    title: String,
+    boardId: Int,
+    columnId: Int? = nil,
+    laneId: Int? = nil,
+    description: String? = nil,
+    asap: Bool? = nil,
+    dueDate: String? = nil,
+    dueDateTimePresent: Bool? = nil,
+    sortOrder: Double? = nil,
+    expiresLater: Bool? = nil,
+    sizeText: String? = nil,
+    ownerId: Int? = nil,
+    responsibleId: Int? = nil,
+    ownerEmail: String? = nil,
+    position: Int? = nil,
+    typeId: Int? = nil,
+    externalId: String? = nil,
+    textFormatTypeId: Int? = nil,
+    properties: Components.Schemas.CreateCardRequest.propertiesPayload? = nil
+  ) async throws(KaitenError) -> Components.Schemas.Card {
+    let body = Components.Schemas.CreateCardRequest(
+      title: title,
+      board_id: boardId,
+      column_id: columnId,
+      lane_id: laneId,
+      description: description,
+      asap: asap,
+      due_date: dueDate,
+      due_date_time_present: dueDateTimePresent,
+      sort_order: sortOrder,
+      expires_later: expiresLater,
+      size_text: sizeText,
+      owner_id: ownerId,
+      responsible_id: responsibleId,
+      owner_email: ownerEmail,
+      position: position,
+      type_id: typeId,
+      external_id: externalId,
+      text_format_type_id: textFormatTypeId,
+      properties: properties
+    )
+    let response = try await call {
+      try await client.create_card(body: .json(body))
     }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
 
-    /// Returns a page of cards, optionally filtered.
-    ///
-    /// - Parameters:
-    ///   - boardId: Filter by board identifier (optional).
-    ///   - columnId: Filter by column identifier (optional).
-    ///   - laneId: Filter by lane identifier (optional).
-    ///   - offset: Number of cards to skip (default `0`).
-    ///   - limit: Maximum number of cards to return (default `100`).
-    ///   - filter: Optional ``CardFilter`` with additional query parameters.
-    /// - Returns: A ``Page`` of cards. Returns an empty page when no cards match.
-    /// - Throws: ``KaitenError``
-    public func listCards(boardId: Int? = nil, columnId: Int? = nil, laneId: Int? = nil, offset: Int = 0, limit: Int = 100, filter: CardFilter? = nil) async throws(KaitenError) -> Page<Components.Schemas.Card> {
-        let f = filter
-        let queryParams = Operations.get_cards.Input.Query(
-            board_id: boardId,
-            column_id: columnId,
-            lane_id: laneId,
-            offset: offset,
-            limit: limit,
-            created_before: f?.createdBefore,
-            created_after: f?.createdAfter,
-            updated_before: f?.updatedBefore,
-            updated_after: f?.updatedAfter,
-            first_moved_in_progress_after: f?.firstMovedInProgressAfter,
-            first_moved_in_progress_before: f?.firstMovedInProgressBefore,
-            last_moved_to_done_at_after: f?.lastMovedToDoneAtAfter,
-            last_moved_to_done_at_before: f?.lastMovedToDoneAtBefore,
-            due_date_after: f?.dueDateAfter,
-            due_date_before: f?.dueDateBefore,
-            query: f?.query,
-            search_fields: f?.searchFields,
-            tag: f?.tag,
-            tag_ids: f?.tagIds,
-            type_id: f?.typeId,
-            type_ids: f?.typeIds,
-            member_ids: f?.memberIds,
-            owner_id: f?.ownerId,
-            owner_ids: f?.ownerIds,
-            responsible_id: f?.responsibleId,
-            responsible_ids: f?.responsibleIds,
-            column_ids: f?.columnIds,
-            space_id: f?.spaceId,
-            external_id: f?.externalId,
-            organizations_ids: f?.organizationsIds,
-            exclude_board_ids: f?.excludeBoardIds,
-            exclude_lane_ids: f?.excludeLaneIds,
-            exclude_column_ids: f?.excludeColumnIds,
-            exclude_owner_ids: f?.excludeOwnerIds,
-            exclude_card_ids: f?.excludeCardIds,
-            condition: f?.condition,
-            states: f?.states,
-            archived: f?.archived,
-            asap: f?.asap,
-            overdue: f?.overdue,
-            done_on_time: f?.doneOnTime,
-            with_due_date: f?.withDueDate,
-            is_request: f?.isRequest,
-            order_by: f?.orderBy,
-            order_direction: f?.orderDirection,
-            order_space_id: f?.orderSpaceId,
-            additional_card_fields: f?.additionalCardFields
-        )
-        guard let response = try await callList({ try await client.get_cards(query: queryParams) }) else {
-            return Page(items: [], offset: offset, limit: limit)
-        }
-        let items: [Components.Schemas.Card] = try decodeResponse(response.toCase()) { try $0.json }
-        return Page(items: items, offset: offset, limit: limit)
+  /// Updates a card by its identifier.
+  ///
+  /// All fields in the request body are optional — only provided values are changed.
+  ///
+  /// - Parameters:
+  ///   - id: The card identifier.
+  ///   - title: New card title.
+  ///   - description: New description (pass `nil` wrapped in `.some(nil)` to clear).
+  ///   - asap: ASAP marker.
+  ///   - dueDate: Deadline in ISO 8601 format (pass `nil` wrapped in `.some(nil)` to clear).
+  ///   - dueDateTimePresent: Whether deadline includes hours and minutes.
+  ///   - sortOrder: Position in the cell.
+  ///   - expiresLater: Fixed deadline flag.
+  ///   - sizeText: Size text (e.g. "1", "S", "XL").
+  ///   - boardId: Target board ID.
+  ///   - columnId: Target column ID.
+  ///   - laneId: Target lane ID.
+  ///   - ownerId: Owner user ID.
+  ///   - typeId: Card type ID.
+  ///   - serviceId: Service ID.
+  ///   - blocked: Send `false` to release all blocks.
+  ///   - condition: 1 = live, 2 = archived.
+  ///   - externalId: External identifier.
+  ///   - textFormatTypeId: 1 = markdown, 2 = html, 3 = jira wiki.
+  ///   - sdNewComment: Service Desk new comment flag.
+  ///   - ownerEmail: Owner email address.
+  ///   - prevCardId: Previous card ID for repositioning.
+  ///   - estimateWorkload: Estimated workload.
+  ///   - properties: Custom properties object.
+  /// - Returns: The updated card.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card does not exist.
+  public func updateCard(
+    id: Int,
+    title: String? = nil,
+    description: String? = nil,
+    asap: Bool? = nil,
+    dueDate: String? = nil,
+    dueDateTimePresent: Bool? = nil,
+    sortOrder: Double? = nil,
+    expiresLater: Bool? = nil,
+    sizeText: String? = nil,
+    boardId: Int? = nil,
+    columnId: Int? = nil,
+    laneId: Int? = nil,
+    ownerId: Int? = nil,
+    typeId: Int? = nil,
+    serviceId: Int? = nil,
+    blocked: Bool? = nil,
+    condition: Int? = nil,
+    externalId: String? = nil,
+    textFormatTypeId: Int? = nil,
+    sdNewComment: Bool? = nil,
+    ownerEmail: String? = nil,
+    prevCardId: Int? = nil,
+    estimateWorkload: Double? = nil,
+    properties: Components.Schemas.UpdateCardRequest.propertiesPayload? = nil
+  ) async throws(KaitenError) -> Components.Schemas.Card {
+    let body = Components.Schemas.UpdateCardRequest(
+      title: title,
+      description: description,
+      asap: asap,
+      due_date: dueDate,
+      due_date_time_present: dueDateTimePresent,
+      sort_order: sortOrder,
+      expires_later: expiresLater,
+      size_text: sizeText,
+      board_id: boardId,
+      column_id: columnId,
+      lane_id: laneId,
+      owner_id: ownerId,
+      type_id: typeId,
+      service_id: serviceId,
+      blocked: blocked,
+      condition: condition,
+      external_id: externalId,
+      text_format_type_id: textFormatTypeId,
+      sd_new_comment: sdNewComment,
+      owner_email: ownerEmail,
+      prev_card_id: prevCardId,
+      estimate_workload: estimateWorkload,
+      properties: properties
+    )
+    let response = try await call {
+      try await client.update_card(
+        path: .init(card_id: id),
+        body: .json(body)
+      )
     }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", id)) { try $0.json }
+  }
 
-    /// Fetches a single card by its identifier.
-    ///
-    /// - Parameter id: The card identifier.
-    /// - Returns: The full card object with all fields including custom properties.
-    /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card does not exist.
-    public func getCard(id: Int) async throws(KaitenError) -> Components.Schemas.Card {
-        let response = try await call { try await client.get_card(path: .init(card_id: id)) }
-        return try decodeResponse(response.toCase(), notFoundResource: ("card", id)) { try $0.json }
+  // MARK: - Card Members
+
+  /// Fetches the list of members assigned to a card.
+  ///
+  /// - Parameter cardId: The card identifier.
+  /// - Returns: An array of detailed member objects. Returns an empty array if no members are assigned.
+  /// - Throws: ``KaitenError``
+  public func getCardMembers(cardId: Int) async throws(KaitenError) -> [Components.Schemas
+    .MemberDetailed]
+  {
+    guard
+      let response = try await callList({
+        try await client.retrieve_list_of_card_members(path: .init(card_id: cardId))
+      })
+    else {
+      return []
     }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
 
-    /// Creates a new card on a board.
-    ///
-    /// - Parameters:
-    ///   - title: Card title (required, max 1024 characters).
-    ///   - boardId: Board ID where the card will be created (required).
-    ///   - columnId: Column ID. If omitted the board's default column is used.
-    ///   - laneId: Lane ID. If omitted the board's default lane is used.
-    ///   - description: Card description (max 32768 characters).
-    ///   - asap: ASAP marker.
-    ///   - dueDate: Deadline in ISO 8601 format.
-    ///   - dueDateTimePresent: Whether deadline includes hours and minutes.
-    ///   - sortOrder: Position in the cell.
-    ///   - expiresLater: Fixed deadline flag.
-    ///   - sizeText: Size text (e.g. "1", "S", "XL").
-    ///   - ownerId: Owner user ID.
-    ///   - responsibleId: Responsible user ID.
-    ///   - ownerEmail: Owner email address (only works if email belongs to company user).
-    ///   - position: 1 = first in cell, 2 = last in cell. Overrides sort_order if present.
-    ///   - typeId: Card type ID.
-    ///   - externalId: External identifier.
-    ///   - textFormatTypeId: 1 = markdown, 2 = html, 3 = jira wiki.
-    ///   - properties: Custom properties object.
-    /// - Returns: The created card.
-    /// - Throws: ``KaitenError``
-    public func createCard(
-        title: String,
-        boardId: Int,
-        columnId: Int? = nil,
-        laneId: Int? = nil,
-        description: String? = nil,
-        asap: Bool? = nil,
-        dueDate: String? = nil,
-        dueDateTimePresent: Bool? = nil,
-        sortOrder: Double? = nil,
-        expiresLater: Bool? = nil,
-        sizeText: String? = nil,
-        ownerId: Int? = nil,
-        responsibleId: Int? = nil,
-        ownerEmail: String? = nil,
-        position: Int? = nil,
-        typeId: Int? = nil,
-        externalId: String? = nil,
-        textFormatTypeId: Int? = nil,
-        properties: Components.Schemas.CreateCardRequest.propertiesPayload? = nil
-    ) async throws(KaitenError) -> Components.Schemas.Card {
-        let body = Components.Schemas.CreateCardRequest(
-            title: title,
-            board_id: boardId,
-            column_id: columnId,
-            lane_id: laneId,
-            description: description,
-            asap: asap,
-            due_date: dueDate,
-            due_date_time_present: dueDateTimePresent,
-            sort_order: sortOrder,
-            expires_later: expiresLater,
-            size_text: sizeText,
-            owner_id: ownerId,
-            responsible_id: responsibleId,
-            owner_email: ownerEmail,
-            position: position,
-            type_id: typeId,
-            external_id: externalId,
-            text_format_type_id: textFormatTypeId,
-            properties: properties
-        )
-        let response = try await call {
-            try await client.create_card(body: .json(body))
-        }
-        return try decodeResponse(response.toCase()) { try $0.json }
+  /// Creates a comment on a card.
+  ///
+  /// - Parameters:
+  ///   - cardId: The card identifier.
+  ///   - text: Comment text (markdown).
+  /// - Returns: The created comment.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card does not exist.
+  public func createComment(cardId: Int, text: String) async throws(KaitenError)
+    -> Components.Schemas.Comment
+  {
+    let response = try await call {
+      try await client.create_card_comment(
+        path: .init(card_id: cardId),
+        body: .json(.init(text: text))
+      )
     }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) { try $0.json }
+  }
 
-    /// Updates a card by its identifier.
-    ///
-    /// All fields in the request body are optional — only provided values are changed.
-    ///
-    /// - Parameters:
-    ///   - id: The card identifier.
-    ///   - title: New card title.
-    ///   - description: New description (pass `nil` wrapped in `.some(nil)` to clear).
-    ///   - asap: ASAP marker.
-    ///   - dueDate: Deadline in ISO 8601 format (pass `nil` wrapped in `.some(nil)` to clear).
-    ///   - dueDateTimePresent: Whether deadline includes hours and minutes.
-    ///   - sortOrder: Position in the cell.
-    ///   - expiresLater: Fixed deadline flag.
-    ///   - sizeText: Size text (e.g. "1", "S", "XL").
-    ///   - boardId: Target board ID.
-    ///   - columnId: Target column ID.
-    ///   - laneId: Target lane ID.
-    ///   - ownerId: Owner user ID.
-    ///   - typeId: Card type ID.
-    ///   - serviceId: Service ID.
-    ///   - blocked: Send `false` to release all blocks.
-    ///   - condition: 1 = live, 2 = archived.
-    ///   - externalId: External identifier.
-    ///   - textFormatTypeId: 1 = markdown, 2 = html, 3 = jira wiki.
-    ///   - sdNewComment: Service Desk new comment flag.
-    ///   - ownerEmail: Owner email address.
-    ///   - prevCardId: Previous card ID for repositioning.
-    ///   - estimateWorkload: Estimated workload.
-    ///   - properties: Custom properties object.
-    /// - Returns: The updated card.
-    /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card does not exist.
-    public func updateCard(
-        id: Int,
-        title: String? = nil,
-        description: String? = nil,
-        asap: Bool? = nil,
-        dueDate: String? = nil,
-        dueDateTimePresent: Bool? = nil,
-        sortOrder: Double? = nil,
-        expiresLater: Bool? = nil,
-        sizeText: String? = nil,
-        boardId: Int? = nil,
-        columnId: Int? = nil,
-        laneId: Int? = nil,
-        ownerId: Int? = nil,
-        typeId: Int? = nil,
-        serviceId: Int? = nil,
-        blocked: Bool? = nil,
-        condition: Int? = nil,
-        externalId: String? = nil,
-        textFormatTypeId: Int? = nil,
-        sdNewComment: Bool? = nil,
-        ownerEmail: String? = nil,
-        prevCardId: Int? = nil,
-        estimateWorkload: Double? = nil,
-        properties: Components.Schemas.UpdateCardRequest.propertiesPayload? = nil
-    ) async throws(KaitenError) -> Components.Schemas.Card {
-        let body = Components.Schemas.UpdateCardRequest(
-            title: title,
-            description: description,
-            asap: asap,
-            due_date: dueDate,
-            due_date_time_present: dueDateTimePresent,
-            sort_order: sortOrder,
-            expires_later: expiresLater,
-            size_text: sizeText,
-            board_id: boardId,
-            column_id: columnId,
-            lane_id: laneId,
-            owner_id: ownerId,
-            type_id: typeId,
-            service_id: serviceId,
-            blocked: blocked,
-            condition: condition,
-            external_id: externalId,
-            text_format_type_id: textFormatTypeId,
-            sd_new_comment: sdNewComment,
-            owner_email: ownerEmail,
-            prev_card_id: prevCardId,
-            estimate_workload: estimateWorkload,
-            properties: properties
-        )
-        let response = try await call {
-            try await client.update_card(
-                path: .init(card_id: id),
-                body: .json(body)
-            )
-        }
-        return try decodeResponse(response.toCase(), notFoundResource: ("card", id)) { try $0.json }
+  /// Fetches all comments on a card.
+  ///
+  /// - Parameter cardId: The card identifier.
+  /// - Returns: An array of comments. Returns an empty array if the card has no comments.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card does not exist.
+  public func getCardComments(cardId: Int) async throws(KaitenError) -> [Components.Schemas.Comment]
+  {
+    guard
+      let response = try await callList({
+        try await client.retrieve_card_comments(path: .init(card_id: cardId))
+      })
+    else {
+      return []
     }
-
-    // MARK: - Card Members
-
-    /// Fetches the list of members assigned to a card.
-    ///
-    /// - Parameter cardId: The card identifier.
-    /// - Returns: An array of detailed member objects. Returns an empty array if no members are assigned.
-    /// - Throws: ``KaitenError``
-    public func getCardMembers(cardId: Int) async throws(KaitenError) -> [Components.Schemas.MemberDetailed] {
-        guard let response = try await callList({ try await client.retrieve_list_of_card_members(path: .init(card_id: cardId)) }) else {
-            return []
-        }
-        return try decodeResponse(response.toCase()) { try $0.json }
-    }
-
-    /// Creates a comment on a card.
-    ///
-    /// - Parameters:
-    ///   - cardId: The card identifier.
-    ///   - text: Comment text (markdown).
-    /// - Returns: The created comment.
-    /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card does not exist.
-    public func createComment(cardId: Int, text: String) async throws(KaitenError) -> Components.Schemas.Comment {
-        let response = try await call {
-            try await client.create_card_comment(
-                path: .init(card_id: cardId),
-                body: .json(.init(text: text))
-            )
-        }
-        return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) { try $0.json }
-    }
-
-    /// Fetches all comments on a card.
-    ///
-    /// - Parameter cardId: The card identifier.
-    /// - Returns: An array of comments. Returns an empty array if the card has no comments.
-    /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card does not exist.
-    public func getCardComments(cardId: Int) async throws(KaitenError) -> [Components.Schemas.Comment] {
-        guard let response = try await callList({ try await client.retrieve_card_comments(path: .init(card_id: cardId)) }) else {
-            return []
-        }
-        return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) { try $0.json }
-    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) { try $0.json }
+  }
 }
 
 // MARK: - Custom Properties
 
 extension KaitenClient {
-    /// Lists all custom property definitions for the company.
-    ///
-    /// Custom properties are company-wide field definitions (e.g. "Team", "Platform")
-    /// that can be attached to cards.
-    ///
-    /// - Parameters:
-    ///   - offset: Number of properties to skip (default `0`).
-    ///   - limit: Maximum number of properties to return (default `100`).
-    ///   - query: Text search query to filter properties by name.
-    ///   - includeValues: Include property values in the response.
-    ///   - includeAuthor: Include author details in the response.
-    ///   - compact: Return compact representation.
-    ///   - loadByIds: Load properties by IDs (use with `ids`).
-    ///   - ids: Array of property IDs to load (requires `loadByIds: true`).
-    ///   - orderBy: Field to order by.
-    ///   - orderDirection: Order direction: asc or desc.
-    /// - Returns: A ``Page`` of custom property definitions.
-    /// - Throws: ``KaitenError``
-    public func listCustomProperties(
-        offset: Int = 0,
-        limit: Int = 100,
-        query: String? = nil,
-        includeValues: Bool? = nil,
-        includeAuthor: Bool? = nil,
-        compact: Bool? = nil,
-        loadByIds: Bool? = nil,
-        ids: [Int]? = nil,
-        orderBy: String? = nil,
-        orderDirection: String? = nil
-    ) async throws(KaitenError) -> Page<Components.Schemas.CustomProperty> {
-        guard let response = try await callList({ try await client.get_list_of_properties(query: .init(offset: offset, limit: limit, include_values: includeValues, include_author: includeAuthor, compact: compact, load_by_ids: loadByIds, ids: ids, order_by: orderBy, order_direction: orderDirection, query: query)) }) else {
-            return Page(items: [], offset: offset, limit: limit)
-        }
-        let items: [Components.Schemas.CustomProperty] = try decodeResponse(response.toCase()) { try $0.json }
-        return Page(items: items, offset: offset, limit: limit)
+  /// Lists all custom property definitions for the company.
+  ///
+  /// Custom properties are company-wide field definitions (e.g. "Team", "Platform")
+  /// that can be attached to cards.
+  ///
+  /// - Parameters:
+  ///   - offset: Number of properties to skip (default `0`).
+  ///   - limit: Maximum number of properties to return (default `100`).
+  ///   - query: Text search query to filter properties by name.
+  ///   - includeValues: Include property values in the response.
+  ///   - includeAuthor: Include author details in the response.
+  ///   - compact: Return compact representation.
+  ///   - loadByIds: Load properties by IDs (use with `ids`).
+  ///   - ids: Array of property IDs to load (requires `loadByIds: true`).
+  ///   - orderBy: Field to order by.
+  ///   - orderDirection: Order direction: asc or desc.
+  /// - Returns: A ``Page`` of custom property definitions.
+  /// - Throws: ``KaitenError``
+  public func listCustomProperties(
+    offset: Int = 0,
+    limit: Int = 100,
+    query: String? = nil,
+    includeValues: Bool? = nil,
+    includeAuthor: Bool? = nil,
+    compact: Bool? = nil,
+    loadByIds: Bool? = nil,
+    ids: [Int]? = nil,
+    orderBy: String? = nil,
+    orderDirection: String? = nil
+  ) async throws(KaitenError) -> Page<Components.Schemas.CustomProperty> {
+    guard
+      let response = try await callList({
+        try await client.get_list_of_properties(
+          query: .init(
+            offset: offset, limit: limit, include_values: includeValues,
+            include_author: includeAuthor, compact: compact, load_by_ids: loadByIds, ids: ids,
+            order_by: orderBy, order_direction: orderDirection, query: query))
+      })
+    else {
+      return Page(items: [], offset: offset, limit: limit)
     }
+    let items: [Components.Schemas.CustomProperty] = try decodeResponse(response.toCase()) {
+      try $0.json
+    }
+    return Page(items: items, offset: offset, limit: limit)
+  }
 
-    /// Fetches a single custom property definition by its identifier.
-    ///
-    /// - Parameter id: The custom property identifier.
-    /// - Returns: The custom property definition.
-    /// - Throws: ``KaitenError/notFound(resource:id:)`` if the property does not exist.
-    public func getCustomProperty(id: Int) async throws(KaitenError) -> Components.Schemas.CustomProperty {
-        let response = try await call { try await client.get_property(path: .init(id: id)) }
-        return try decodeResponse(response.toCase(), notFoundResource: ("customProperty", id)) { try $0.json }
+  /// Fetches a single custom property definition by its identifier.
+  ///
+  /// - Parameter id: The custom property identifier.
+  /// - Returns: The custom property definition.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the property does not exist.
+  public func getCustomProperty(id: Int) async throws(KaitenError)
+    -> Components.Schemas.CustomProperty
+  {
+    let response = try await call { try await client.get_property(path: .init(id: id)) }
+    return try decodeResponse(response.toCase(), notFoundResource: ("customProperty", id)) {
+      try $0.json
     }
+  }
 }
 
 // MARK: - Boards
 
 extension KaitenClient {
-    /// Fetches a board by its identifier.
-    ///
-    /// Returns the full board object including columns, lanes, and cards.
-    ///
-    /// - Parameter id: The board identifier.
-    /// - Returns: The full board object.
-    /// - Throws: ``KaitenError/notFound(resource:id:)`` if the board does not exist.
-    public func getBoard(id: Int) async throws(KaitenError) -> Components.Schemas.Board {
-        let response = try await call { try await client.get_board(path: .init(id: id)) }
-        return try decodeResponse(response.toCase(), notFoundResource: ("board", id)) { try $0.json }
-    }
+  /// Fetches a board by its identifier.
+  ///
+  /// Returns the full board object including columns, lanes, and cards.
+  ///
+  /// - Parameter id: The board identifier.
+  /// - Returns: The full board object.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the board does not exist.
+  public func getBoard(id: Int) async throws(KaitenError) -> Components.Schemas.Board {
+    let response = try await call { try await client.get_board(path: .init(id: id)) }
+    return try decodeResponse(response.toCase(), notFoundResource: ("board", id)) { try $0.json }
+  }
 
-    /// Fetches all columns for a board.
-    ///
-    /// - Parameter boardId: The board identifier.
-    /// - Returns: An array of columns. Returns an empty array if the board has no columns.
-    /// - Throws: ``KaitenError/notFound(resource:id:)`` if the board does not exist.
-    public func getBoardColumns(boardId: Int) async throws(KaitenError) -> [Components.Schemas.Column] {
-        guard let response = try await callList({ try await client.get_list_of_columns(path: .init(board_id: boardId)) }) else {
-            return []
-        }
-        return try decodeResponse(response.toCase(), notFoundResource: ("board", boardId)) { try $0.json }
+  /// Fetches all columns for a board.
+  ///
+  /// - Parameter boardId: The board identifier.
+  /// - Returns: An array of columns. Returns an empty array if the board has no columns.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the board does not exist.
+  public func getBoardColumns(boardId: Int) async throws(KaitenError) -> [Components.Schemas.Column]
+  {
+    guard
+      let response = try await callList({
+        try await client.get_list_of_columns(path: .init(board_id: boardId))
+      })
+    else {
+      return []
     }
+    return try decodeResponse(response.toCase(), notFoundResource: ("board", boardId)) {
+      try $0.json
+    }
+  }
 
-    /// Fetches all lanes (horizontal swimlanes) for a board.
-    ///
-    /// - Parameters:
-    ///   - boardId: The board identifier.
-    ///   - condition: Optional lane condition filter: 1 = live, 2 = archived, 3 = deleted.
-    /// - Returns: An array of lanes. Returns an empty array if the board has no lanes.
-    /// - Throws: ``KaitenError/notFound(resource:id:)`` if the board does not exist.
-    public func getBoardLanes(boardId: Int, condition: Int? = nil) async throws(KaitenError) -> [Components.Schemas.Lane] {
-        guard let response = try await callList({ try await client.get_list_of_lanes(path: .init(board_id: boardId), query: .init(condition: condition)) }) else {
-            return []
-        }
-        return try decodeResponse(response.toCase(), notFoundResource: ("board", boardId)) { try $0.json }
+  /// Fetches all lanes (horizontal swimlanes) for a board.
+  ///
+  /// - Parameters:
+  ///   - boardId: The board identifier.
+  ///   - condition: Optional lane condition filter: 1 = live, 2 = archived, 3 = deleted.
+  /// - Returns: An array of lanes. Returns an empty array if the board has no lanes.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the board does not exist.
+  public func getBoardLanes(boardId: Int, condition: Int? = nil) async throws(KaitenError)
+    -> [Components.Schemas.Lane]
+  {
+    guard
+      let response = try await callList({
+        try await client.get_list_of_lanes(
+          path: .init(board_id: boardId), query: .init(condition: condition))
+      })
+    else {
+      return []
     }
+    return try decodeResponse(response.toCase(), notFoundResource: ("board", boardId)) {
+      try $0.json
+    }
+  }
 }
 
 // MARK: - Spaces
 
 extension KaitenClient {
-    /// Lists all spaces visible to the authenticated user.
-    ///
-    /// - Returns: An array of spaces. Returns an empty array if no spaces are available.
-    /// - Throws: ``KaitenError``
-    public func listSpaces() async throws(KaitenError) -> [Components.Schemas.Space] {
-        guard let response = try await callList({ try await client.retrieve_list_of_spaces() }) else {
-            return []
-        }
-        return try decodeResponse(response.toCase()) { try $0.json }
+  /// Lists all spaces visible to the authenticated user.
+  ///
+  /// - Returns: An array of spaces. Returns an empty array if no spaces are available.
+  /// - Throws: ``KaitenError``
+  public func listSpaces() async throws(KaitenError) -> [Components.Schemas.Space] {
+    guard let response = try await callList({ try await client.retrieve_list_of_spaces() }) else {
+      return []
     }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
 
-    /// Lists all boards within a space.
-    ///
-    /// - Parameter spaceId: The space identifier.
-    /// - Returns: An array of boards. Returns an empty array if the space has no boards.
-    /// - Throws: ``KaitenError/notFound(resource:id:)`` if the space does not exist.
-    public func listBoards(spaceId: Int) async throws(KaitenError) -> [Components.Schemas.BoardInSpace] {
-        guard let response = try await callList({ try await client.get_list_of_boards(path: .init(space_id: spaceId)) }) else {
-            return []
-        }
-        return try decodeResponse(response.toCase(), notFoundResource: ("space", spaceId)) { try $0.json }
+  /// Lists all boards within a space.
+  ///
+  /// - Parameter spaceId: The space identifier.
+  /// - Returns: An array of boards. Returns an empty array if the space has no boards.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the space does not exist.
+  public func listBoards(spaceId: Int) async throws(KaitenError) -> [Components.Schemas
+    .BoardInSpace]
+  {
+    guard
+      let response = try await callList({
+        try await client.get_list_of_boards(path: .init(space_id: spaceId))
+      })
+    else {
+      return []
     }
+    return try decodeResponse(response.toCase(), notFoundResource: ("space", spaceId)) {
+      try $0.json
+    }
+  }
 }
 
 // MARK: - Helpers
 
 extension Optional {
-    func orThrow(_ error: @autoclosure () -> KaitenError) throws(KaitenError) -> Wrapped {
-        guard let self else { throw error() }
-        return self
-    }
+  func orThrow(_ error: @autoclosure () -> KaitenError) throws(KaitenError) -> Wrapped {
+    guard let self else { throw error() }
+    return self
+  }
 }

--- a/Sources/KaitenSDK/KaitenError.swift
+++ b/Sources/KaitenSDK/KaitenError.swift
@@ -2,54 +2,53 @@ import Foundation
 
 /// Errors thrown by the Kaiten SDK.
 public enum KaitenError: Error, Sendable {
-    /// A required configuration value is missing.
-    case missingConfiguration(String)
-    /// The provided URL is invalid.
-    case invalidURL(String)
-    /// The API returned 401 Unauthorized.
-    case unauthorized
-    /// The requested resource was not found.
-    case notFound(resource: String, id: Int)
-    /// The API rate limit has been exceeded.
-    case rateLimited(retryAfter: TimeInterval?)
-    /// The server returned a 5xx error.
-    case serverError(statusCode: Int, body: String?)
-    /// A network-level error occurred.
-    case networkError(underlying: any Error)
-    /// A decoding error occurred while parsing the response.
-    case decodingError(underlying: any Error)
-    /// The API returned an unexpected HTTP status code.
-    case unexpectedResponse(statusCode: Int, body: String? = nil)
+  /// A required configuration value is missing.
+  case missingConfiguration(String)
+  /// The provided URL is invalid.
+  case invalidURL(String)
+  /// The API returned 401 Unauthorized.
+  case unauthorized
+  /// The requested resource was not found.
+  case notFound(resource: String, id: Int)
+  /// The API rate limit has been exceeded.
+  case rateLimited(retryAfter: TimeInterval?)
+  /// The server returned a 5xx error.
+  case serverError(statusCode: Int, body: String?)
+  /// A network-level error occurred.
+  case networkError(underlying: any Error)
+  /// A decoding error occurred while parsing the response.
+  case decodingError(underlying: any Error)
+  /// The API returned an unexpected HTTP status code.
+  case unexpectedResponse(statusCode: Int, body: String? = nil)
 }
 
 // MARK: - LocalizedError
 
 extension KaitenError: LocalizedError {
-    public var errorDescription: String? {
-        switch self {
-        case .missingConfiguration(let key):
-            "Missing required configuration: \(key)"
-        case .invalidURL(let url):
-            "Invalid URL: \(url)"
-        case .unauthorized:
-            "Unauthorized – check your API token"
-        case .notFound(let resource, let id):
-            "\(resource) with id \(id) not found"
-        case .rateLimited(let retryAfter):
-            if let retryAfter {
-                "Rate limited – retry after \(Int(retryAfter))s"
-            } else {
-                "Rate limited – retry later"
-            }
-        case .serverError(let statusCode, let body):
-            "Server error \(statusCode)" + (body.map { ": \($0)" } ?? "")
-        case .networkError(let underlying):
-            "Network error: \(underlying.localizedDescription)"
-        case .decodingError(let underlying):
-            "Decoding error: \(underlying.localizedDescription)"
-        case .unexpectedResponse(let statusCode, let body):
-            "Unexpected HTTP response: \(statusCode)" + (body.map { ": \($0)" } ?? "")
-        }
+  public var errorDescription: String? {
+    switch self {
+    case .missingConfiguration(let key):
+      "Missing required configuration: \(key)"
+    case .invalidURL(let url):
+      "Invalid URL: \(url)"
+    case .unauthorized:
+      "Unauthorized – check your API token"
+    case .notFound(let resource, let id):
+      "\(resource) with id \(id) not found"
+    case .rateLimited(let retryAfter):
+      if let retryAfter {
+        "Rate limited – retry after \(Int(retryAfter))s"
+      } else {
+        "Rate limited – retry later"
+      }
+    case .serverError(let statusCode, let body):
+      "Server error \(statusCode)" + (body.map { ": \($0)" } ?? "")
+    case .networkError(let underlying):
+      "Network error: \(underlying.localizedDescription)"
+    case .decodingError(let underlying):
+      "Decoding error: \(underlying.localizedDescription)"
+    case .unexpectedResponse(let statusCode, let body):
+      "Unexpected HTTP response: \(statusCode)" + (body.map { ": \($0)" } ?? "")
     }
+  }
 }
-

--- a/Sources/KaitenSDK/Page.swift
+++ b/Sources/KaitenSDK/Page.swift
@@ -1,21 +1,21 @@
 /// A page of results from a paginated API endpoint.
 public struct Page<T: Sendable>: Sendable {
-    /// The items in this page.
-    public let items: [T]
-    /// The offset used to fetch this page.
-    public let offset: Int
-    /// The limit used to fetch this page.
-    public let limit: Int
-    /// Whether there are likely more results available.
-    /// Determined by `items.count == limit`.
-    public let hasMore: Bool
+  /// The items in this page.
+  public let items: [T]
+  /// The offset used to fetch this page.
+  public let offset: Int
+  /// The limit used to fetch this page.
+  public let limit: Int
+  /// Whether there are likely more results available.
+  /// Determined by `items.count == limit`.
+  public let hasMore: Bool
 
-    public init(items: [T], offset: Int, limit: Int) {
-        self.items = items
-        self.offset = offset
-        self.limit = limit
-        self.hasMore = items.count == limit
-    }
+  public init(items: [T], offset: Int, limit: Int) {
+    self.items = items
+    self.offset = offset
+    self.limit = limit
+    self.hasMore = items.count == limit
+  }
 }
 
 extension Page: Equatable where T: Equatable {}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -5,171 +5,173 @@
 // MARK: - Cards
 
 extension Operations.get_cards.Output {
-    func toCase() -> KaitenClient.ResponseCase<Operations.get_cards.Output.Ok.Body> {
-        switch self {
-        case .ok(let ok): .ok(ok.body)
-        case .unauthorized: .unauthorized
-        case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
-        }
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_cards.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
     }
+  }
 }
 
 extension Operations.create_card.Output {
-    func toCase() -> KaitenClient.ResponseCase<Operations.create_card.Output.Ok.Body> {
-        switch self {
-        case .ok(let ok): .ok(ok.body)
-        case .badRequest: .undocumented(statusCode: 400)
-        case .unauthorized: .unauthorized
-        case .forbidden: .forbidden
-        case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
-        }
+  func toCase() -> KaitenClient.ResponseCase<Operations.create_card.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
     }
+  }
 }
 
 extension Operations.get_card.Output {
-    func toCase() -> KaitenClient.ResponseCase<Operations.get_card.Output.Ok.Body> {
-        switch self {
-        case .ok(let ok): .ok(ok.body)
-        case .unauthorized: .unauthorized
-        case .notFound: .notFound
-        case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
-        }
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_card.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
     }
+  }
 }
 
 extension Operations.update_card.Output {
-    func toCase() -> KaitenClient.ResponseCase<Operations.update_card.Output.Ok.Body> {
-        switch self {
-        case .ok(let ok): .ok(ok.body)
-        case .badRequest: .undocumented(statusCode: 400)
-        case .unauthorized: .unauthorized
-        case .forbidden: .forbidden
-        case .notFound: .notFound
-        case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
-        }
+  func toCase() -> KaitenClient.ResponseCase<Operations.update_card.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
     }
+  }
 }
 
 // MARK: - Card Members & Comments
 
 extension Operations.retrieve_list_of_card_members.Output {
-    func toCase() -> KaitenClient.ResponseCase<Operations.retrieve_list_of_card_members.Output.Ok.Body> {
-        switch self {
-        case .ok(let ok): .ok(ok.body)
-        case .unauthorized: .unauthorized
-        case .forbidden: .forbidden
-        case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
-        }
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.retrieve_list_of_card_members.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
     }
+  }
 }
 
 extension Operations.retrieve_card_comments.Output {
-    func toCase() -> KaitenClient.ResponseCase<Operations.retrieve_card_comments.Output.Ok.Body> {
-        switch self {
-        case .ok(let ok): .ok(ok.body)
-        case .unauthorized: .unauthorized
-        case .forbidden: .forbidden
-        case .notFound: .notFound
-        case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
-        }
+  func toCase() -> KaitenClient.ResponseCase<Operations.retrieve_card_comments.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
     }
+  }
 }
 
 extension Operations.create_card_comment.Output {
-    func toCase() -> KaitenClient.ResponseCase<Operations.create_card_comment.Output.Ok.Body> {
-        switch self {
-        case .ok(let ok): .ok(ok.body)
-        case .unauthorized: .unauthorized
-        case .forbidden: .forbidden
-        case .notFound: .notFound
-        case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
-        }
+  func toCase() -> KaitenClient.ResponseCase<Operations.create_card_comment.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
     }
+  }
 }
 
 // MARK: - Custom Properties
 
 extension Operations.get_list_of_properties.Output {
-    func toCase() -> KaitenClient.ResponseCase<Operations.get_list_of_properties.Output.Ok.Body> {
-        switch self {
-        case .ok(let ok): .ok(ok.body)
-        case .unauthorized: .unauthorized
-        case .forbidden: .forbidden
-        case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
-        }
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_list_of_properties.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
     }
+  }
 }
 
 extension Operations.get_property.Output {
-    func toCase() -> KaitenClient.ResponseCase<Operations.get_property.Output.Ok.Body> {
-        switch self {
-        case .ok(let ok): .ok(ok.body)
-        case .unauthorized: .unauthorized
-        case .forbidden: .forbidden
-        case .notFound: .notFound
-        case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
-        }
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_property.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
     }
+  }
 }
 
 // MARK: - Boards
 
 extension Operations.get_board.Output {
-    func toCase() -> KaitenClient.ResponseCase<Operations.get_board.Output.Ok.Body> {
-        switch self {
-        case .ok(let ok): .ok(ok.body)
-        case .unauthorized: .unauthorized
-        case .forbidden: .forbidden
-        case .notFound: .notFound
-        case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
-        }
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_board.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
     }
+  }
 }
 
 extension Operations.get_list_of_columns.Output {
-    func toCase() -> KaitenClient.ResponseCase<Operations.get_list_of_columns.Output.Ok.Body> {
-        switch self {
-        case .ok(let ok): .ok(ok.body)
-        case .unauthorized: .unauthorized
-        case .forbidden: .forbidden
-        case .notFound: .notFound
-        case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
-        }
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_list_of_columns.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
     }
+  }
 }
 
 extension Operations.get_list_of_lanes.Output {
-    func toCase() -> KaitenClient.ResponseCase<Operations.get_list_of_lanes.Output.Ok.Body> {
-        switch self {
-        case .ok(let ok): .ok(ok.body)
-        case .unauthorized: .unauthorized
-        case .forbidden: .forbidden
-        case .notFound: .notFound
-        case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
-        }
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_list_of_lanes.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
     }
+  }
 }
 
 // MARK: - Spaces
 
 extension Operations.retrieve_list_of_spaces.Output {
-    func toCase() -> KaitenClient.ResponseCase<Operations.retrieve_list_of_spaces.Output.Ok.Body> {
-        switch self {
-        case .ok(let ok): .ok(ok.body)
-        case .unauthorized: .unauthorized
-        case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
-        }
+  func toCase() -> KaitenClient.ResponseCase<Operations.retrieve_list_of_spaces.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
     }
+  }
 }
 
 extension Operations.get_list_of_boards.Output {
-    func toCase() -> KaitenClient.ResponseCase<Operations.get_list_of_boards.Output.Ok.Body> {
-        switch self {
-        case .ok(let ok): .ok(ok.body)
-        case .unauthorized: .unauthorized
-        case .forbidden: .forbidden
-        case .notFound: .notFound
-        case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
-        }
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_list_of_boards.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
     }
+  }
 }

--- a/Sources/kaiten/BoardCommands.swift
+++ b/Sources/kaiten/BoardCommands.swift
@@ -4,76 +4,76 @@ import KaitenSDK
 // MARK: - Boards
 
 struct ListBoards: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "list-boards",
-        abstract: "List boards in a space"
-    )
+  static let configuration = CommandConfiguration(
+    commandName: "list-boards",
+    abstract: "List boards in a space"
+  )
 
-    @OptionGroup var global: GlobalOptions
+  @OptionGroup var global: GlobalOptions
 
-    @Option(name: .long, help: "Space ID")
-    var spaceId: Int
+  @Option(name: .long, help: "Space ID")
+  var spaceId: Int
 
-    func run() async throws {
-        let client = try await global.makeClient()
-        let boards = try await client.listBoards(spaceId: spaceId)
-        try printJSON(boards)
-    }
+  func run() async throws {
+    let client = try await global.makeClient()
+    let boards = try await client.listBoards(spaceId: spaceId)
+    try printJSON(boards)
+  }
 }
 
 struct GetBoard: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "get-board",
-        abstract: "Get a board by ID"
-    )
+  static let configuration = CommandConfiguration(
+    commandName: "get-board",
+    abstract: "Get a board by ID"
+  )
 
-    @OptionGroup var global: GlobalOptions
+  @OptionGroup var global: GlobalOptions
 
-    @Option(name: .long, help: "Board ID")
-    var id: Int
+  @Option(name: .long, help: "Board ID")
+  var id: Int
 
-    func run() async throws {
-        let client = try await global.makeClient()
-        let board = try await client.getBoard(id: id)
-        try printJSON(board)
-    }
+  func run() async throws {
+    let client = try await global.makeClient()
+    let board = try await client.getBoard(id: id)
+    try printJSON(board)
+  }
 }
 
 struct GetBoardColumns: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "get-board-columns",
-        abstract: "Get columns of a board"
-    )
+  static let configuration = CommandConfiguration(
+    commandName: "get-board-columns",
+    abstract: "Get columns of a board"
+  )
 
-    @OptionGroup var global: GlobalOptions
+  @OptionGroup var global: GlobalOptions
 
-    @Option(name: .long, help: "Board ID")
-    var boardId: Int
+  @Option(name: .long, help: "Board ID")
+  var boardId: Int
 
-    func run() async throws {
-        let client = try await global.makeClient()
-        let columns = try await client.getBoardColumns(boardId: boardId)
-        try printJSON(columns)
-    }
+  func run() async throws {
+    let client = try await global.makeClient()
+    let columns = try await client.getBoardColumns(boardId: boardId)
+    try printJSON(columns)
+  }
 }
 
 struct GetBoardLanes: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "get-board-lanes",
-        abstract: "Get lanes of a board"
-    )
+  static let configuration = CommandConfiguration(
+    commandName: "get-board-lanes",
+    abstract: "Get lanes of a board"
+  )
 
-    @OptionGroup var global: GlobalOptions
+  @OptionGroup var global: GlobalOptions
 
-    @Option(name: .long, help: "Board ID")
-    var boardId: Int
+  @Option(name: .long, help: "Board ID")
+  var boardId: Int
 
-    @Option(name: .long, help: "Lane condition: 1 = live, 2 = archived, 3 = deleted")
-    var condition: Int?
+  @Option(name: .long, help: "Lane condition: 1 = live, 2 = archived, 3 = deleted")
+  var condition: Int?
 
-    func run() async throws {
-        let client = try await global.makeClient()
-        let lanes = try await client.getBoardLanes(boardId: boardId, condition: condition)
-        try printJSON(lanes)
-    }
+  func run() async throws {
+    let client = try await global.makeClient()
+    let lanes = try await client.getBoardLanes(boardId: boardId, condition: condition)
+    try printJSON(lanes)
+  }
 }

--- a/Sources/kaiten/CardCommands.swift
+++ b/Sources/kaiten/CardCommands.swift
@@ -4,476 +4,478 @@ import KaitenSDK
 // MARK: - Cards
 
 struct ListCards: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "list-cards",
-        abstract: "List cards on a board (paginated)"
+  static let configuration = CommandConfiguration(
+    commandName: "list-cards",
+    abstract: "List cards on a board (paginated)"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Board ID")
+  var boardId: Int?
+
+  @Option(name: .long, help: "Column ID")
+  var columnId: Int?
+
+  @Option(name: .long, help: "Lane ID")
+  var laneId: Int?
+
+  @Option(name: .long, help: "Offset for pagination (default: 0)")
+  var offset: Int = 0
+
+  @Option(name: .long, help: "Limit for pagination (default/max: 100)")
+  var limit: Int = 100
+
+  // Date filters
+  @Option(name: .long, help: "Filter cards created before this date (ISO 8601)")
+  var createdBefore: String?
+
+  @Option(name: .long, help: "Filter cards created after this date (ISO 8601)")
+  var createdAfter: String?
+
+  @Option(name: .long, help: "Filter cards updated before this date (ISO 8601)")
+  var updatedBefore: String?
+
+  @Option(name: .long, help: "Filter cards updated after this date (ISO 8601)")
+  var updatedAfter: String?
+
+  @Option(name: .long, help: "Filter cards first moved to in-progress after this date")
+  var firstMovedInProgressAfter: String?
+
+  @Option(name: .long, help: "Filter cards first moved to in-progress before this date")
+  var firstMovedInProgressBefore: String?
+
+  @Option(name: .long, help: "Filter cards last moved to done after this date")
+  var lastMovedToDoneAtAfter: String?
+
+  @Option(name: .long, help: "Filter cards last moved to done before this date")
+  var lastMovedToDoneAtBefore: String?
+
+  @Option(name: .long, help: "Filter cards with due date after this date")
+  var dueDateAfter: String?
+
+  @Option(name: .long, help: "Filter cards with due date before this date")
+  var dueDateBefore: String?
+
+  // Text search
+  @Option(name: .long, help: "Text search query")
+  var query: String?
+
+  @Option(name: .long, help: "Comma-separated fields to search in")
+  var searchFields: String?
+
+  // Tags
+  @Option(name: .long, help: "Filter by tag name")
+  var tag: String?
+
+  @Option(name: .long, help: "Comma-separated tag IDs")
+  var tagIds: String?
+
+  // ID filters
+  @Option(name: .long, help: "Filter by card type ID")
+  var typeId: Int?
+
+  @Option(name: .long, help: "Comma-separated card type IDs")
+  var typeIds: String?
+
+  @Option(name: .long, help: "Comma-separated member user IDs")
+  var memberIds: String?
+
+  @Option(name: .long, help: "Filter by owner user ID")
+  var ownerId: Int?
+
+  @Option(name: .long, help: "Comma-separated owner user IDs")
+  var ownerIds: String?
+
+  @Option(name: .long, help: "Filter by responsible user ID")
+  var responsibleId: Int?
+
+  @Option(name: .long, help: "Comma-separated responsible user IDs")
+  var responsibleIds: String?
+
+  @Option(name: .long, help: "Comma-separated column IDs")
+  var columnIds: String?
+
+  @Option(name: .long, help: "Filter by space ID")
+  var spaceId: Int?
+
+  @Option(name: .long, help: "Filter by external ID")
+  var externalId: String?
+
+  @Option(name: .long, help: "Comma-separated organization IDs")
+  var organizationsIds: String?
+
+  // Exclude filters
+  @Option(name: .long, help: "Comma-separated board IDs to exclude")
+  var excludeBoardIds: String?
+
+  @Option(name: .long, help: "Comma-separated lane IDs to exclude")
+  var excludeLaneIds: String?
+
+  @Option(name: .long, help: "Comma-separated column IDs to exclude")
+  var excludeColumnIds: String?
+
+  @Option(name: .long, help: "Comma-separated owner IDs to exclude")
+  var excludeOwnerIds: String?
+
+  @Option(name: .long, help: "Comma-separated card IDs to exclude")
+  var excludeCardIds: String?
+
+  // State filters
+  @Option(name: .long, help: "Card condition: 1 = on board, 2 = archived")
+  var condition: Int?
+
+  @Option(name: .long, help: "Comma-separated states: 1 = queued, 2 = in progress, 3 = done")
+  var states: String?
+
+  @Option(name: .long, help: "Filter by archived status")
+  var archived: Bool?
+
+  @Option(name: .long, help: "Filter ASAP cards")
+  var asap: Bool?
+
+  @Option(name: .long, help: "Filter overdue cards")
+  var overdue: Bool?
+
+  @Option(name: .long, help: "Filter cards done on time")
+  var doneOnTime: Bool?
+
+  @Option(name: .long, help: "Filter cards that have a due date")
+  var withDueDate: Bool?
+
+  @Option(name: .long, help: "Filter service desk request cards")
+  var isRequest: Bool?
+
+  // Sorting
+  @Option(name: .long, help: "Field to order by")
+  var orderBy: String?
+
+  @Option(name: .long, help: "Order direction: asc or desc")
+  var orderDirection: String?
+
+  @Option(name: .long, help: "Space ID for ordering context")
+  var orderSpaceId: Int?
+
+  // Extra
+  @Option(name: .long, help: "Comma-separated additional fields to include")
+  var additionalCardFields: String?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let filter = KaitenClient.CardFilter(
+      createdBefore: try DateParsing.parse(createdBefore),
+      createdAfter: try DateParsing.parse(createdAfter),
+      updatedBefore: try DateParsing.parse(updatedBefore),
+      updatedAfter: try DateParsing.parse(updatedAfter),
+      firstMovedInProgressAfter: try DateParsing.parse(firstMovedInProgressAfter),
+      firstMovedInProgressBefore: try DateParsing.parse(firstMovedInProgressBefore),
+      lastMovedToDoneAtAfter: try DateParsing.parse(lastMovedToDoneAtAfter),
+      lastMovedToDoneAtBefore: try DateParsing.parse(lastMovedToDoneAtBefore),
+      dueDateAfter: try DateParsing.parse(dueDateAfter),
+      dueDateBefore: try DateParsing.parse(dueDateBefore),
+      query: query,
+      searchFields: searchFields,
+      tag: tag,
+      tagIds: tagIds,
+      typeId: typeId,
+      typeIds: typeIds,
+      memberIds: memberIds,
+      ownerId: ownerId,
+      ownerIds: ownerIds,
+      responsibleId: responsibleId,
+      responsibleIds: responsibleIds,
+      columnIds: columnIds,
+      spaceId: spaceId,
+      externalId: externalId,
+      organizationsIds: organizationsIds,
+      excludeBoardIds: excludeBoardIds,
+      excludeLaneIds: excludeLaneIds,
+      excludeColumnIds: excludeColumnIds,
+      excludeOwnerIds: excludeOwnerIds,
+      excludeCardIds: excludeCardIds,
+      condition: condition,
+      states: states,
+      archived: archived,
+      asap: asap,
+      overdue: overdue,
+      doneOnTime: doneOnTime,
+      withDueDate: withDueDate,
+      isRequest: isRequest,
+      orderBy: orderBy,
+      orderDirection: orderDirection,
+      orderSpaceId: orderSpaceId,
+      additionalCardFields: additionalCardFields
     )
-
-    @OptionGroup var global: GlobalOptions
-
-    @Option(name: .long, help: "Board ID")
-    var boardId: Int?
-
-    @Option(name: .long, help: "Column ID")
-    var columnId: Int?
-
-    @Option(name: .long, help: "Lane ID")
-    var laneId: Int?
-
-    @Option(name: .long, help: "Offset for pagination (default: 0)")
-    var offset: Int = 0
-
-    @Option(name: .long, help: "Limit for pagination (default/max: 100)")
-    var limit: Int = 100
-
-    // Date filters
-    @Option(name: .long, help: "Filter cards created before this date (ISO 8601)")
-    var createdBefore: String?
-
-    @Option(name: .long, help: "Filter cards created after this date (ISO 8601)")
-    var createdAfter: String?
-
-    @Option(name: .long, help: "Filter cards updated before this date (ISO 8601)")
-    var updatedBefore: String?
-
-    @Option(name: .long, help: "Filter cards updated after this date (ISO 8601)")
-    var updatedAfter: String?
-
-    @Option(name: .long, help: "Filter cards first moved to in-progress after this date")
-    var firstMovedInProgressAfter: String?
-
-    @Option(name: .long, help: "Filter cards first moved to in-progress before this date")
-    var firstMovedInProgressBefore: String?
-
-    @Option(name: .long, help: "Filter cards last moved to done after this date")
-    var lastMovedToDoneAtAfter: String?
-
-    @Option(name: .long, help: "Filter cards last moved to done before this date")
-    var lastMovedToDoneAtBefore: String?
-
-    @Option(name: .long, help: "Filter cards with due date after this date")
-    var dueDateAfter: String?
-
-    @Option(name: .long, help: "Filter cards with due date before this date")
-    var dueDateBefore: String?
-
-    // Text search
-    @Option(name: .long, help: "Text search query")
-    var query: String?
-
-    @Option(name: .long, help: "Comma-separated fields to search in")
-    var searchFields: String?
-
-    // Tags
-    @Option(name: .long, help: "Filter by tag name")
-    var tag: String?
-
-    @Option(name: .long, help: "Comma-separated tag IDs")
-    var tagIds: String?
-
-    // ID filters
-    @Option(name: .long, help: "Filter by card type ID")
-    var typeId: Int?
-
-    @Option(name: .long, help: "Comma-separated card type IDs")
-    var typeIds: String?
-
-    @Option(name: .long, help: "Comma-separated member user IDs")
-    var memberIds: String?
-
-    @Option(name: .long, help: "Filter by owner user ID")
-    var ownerId: Int?
-
-    @Option(name: .long, help: "Comma-separated owner user IDs")
-    var ownerIds: String?
-
-    @Option(name: .long, help: "Filter by responsible user ID")
-    var responsibleId: Int?
-
-    @Option(name: .long, help: "Comma-separated responsible user IDs")
-    var responsibleIds: String?
-
-    @Option(name: .long, help: "Comma-separated column IDs")
-    var columnIds: String?
-
-    @Option(name: .long, help: "Filter by space ID")
-    var spaceId: Int?
-
-    @Option(name: .long, help: "Filter by external ID")
-    var externalId: String?
-
-    @Option(name: .long, help: "Comma-separated organization IDs")
-    var organizationsIds: String?
-
-    // Exclude filters
-    @Option(name: .long, help: "Comma-separated board IDs to exclude")
-    var excludeBoardIds: String?
-
-    @Option(name: .long, help: "Comma-separated lane IDs to exclude")
-    var excludeLaneIds: String?
-
-    @Option(name: .long, help: "Comma-separated column IDs to exclude")
-    var excludeColumnIds: String?
-
-    @Option(name: .long, help: "Comma-separated owner IDs to exclude")
-    var excludeOwnerIds: String?
-
-    @Option(name: .long, help: "Comma-separated card IDs to exclude")
-    var excludeCardIds: String?
-
-    // State filters
-    @Option(name: .long, help: "Card condition: 1 = on board, 2 = archived")
-    var condition: Int?
-
-    @Option(name: .long, help: "Comma-separated states: 1 = queued, 2 = in progress, 3 = done")
-    var states: String?
-
-    @Option(name: .long, help: "Filter by archived status")
-    var archived: Bool?
-
-    @Option(name: .long, help: "Filter ASAP cards")
-    var asap: Bool?
-
-    @Option(name: .long, help: "Filter overdue cards")
-    var overdue: Bool?
-
-    @Option(name: .long, help: "Filter cards done on time")
-    var doneOnTime: Bool?
-
-    @Option(name: .long, help: "Filter cards that have a due date")
-    var withDueDate: Bool?
-
-    @Option(name: .long, help: "Filter service desk request cards")
-    var isRequest: Bool?
-
-    // Sorting
-    @Option(name: .long, help: "Field to order by")
-    var orderBy: String?
-
-    @Option(name: .long, help: "Order direction: asc or desc")
-    var orderDirection: String?
-
-    @Option(name: .long, help: "Space ID for ordering context")
-    var orderSpaceId: Int?
-
-    // Extra
-    @Option(name: .long, help: "Comma-separated additional fields to include")
-    var additionalCardFields: String?
-
-    func run() async throws {
-        let client = try await global.makeClient()
-        let filter = KaitenClient.CardFilter(
-            createdBefore: try DateParsing.parse(createdBefore),
-            createdAfter: try DateParsing.parse(createdAfter),
-            updatedBefore: try DateParsing.parse(updatedBefore),
-            updatedAfter: try DateParsing.parse(updatedAfter),
-            firstMovedInProgressAfter: try DateParsing.parse(firstMovedInProgressAfter),
-            firstMovedInProgressBefore: try DateParsing.parse(firstMovedInProgressBefore),
-            lastMovedToDoneAtAfter: try DateParsing.parse(lastMovedToDoneAtAfter),
-            lastMovedToDoneAtBefore: try DateParsing.parse(lastMovedToDoneAtBefore),
-            dueDateAfter: try DateParsing.parse(dueDateAfter),
-            dueDateBefore: try DateParsing.parse(dueDateBefore),
-            query: query,
-            searchFields: searchFields,
-            tag: tag,
-            tagIds: tagIds,
-            typeId: typeId,
-            typeIds: typeIds,
-            memberIds: memberIds,
-            ownerId: ownerId,
-            ownerIds: ownerIds,
-            responsibleId: responsibleId,
-            responsibleIds: responsibleIds,
-            columnIds: columnIds,
-            spaceId: spaceId,
-            externalId: externalId,
-            organizationsIds: organizationsIds,
-            excludeBoardIds: excludeBoardIds,
-            excludeLaneIds: excludeLaneIds,
-            excludeColumnIds: excludeColumnIds,
-            excludeOwnerIds: excludeOwnerIds,
-            excludeCardIds: excludeCardIds,
-            condition: condition,
-            states: states,
-            archived: archived,
-            asap: asap,
-            overdue: overdue,
-            doneOnTime: doneOnTime,
-            withDueDate: withDueDate,
-            isRequest: isRequest,
-            orderBy: orderBy,
-            orderDirection: orderDirection,
-            orderSpaceId: orderSpaceId,
-            additionalCardFields: additionalCardFields
-        )
-        let page = try await client.listCards(boardId: boardId, columnId: columnId, laneId: laneId, offset: offset, limit: limit, filter: filter)
-        try printJSON(page)
-    }
+    let page = try await client.listCards(
+      boardId: boardId, columnId: columnId, laneId: laneId, offset: offset, limit: limit,
+      filter: filter)
+    try printJSON(page)
+  }
 }
 
 struct CreateCard: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "create-card",
-        abstract: "Create a new card on a board"
+  static let configuration = CommandConfiguration(
+    commandName: "create-card",
+    abstract: "Create a new card on a board"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Board ID (required)")
+  var boardId: Int
+
+  @Option(name: .long, help: "Card title (required)")
+  var title: String
+
+  @Option(name: .long, help: "Column ID")
+  var columnId: Int?
+
+  @Option(name: .long, help: "Lane ID")
+  var laneId: Int?
+
+  @Option(name: .long, help: "Card description")
+  var description: String?
+
+  @Option(name: .long, help: "ASAP marker")
+  var asap: Bool?
+
+  @Option(name: .long, help: "Deadline (ISO 8601)")
+  var dueDate: String?
+
+  @Option(name: .long, help: "Deadline includes hours and minutes")
+  var dueDateTimePresent: Bool?
+
+  @Option(name: .long, help: "Position in the cell")
+  var sortOrder: Double?
+
+  @Option(name: .long, help: "Fixed deadline flag")
+  var expiresLater: Bool?
+
+  @Option(name: .long, help: "Size text (e.g. '1', 'S', 'XL')")
+  var sizeText: String?
+
+  @Option(name: .long, help: "Owner user ID")
+  var ownerId: Int?
+
+  @Option(name: .long, help: "Responsible user ID")
+  var responsibleId: Int?
+
+  @Option(name: .long, help: "Owner email address")
+  var ownerEmail: String?
+
+  @Option(name: .long, help: "1 - first in cell, 2 - last in cell")
+  var position: Int?
+
+  @Option(name: .long, help: "Card type ID")
+  var typeId: Int?
+
+  @Option(name: .long, help: "External ID")
+  var externalId: String?
+
+  @Option(name: .long, help: "Text format: 1 - markdown, 2 - html, 3 - jira wiki")
+  var textFormatTypeId: Int?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let card = try await client.createCard(
+      title: title,
+      boardId: boardId,
+      columnId: columnId,
+      laneId: laneId,
+      description: description,
+      asap: asap,
+      dueDate: dueDate,
+      dueDateTimePresent: dueDateTimePresent,
+      sortOrder: sortOrder,
+      expiresLater: expiresLater,
+      sizeText: sizeText,
+      ownerId: ownerId,
+      responsibleId: responsibleId,
+      ownerEmail: ownerEmail,
+      position: position,
+      typeId: typeId,
+      externalId: externalId,
+      textFormatTypeId: textFormatTypeId
     )
-
-    @OptionGroup var global: GlobalOptions
-
-    @Option(name: .long, help: "Board ID (required)")
-    var boardId: Int
-
-    @Option(name: .long, help: "Card title (required)")
-    var title: String
-
-    @Option(name: .long, help: "Column ID")
-    var columnId: Int?
-
-    @Option(name: .long, help: "Lane ID")
-    var laneId: Int?
-
-    @Option(name: .long, help: "Card description")
-    var description: String?
-
-    @Option(name: .long, help: "ASAP marker")
-    var asap: Bool?
-
-    @Option(name: .long, help: "Deadline (ISO 8601)")
-    var dueDate: String?
-
-    @Option(name: .long, help: "Deadline includes hours and minutes")
-    var dueDateTimePresent: Bool?
-
-    @Option(name: .long, help: "Position in the cell")
-    var sortOrder: Double?
-
-    @Option(name: .long, help: "Fixed deadline flag")
-    var expiresLater: Bool?
-
-    @Option(name: .long, help: "Size text (e.g. '1', 'S', 'XL')")
-    var sizeText: String?
-
-    @Option(name: .long, help: "Owner user ID")
-    var ownerId: Int?
-
-    @Option(name: .long, help: "Responsible user ID")
-    var responsibleId: Int?
-
-    @Option(name: .long, help: "Owner email address")
-    var ownerEmail: String?
-
-    @Option(name: .long, help: "1 - first in cell, 2 - last in cell")
-    var position: Int?
-
-    @Option(name: .long, help: "Card type ID")
-    var typeId: Int?
-
-    @Option(name: .long, help: "External ID")
-    var externalId: String?
-
-    @Option(name: .long, help: "Text format: 1 - markdown, 2 - html, 3 - jira wiki")
-    var textFormatTypeId: Int?
-
-    func run() async throws {
-        let client = try await global.makeClient()
-        let card = try await client.createCard(
-            title: title,
-            boardId: boardId,
-            columnId: columnId,
-            laneId: laneId,
-            description: description,
-            asap: asap,
-            dueDate: dueDate,
-            dueDateTimePresent: dueDateTimePresent,
-            sortOrder: sortOrder,
-            expiresLater: expiresLater,
-            sizeText: sizeText,
-            ownerId: ownerId,
-            responsibleId: responsibleId,
-            ownerEmail: ownerEmail,
-            position: position,
-            typeId: typeId,
-            externalId: externalId,
-            textFormatTypeId: textFormatTypeId
-        )
-        try printJSON(card)
-    }
+    try printJSON(card)
+  }
 }
 
 struct GetCard: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "get-card",
-        abstract: "Get a card by ID"
-    )
+  static let configuration = CommandConfiguration(
+    commandName: "get-card",
+    abstract: "Get a card by ID"
+  )
 
-    @OptionGroup var global: GlobalOptions
+  @OptionGroup var global: GlobalOptions
 
-    @Option(name: .long, help: "Card ID")
-    var id: Int
+  @Option(name: .long, help: "Card ID")
+  var id: Int
 
-    func run() async throws {
-        let client = try await global.makeClient()
-        let card = try await client.getCard(id: id)
-        try printJSON(card)
-    }
+  func run() async throws {
+    let client = try await global.makeClient()
+    let card = try await client.getCard(id: id)
+    try printJSON(card)
+  }
 }
 
 struct UpdateCard: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "update-card",
-        abstract: "Update a card by ID"
+  static let configuration = CommandConfiguration(
+    commandName: "update-card",
+    abstract: "Update a card by ID"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var id: Int
+
+  @Option(name: .long, help: "New title")
+  var title: String?
+
+  @Option(name: .long, help: "New description")
+  var description: String?
+
+  @Option(name: .long, help: "ASAP marker")
+  var asap: Bool?
+
+  @Option(name: .long, help: "Deadline (ISO 8601)")
+  var dueDate: String?
+
+  @Option(name: .long, help: "Deadline includes hours and minutes")
+  var dueDateTimePresent: Bool?
+
+  @Option(name: .long, help: "Position in the cell")
+  var sortOrder: Double?
+
+  @Option(name: .long, help: "Fixed deadline flag")
+  var expiresLater: Bool?
+
+  @Option(name: .long, help: "Size text (e.g. '1', 'S', 'XL')")
+  var sizeText: String?
+
+  @Option(name: .long, help: "Board ID")
+  var boardId: Int?
+
+  @Option(name: .long, help: "Column ID")
+  var columnId: Int?
+
+  @Option(name: .long, help: "Lane ID")
+  var laneId: Int?
+
+  @Option(name: .long, help: "Owner user ID")
+  var ownerId: Int?
+
+  @Option(name: .long, help: "Card type ID")
+  var typeId: Int?
+
+  @Option(name: .long, help: "Service ID")
+  var serviceId: Int?
+
+  @Option(name: .long, help: "Release all blocks (pass false)")
+  var blocked: Bool?
+
+  @Option(name: .long, help: "Condition: 1 = live, 2 = archived")
+  var condition: Int?
+
+  @Option(name: .long, help: "External ID")
+  var externalId: String?
+
+  @Option(name: .long, help: "Text format: 1 = markdown, 2 = html, 3 = jira wiki")
+  var textFormatTypeId: Int?
+
+  @Option(name: .long, help: "Owner email address")
+  var ownerEmail: String?
+
+  @Option(name: .long, help: "Previous card ID for repositioning")
+  var prevCardId: Int?
+
+  @Option(name: .long, help: "Estimate workload")
+  var estimateWorkload: Double?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let card = try await client.updateCard(
+      id: id,
+      title: title,
+      description: description,
+      asap: asap,
+      dueDate: dueDate,
+      dueDateTimePresent: dueDateTimePresent,
+      sortOrder: sortOrder,
+      expiresLater: expiresLater,
+      sizeText: sizeText,
+      boardId: boardId,
+      columnId: columnId,
+      laneId: laneId,
+      ownerId: ownerId,
+      typeId: typeId,
+      serviceId: serviceId,
+      blocked: blocked,
+      condition: condition,
+      externalId: externalId,
+      textFormatTypeId: textFormatTypeId,
+      ownerEmail: ownerEmail,
+      prevCardId: prevCardId,
+      estimateWorkload: estimateWorkload
     )
-
-    @OptionGroup var global: GlobalOptions
-
-    @Option(name: .long, help: "Card ID")
-    var id: Int
-
-    @Option(name: .long, help: "New title")
-    var title: String?
-
-    @Option(name: .long, help: "New description")
-    var description: String?
-
-    @Option(name: .long, help: "ASAP marker")
-    var asap: Bool?
-
-    @Option(name: .long, help: "Deadline (ISO 8601)")
-    var dueDate: String?
-
-    @Option(name: .long, help: "Deadline includes hours and minutes")
-    var dueDateTimePresent: Bool?
-
-    @Option(name: .long, help: "Position in the cell")
-    var sortOrder: Double?
-
-    @Option(name: .long, help: "Fixed deadline flag")
-    var expiresLater: Bool?
-
-    @Option(name: .long, help: "Size text (e.g. '1', 'S', 'XL')")
-    var sizeText: String?
-
-    @Option(name: .long, help: "Board ID")
-    var boardId: Int?
-
-    @Option(name: .long, help: "Column ID")
-    var columnId: Int?
-
-    @Option(name: .long, help: "Lane ID")
-    var laneId: Int?
-
-    @Option(name: .long, help: "Owner user ID")
-    var ownerId: Int?
-
-    @Option(name: .long, help: "Card type ID")
-    var typeId: Int?
-
-    @Option(name: .long, help: "Service ID")
-    var serviceId: Int?
-
-    @Option(name: .long, help: "Release all blocks (pass false)")
-    var blocked: Bool?
-
-    @Option(name: .long, help: "Condition: 1 = live, 2 = archived")
-    var condition: Int?
-
-    @Option(name: .long, help: "External ID")
-    var externalId: String?
-
-    @Option(name: .long, help: "Text format: 1 = markdown, 2 = html, 3 = jira wiki")
-    var textFormatTypeId: Int?
-
-    @Option(name: .long, help: "Owner email address")
-    var ownerEmail: String?
-
-    @Option(name: .long, help: "Previous card ID for repositioning")
-    var prevCardId: Int?
-
-    @Option(name: .long, help: "Estimate workload")
-    var estimateWorkload: Double?
-
-    func run() async throws {
-        let client = try await global.makeClient()
-        let card = try await client.updateCard(
-            id: id,
-            title: title,
-            description: description,
-            asap: asap,
-            dueDate: dueDate,
-            dueDateTimePresent: dueDateTimePresent,
-            sortOrder: sortOrder,
-            expiresLater: expiresLater,
-            sizeText: sizeText,
-            boardId: boardId,
-            columnId: columnId,
-            laneId: laneId,
-            ownerId: ownerId,
-            typeId: typeId,
-            serviceId: serviceId,
-            blocked: blocked,
-            condition: condition,
-            externalId: externalId,
-            textFormatTypeId: textFormatTypeId,
-            ownerEmail: ownerEmail,
-            prevCardId: prevCardId,
-            estimateWorkload: estimateWorkload
-        )
-        try printJSON(card)
-    }
+    try printJSON(card)
+  }
 }
 
 struct GetCardComments: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "get-card-comments",
-        abstract: "Get comments on a card"
-    )
+  static let configuration = CommandConfiguration(
+    commandName: "get-card-comments",
+    abstract: "Get comments on a card"
+  )
 
-    @OptionGroup var global: GlobalOptions
+  @OptionGroup var global: GlobalOptions
 
-    @Option(name: .long, help: "Card ID")
-    var cardId: Int
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
 
-    func run() async throws {
-        let client = try await global.makeClient()
-        let comments = try await client.getCardComments(cardId: cardId)
-        try printJSON(comments)
-    }
+  func run() async throws {
+    let client = try await global.makeClient()
+    let comments = try await client.getCardComments(cardId: cardId)
+    try printJSON(comments)
+  }
 }
 
 struct GetCardMembers: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "get-card-members",
-        abstract: "Get members of a card"
-    )
+  static let configuration = CommandConfiguration(
+    commandName: "get-card-members",
+    abstract: "Get members of a card"
+  )
 
-    @OptionGroup var global: GlobalOptions
+  @OptionGroup var global: GlobalOptions
 
-    @Option(name: .long, help: "Card ID")
-    var cardId: Int
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
 
-    func run() async throws {
-        let client = try await global.makeClient()
-        let members = try await client.getCardMembers(cardId: cardId)
-        try printJSON(members)
-    }
+  func run() async throws {
+    let client = try await global.makeClient()
+    let members = try await client.getCardMembers(cardId: cardId)
+    try printJSON(members)
+  }
 }
 
 struct AddComment: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "add-comment",
-        abstract: "Create a comment on a card"
-    )
+  static let configuration = CommandConfiguration(
+    commandName: "add-comment",
+    abstract: "Create a comment on a card"
+  )
 
-    @OptionGroup var global: GlobalOptions
+  @OptionGroup var global: GlobalOptions
 
-    @Option(name: .long, help: "Card ID")
-    var cardId: Int
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
 
-    @Option(name: .long, help: "Comment text (markdown)")
-    var text: String
+  @Option(name: .long, help: "Comment text (markdown)")
+  var text: String
 
-    func run() async throws {
-        let client = try await global.makeClient()
-        let comment = try await client.createComment(cardId: cardId, text: text)
-        try printJSON(comment)
-    }
+  func run() async throws {
+    let client = try await global.makeClient()
+    let comment = try await client.createComment(cardId: cardId, text: text)
+    try printJSON(comment)
+  }
 }

--- a/Sources/kaiten/CustomPropertyCommands.swift
+++ b/Sources/kaiten/CustomPropertyCommands.swift
@@ -4,76 +4,78 @@ import KaitenSDK
 // MARK: - Custom Properties
 
 struct ListCustomProperties: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "list-custom-properties",
-        abstract: "List custom property definitions (paginated)"
-    )
+  static let configuration = CommandConfiguration(
+    commandName: "list-custom-properties",
+    abstract: "List custom property definitions (paginated)"
+  )
 
-    @OptionGroup var global: GlobalOptions
+  @OptionGroup var global: GlobalOptions
 
-    @Option(name: .long, help: "Offset for pagination (default: 0)")
-    var offset: Int = 0
+  @Option(name: .long, help: "Offset for pagination (default: 0)")
+  var offset: Int = 0
 
-    @Option(name: .long, help: "Limit for pagination (default/max: 100)")
-    var limit: Int = 100
+  @Option(name: .long, help: "Limit for pagination (default/max: 100)")
+  var limit: Int = 100
 
-    @Option(name: .long, help: "Text search query")
-    var query: String?
+  @Option(name: .long, help: "Text search query")
+  var query: String?
 
-    @Option(name: .long, help: "Include property values in response")
-    var includeValues: Bool?
+  @Option(name: .long, help: "Include property values in response")
+  var includeValues: Bool?
 
-    @Option(name: .long, help: "Include author details in response")
-    var includeAuthor: Bool?
+  @Option(name: .long, help: "Include author details in response")
+  var includeAuthor: Bool?
 
-    @Option(name: .long, help: "Return compact representation")
-    var compact: Bool?
+  @Option(name: .long, help: "Return compact representation")
+  var compact: Bool?
 
-    @Option(name: .long, help: "Load properties by IDs")
-    var loadByIds: Bool?
+  @Option(name: .long, help: "Load properties by IDs")
+  var loadByIds: Bool?
 
-    @Option(name: .long, help: "Comma-separated property IDs to load")
-    var ids: String?
+  @Option(name: .long, help: "Comma-separated property IDs to load")
+  var ids: String?
 
-    @Option(name: .long, help: "Field to order by")
-    var orderBy: String?
+  @Option(name: .long, help: "Field to order by")
+  var orderBy: String?
 
-    @Option(name: .long, help: "Order direction: asc or desc")
-    var orderDirection: String?
+  @Option(name: .long, help: "Order direction: asc or desc")
+  var orderDirection: String?
 
-    func run() async throws {
-        let client = try await global.makeClient()
-        let parsedIds = ids?.split(separator: ",").compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
-        let page = try await client.listCustomProperties(
-            offset: offset,
-            limit: limit,
-            query: query,
-            includeValues: includeValues,
-            includeAuthor: includeAuthor,
-            compact: compact,
-            loadByIds: loadByIds,
-            ids: parsedIds,
-            orderBy: orderBy,
-            orderDirection: orderDirection
-        )
-        try printJSON(page)
+  func run() async throws {
+    let client = try await global.makeClient()
+    let parsedIds = ids?.split(separator: ",").compactMap {
+      Int($0.trimmingCharacters(in: .whitespaces))
     }
+    let page = try await client.listCustomProperties(
+      offset: offset,
+      limit: limit,
+      query: query,
+      includeValues: includeValues,
+      includeAuthor: includeAuthor,
+      compact: compact,
+      loadByIds: loadByIds,
+      ids: parsedIds,
+      orderBy: orderBy,
+      orderDirection: orderDirection
+    )
+    try printJSON(page)
+  }
 }
 
 struct GetCustomProperty: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "get-custom-property",
-        abstract: "Get a custom property by ID"
-    )
+  static let configuration = CommandConfiguration(
+    commandName: "get-custom-property",
+    abstract: "Get a custom property by ID"
+  )
 
-    @OptionGroup var global: GlobalOptions
+  @OptionGroup var global: GlobalOptions
 
-    @Option(name: .long, help: "Custom property ID")
-    var id: Int
+  @Option(name: .long, help: "Custom property ID")
+  var id: Int
 
-    func run() async throws {
-        let client = try await global.makeClient()
-        let prop = try await client.getCustomProperty(id: id)
-        try printJSON(prop)
-    }
+  func run() async throws {
+    let client = try await global.makeClient()
+    let prop = try await client.getCustomProperty(id: id)
+    try printJSON(prop)
+  }
 }

--- a/Sources/kaiten/DateParsing.swift
+++ b/Sources/kaiten/DateParsing.swift
@@ -1,40 +1,41 @@
+import ArgumentParser
 import Foundation
 import Synchronization
-import ArgumentParser
 
 /// ISO 8601 date format used across the CLI.
 ///
 /// Accepts both full datetime (`2025-01-15T10:30:00Z`) and date-only (`2025-01-15`).
 enum DateParsing: Sendable {
-    private static let iso8601Full = Mutex(ISO8601DateFormatter())
-    private static let dateOnly = Mutex({
-        let f = DateFormatter()
-        f.dateFormat = "yyyy-MM-dd"
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.timeZone = TimeZone(identifier: "UTC")
-        return f
+  private static let iso8601Full = Mutex(ISO8601DateFormatter())
+  private static let dateOnly = Mutex(
+    {
+      let f = DateFormatter()
+      f.dateFormat = "yyyy-MM-dd"
+      f.locale = Locale(identifier: "en_US_POSIX")
+      f.timeZone = TimeZone(identifier: "UTC")
+      return f
     }())
 
-    /// Parses an ISO 8601 string into a `Date`.
-    ///
-    /// - Parameter string: Date string in `yyyy-MM-dd` or `yyyy-MM-ddTHH:mm:ssZ` format.
-    /// - Throws: `ValidationError` if the string cannot be parsed.
-    /// - Returns: The parsed `Date`.
-    static func parse(_ string: String) throws -> Date {
-        if let date = iso8601Full.withLock({ $0.date(from: string) }) {
-            return date
-        }
-        if let date = dateOnly.withLock({ $0.date(from: string) }) {
-            return date
-        }
-        throw ValidationError(
-            "Invalid date: '\(string)'. Expected ISO 8601 format (e.g. 2025-01-15 or 2025-01-15T10:30:00Z)"
-        )
+  /// Parses an ISO 8601 string into a `Date`.
+  ///
+  /// - Parameter string: Date string in `yyyy-MM-dd` or `yyyy-MM-ddTHH:mm:ssZ` format.
+  /// - Throws: `ValidationError` if the string cannot be parsed.
+  /// - Returns: The parsed `Date`.
+  static func parse(_ string: String) throws -> Date {
+    if let date = iso8601Full.withLock({ $0.date(from: string) }) {
+      return date
     }
+    if let date = dateOnly.withLock({ $0.date(from: string) }) {
+      return date
+    }
+    throw ValidationError(
+      "Invalid date: '\(string)'. Expected ISO 8601 format (e.g. 2025-01-15 or 2025-01-15T10:30:00Z)"
+    )
+  }
 
-    /// Parses an optional date string.
-    static func parse(_ string: String?) throws -> Date? {
-        guard let string else { return nil }
-        return try parse(string)
-    }
+  /// Parses an optional date string.
+  static func parse(_ string: String?) throws -> Date? {
+    guard let string else { return nil }
+    return try parse(string)
+  }
 }

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -6,71 +6,71 @@ import SystemPackage
 
 @main
 struct Kaiten: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "kaiten",
-        abstract: "CLI for Kaiten API",
-        subcommands: [
-            ListSpaces.self,
-            ListBoards.self,
-            GetBoard.self,
-            GetBoardColumns.self,
-            GetBoardLanes.self,
-            ListCards.self,
-            CreateCard.self,
-            GetCard.self,
-            UpdateCard.self,
-            GetCardComments.self,
-            AddComment.self,
-            GetCardMembers.self,
-            ListCustomProperties.self,
-            GetCustomProperty.self,
-        ]
-    )
+  static let configuration = CommandConfiguration(
+    commandName: "kaiten",
+    abstract: "CLI for Kaiten API",
+    subcommands: [
+      ListSpaces.self,
+      ListBoards.self,
+      GetBoard.self,
+      GetBoardColumns.self,
+      GetBoardLanes.self,
+      ListCards.self,
+      CreateCard.self,
+      GetCard.self,
+      UpdateCard.self,
+      GetCardComments.self,
+      AddComment.self,
+      GetCardMembers.self,
+      ListCustomProperties.self,
+      GetCustomProperty.self,
+    ]
+  )
 }
 
 // MARK: - Global Options
 
 struct GlobalOptions: ParsableArguments {
-    @Option(name: .long, help: "Kaiten API base URL (overrides config file)")
-    var url: String?
+  @Option(name: .long, help: "Kaiten API base URL (overrides config file)")
+  var url: String?
 
-    @Option(name: .long, help: "Kaiten API token (overrides config file)")
-    var token: String?
+  @Option(name: .long, help: "Kaiten API token (overrides config file)")
+  var token: String?
 
-    func makeClient() async throws -> KaitenClient {
-        let configPath = Self.configPath
+  func makeClient() async throws -> KaitenClient {
+    let configPath = Self.configPath
 
-        let providers: [ConfigProvider] = [
-            (try? await FileProvider<JSONSnapshot>(filePath: FilePath(configPath))) as ConfigProvider?,
-        ].compactMap { $0 }
+    let providers: [ConfigProvider] = [
+      (try? await FileProvider<JSONSnapshot>(filePath: FilePath(configPath))) as ConfigProvider?
+    ].compactMap { $0 }
 
-        // If no config file exists, don't create ConfigReader — rely on CLI flags (#81)
-        let config: ConfigReader? = providers.isEmpty ? nil : ConfigReader(providers: providers)
+    // If no config file exists, don't create ConfigReader — rely on CLI flags (#81)
+    let config: ConfigReader? = providers.isEmpty ? nil : ConfigReader(providers: providers)
 
-        guard let baseURL = url ?? config?.string(forKey: "url") else {
-            throw ValidationError(
-                "Missing Kaiten API URL. Pass --url or set \"url\" in \(configPath)"
-            )
-        }
-        guard let apiToken = token ?? config?.string(forKey: "token") else {
-            throw ValidationError(
-                "Missing Kaiten API token. Pass --token or set \"token\" in \(configPath)"
-            )
-        }
-        return try KaitenClient(baseURL: baseURL, token: apiToken)
+    guard let baseURL = url ?? config?.string(forKey: "url") else {
+      throw ValidationError(
+        "Missing Kaiten API URL. Pass --url or set \"url\" in \(configPath)"
+      )
     }
-
-    private static var configPath: String {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        return home.appendingPathComponent(".config/kaiten-mcp/config.json").path
+    guard let apiToken = token ?? config?.string(forKey: "token") else {
+      throw ValidationError(
+        "Missing Kaiten API token. Pass --token or set \"token\" in \(configPath)"
+      )
     }
+    return try KaitenClient(baseURL: baseURL, token: apiToken)
+  }
+
+  private static var configPath: String {
+    let home = FileManager.default.homeDirectoryForCurrentUser
+    return home.appendingPathComponent(".config/kaiten-mcp/config.json").path
+  }
 }
 
 // MARK: - Helpers
 
 func printJSON(_ value: some Encodable) throws {
-    let encoder = JSONEncoder()
-    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-    let data = try encoder.encode(value)
-    print(String(data: data, encoding: .utf8)!)
+  let encoder = JSONEncoder()
+  encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+  let data = try encoder.encode(value)
+  print(String(data: data, encoding: .utf8)!)
 }

--- a/Sources/kaiten/SpaceCommands.swift
+++ b/Sources/kaiten/SpaceCommands.swift
@@ -4,16 +4,16 @@ import KaitenSDK
 // MARK: - Spaces
 
 struct ListSpaces: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "list-spaces",
-        abstract: "List all spaces"
-    )
+  static let configuration = CommandConfiguration(
+    commandName: "list-spaces",
+    abstract: "List all spaces"
+  )
 
-    @OptionGroup var global: GlobalOptions
+  @OptionGroup var global: GlobalOptions
 
-    func run() async throws {
-        let client = try await global.makeClient()
-        let spaces = try await client.listSpaces()
-        try printJSON(spaces)
-    }
+  func run() async throws {
+    let client = try await global.makeClient()
+    let spaces = try await client.listSpaces()
+    try printJSON(spaces)
+  }
 }

--- a/Tests/KaitenSDKTests/AuthMiddlewareTests.swift
+++ b/Tests/KaitenSDKTests/AuthMiddlewareTests.swift
@@ -9,38 +9,38 @@ import Testing
 @Suite("AuthenticationMiddleware")
 struct AuthMiddlewareTests {
 
-    @Test("Adds Bearer token header")
-    func addsBearer() async throws {
-        let middleware = AuthenticationMiddleware(token: "my-secret-token")
-        let capturedRequest = Mutex<HTTPRequest?>(nil)
+  @Test("Adds Bearer token header")
+  func addsBearer() async throws {
+    let middleware = AuthenticationMiddleware(token: "my-secret-token")
+    let capturedRequest = Mutex<HTTPRequest?>(nil)
 
-        let _ = try await middleware.intercept(
-            HTTPRequest(method: .get, scheme: "https", authority: "test.kaiten.ru", path: "/test"),
-            body: nil,
-            baseURL: URL(string: "https://test.kaiten.ru")!,
-            operationID: "test"
-        ) { request, body, baseURL in
-            capturedRequest.withLock { $0 = request }
-            return (HTTPResponse(status: .ok), nil)
-        }
-
-        let header = capturedRequest.withLock { $0?.headerFields[.authorization] }
-        #expect(header == "Bearer my-secret-token")
+    let _ = try await middleware.intercept(
+      HTTPRequest(method: .get, scheme: "https", authority: "test.kaiten.ru", path: "/test"),
+      body: nil,
+      baseURL: URL(string: "https://test.kaiten.ru")!,
+      operationID: "test"
+    ) { request, body, baseURL in
+      capturedRequest.withLock { $0 = request }
+      return (HTTPResponse(status: .ok), nil)
     }
 
-    @Test("Passes through 401 without throwing")
-    func passesThrough401() async throws {
-        let middleware = AuthenticationMiddleware(token: "bad-token")
+    let header = capturedRequest.withLock { $0?.headerFields[.authorization] }
+    #expect(header == "Bearer my-secret-token")
+  }
 
-        let (response, _) = try await middleware.intercept(
-            HTTPRequest(method: .get, scheme: "https", authority: "test.kaiten.ru", path: "/test"),
-            body: nil,
-            baseURL: URL(string: "https://test.kaiten.ru")!,
-            operationID: "test"
-        ) { _, _, _ in
-            (HTTPResponse(status: .unauthorized), nil)
-        }
+  @Test("Passes through 401 without throwing")
+  func passesThrough401() async throws {
+    let middleware = AuthenticationMiddleware(token: "bad-token")
 
-        #expect(response.status == .unauthorized)
+    let (response, _) = try await middleware.intercept(
+      HTTPRequest(method: .get, scheme: "https", authority: "test.kaiten.ru", path: "/test"),
+      body: nil,
+      baseURL: URL(string: "https://test.kaiten.ru")!,
+      operationID: "test"
+    ) { _, _, _ in
+      (HTTPResponse(status: .unauthorized), nil)
     }
+
+    #expect(response.status == .unauthorized)
+  }
 }

--- a/Tests/KaitenSDKTests/CardCommentsTests.swift
+++ b/Tests/KaitenSDKTests/CardCommentsTests.swift
@@ -7,26 +7,28 @@ import Testing
 @Suite("CardComments")
 struct CardCommentsTests {
 
-    @Test("getCardComments 200 returns array")
-    func listSuccess() async throws {
-        let json = """
-            [{"id": 1, "uid": "abc-123", "text": "Hello", "type": 1, "edited": false, "card_id": 100, "author_id": 5, "internal": false, "deleted": false, "sd_description": false, "updated": "2025-01-01T00:00:00Z", "created": "2025-01-01T00:00:00Z"}]
-            """
-        let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  @Test("getCardComments 200 returns array")
+  func listSuccess() async throws {
+    let json = """
+      [{"id": 1, "uid": "abc-123", "text": "Hello", "type": 1, "edited": false, "card_id": 100, "author_id": 5, "internal": false, "deleted": false, "sd_description": false, "updated": "2025-01-01T00:00:00Z", "created": "2025-01-01T00:00:00Z"}]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-        let comments = try await client.getCardComments(cardId: 100)
-        #expect(comments.count == 1)
-        #expect(comments[0].text == "Hello")
+    let comments = try await client.getCardComments(cardId: 100)
+    #expect(comments.count == 1)
+    #expect(comments[0].text == "Hello")
+  }
+
+  @Test("getCardComments 404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.getCardComments(cardId: 999)
     }
-
-    @Test("getCardComments 404 throws notFound")
-    func notFound() async throws {
-        let transport = MockClientTransport.returning(statusCode: 404)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
-
-        await #expect(throws: KaitenError.self) {
-            _ = try await client.getCardComments(cardId: 999)
-        }
-    }
+  }
 }

--- a/Tests/KaitenSDKTests/CreateCardTests.swift
+++ b/Tests/KaitenSDKTests/CreateCardTests.swift
@@ -7,46 +7,50 @@ import Testing
 @Suite("CreateCard")
 struct CreateCardTests {
 
-    @Test("200 returns created Card")
-    func success() async throws {
-        let json = """
-            {"id": 123, "title": "New card", "board_id": 1}
-            """
-        let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  @Test("200 returns created Card")
+  func success() async throws {
+    let json = """
+      {"id": 123, "title": "New card", "board_id": 1}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-        let card = try await client.createCard(title: "New card", boardId: 1)
-        #expect(card.id == 123)
-        #expect(card.title == "New card")
+    let card = try await client.createCard(title: "New card", boardId: 1)
+    #expect(card.id == 123)
+    #expect(card.title == "New card")
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createCard(title: "Test", boardId: 1)
     }
+  }
 
-    @Test("401 throws unauthorized")
-    func unauthorized() async throws {
-        let transport = MockClientTransport.returning(statusCode: 401)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  @Test("400 throws unexpectedResponse")
+  func badRequest() async throws {
+    let transport = MockClientTransport.returning(statusCode: 400)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-        await #expect(throws: KaitenError.self) {
-            _ = try await client.createCard(title: "Test", boardId: 1)
-        }
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createCard(title: "Test", boardId: 1)
     }
+  }
 
-    @Test("400 throws unexpectedResponse")
-    func badRequest() async throws {
-        let transport = MockClientTransport.returning(statusCode: 400)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  @Test("403 throws unexpectedResponse")
+  func forbidden() async throws {
+    let transport = MockClientTransport.returning(statusCode: 403)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-        await #expect(throws: KaitenError.self) {
-            _ = try await client.createCard(title: "Test", boardId: 1)
-        }
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createCard(title: "Test", boardId: 1)
     }
-
-    @Test("403 throws unexpectedResponse")
-    func forbidden() async throws {
-        let transport = MockClientTransport.returning(statusCode: 403)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
-
-        await #expect(throws: KaitenError.self) {
-            _ = try await client.createCard(title: "Test", boardId: 1)
-        }
-    }
+  }
 }

--- a/Tests/KaitenSDKTests/CustomPropertiesTests.swift
+++ b/Tests/KaitenSDKTests/CustomPropertiesTests.swift
@@ -7,41 +7,43 @@ import Testing
 @Suite("CustomProperties")
 struct CustomPropertiesTests {
 
+  @Test("listCustomProperties 200 returns page")
+  func listSuccess() async throws {
+    let json = """
+      [{"id": 1, "name": "Priority", "type": "select"}, {"id": 2, "name": "Effort", "type": "number"}]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    @Test("listCustomProperties 200 returns page")
-    func listSuccess() async throws {
-        let json = """
-            [{"id": 1, "name": "Priority", "type": "select"}, {"id": 2, "name": "Effort", "type": "number"}]
-            """
-        let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+    let page = try await client.listCustomProperties()
+    #expect(page.items.count == 2)
+    #expect(page.items[0].name == "Priority")
+    #expect(page.offset == 0)
+    #expect(page.limit == 100)
+  }
 
-        let page = try await client.listCustomProperties()
-        #expect(page.items.count == 2)
-        #expect(page.items[0].name == "Priority")
-        #expect(page.offset == 0)
-        #expect(page.limit == 100)
+  @Test("getCustomProperty 200 returns single")
+  func getSuccess() async throws {
+    let json = """
+      {"id": 1, "name": "Priority", "type": "select"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let prop = try await client.getCustomProperty(id: 1)
+    #expect(prop.name == "Priority")
+  }
+
+  @Test("getCustomProperty 404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.getCustomProperty(id: 999)
     }
-
-    @Test("getCustomProperty 200 returns single")
-    func getSuccess() async throws {
-        let json = """
-            {"id": 1, "name": "Priority", "type": "select"}
-            """
-        let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
-
-        let prop = try await client.getCustomProperty(id: 1)
-        #expect(prop.name == "Priority")
-    }
-
-    @Test("getCustomProperty 404 throws notFound")
-    func notFound() async throws {
-        let transport = MockClientTransport.returning(statusCode: 404)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
-
-        await #expect(throws: KaitenError.self) {
-            _ = try await client.getCustomProperty(id: 999)
-        }
-    }
+  }
 }

--- a/Tests/KaitenSDKTests/DateParsingTests.swift
+++ b/Tests/KaitenSDKTests/DateParsingTests.swift
@@ -5,51 +5,51 @@ import Testing
 
 @Suite("DateParsing")
 struct DateParsingTests {
-    @Test("Parses full ISO 8601 datetime")
-    func fullISO8601() throws {
-        let date = try DateParsing.parse("2025-01-15T10:30:00Z")
-        let calendar = Calendar(identifier: .gregorian)
-        let components = calendar.dateComponents(in: TimeZone(identifier: "UTC")!, from: date)
-        #expect(components.year == 2025)
-        #expect(components.month == 1)
-        #expect(components.day == 15)
-        #expect(components.hour == 10)
-        #expect(components.minute == 30)
-    }
+  @Test("Parses full ISO 8601 datetime")
+  func fullISO8601() throws {
+    let date = try DateParsing.parse("2025-01-15T10:30:00Z")
+    let calendar = Calendar(identifier: .gregorian)
+    let components = calendar.dateComponents(in: TimeZone(identifier: "UTC")!, from: date)
+    #expect(components.year == 2025)
+    #expect(components.month == 1)
+    #expect(components.day == 15)
+    #expect(components.hour == 10)
+    #expect(components.minute == 30)
+  }
 
-    @Test("Parses date-only string")
-    func dateOnly() throws {
-        let date = try DateParsing.parse("2025-01-15")
-        let calendar = Calendar(identifier: .gregorian)
-        let components = calendar.dateComponents(in: TimeZone(identifier: "UTC")!, from: date)
-        #expect(components.year == 2025)
-        #expect(components.month == 1)
-        #expect(components.day == 15)
-    }
+  @Test("Parses date-only string")
+  func dateOnly() throws {
+    let date = try DateParsing.parse("2025-01-15")
+    let calendar = Calendar(identifier: .gregorian)
+    let components = calendar.dateComponents(in: TimeZone(identifier: "UTC")!, from: date)
+    #expect(components.year == 2025)
+    #expect(components.month == 1)
+    #expect(components.day == 15)
+  }
 
-    @Test("Throws on invalid date string")
-    func invalidDate() {
-        #expect(throws: Error.self) {
-            try DateParsing.parse("not-a-date")
-        }
+  @Test("Throws on invalid date string")
+  func invalidDate() {
+    #expect(throws: Error.self) {
+      try DateParsing.parse("not-a-date")
     }
+  }
 
-    @Test("Throws on empty string")
-    func emptyString() {
-        #expect(throws: Error.self) {
-            try DateParsing.parse("")
-        }
+  @Test("Throws on empty string")
+  func emptyString() {
+    #expect(throws: Error.self) {
+      try DateParsing.parse("")
     }
+  }
 
-    @Test("Optional parse returns nil for nil input")
-    func optionalNil() throws {
-        let result = try DateParsing.parse(nil as String?)
-        #expect(result == nil)
-    }
+  @Test("Optional parse returns nil for nil input")
+  func optionalNil() throws {
+    let result = try DateParsing.parse(nil as String?)
+    #expect(result == nil)
+  }
 
-    @Test("Optional parse returns date for valid input")
-    func optionalValid() throws {
-        let result = try DateParsing.parse("2025-06-01" as String?)
-        #expect(result != nil)
-    }
+  @Test("Optional parse returns date for valid input")
+  func optionalValid() throws {
+    let result = try DateParsing.parse("2025-06-01" as String?)
+    #expect(result != nil)
+  }
 }

--- a/Tests/KaitenSDKTests/GetBoardColumnsTests.swift
+++ b/Tests/KaitenSDKTests/GetBoardColumnsTests.swift
@@ -7,27 +7,28 @@ import Testing
 @Suite("GetBoardColumns")
 struct GetBoardColumnsTests {
 
+  @Test("200 returns columns")
+  func success() async throws {
+    let json = """
+      [{"id": 10, "title": "To Do", "board_id": 1}, {"id": 11, "title": "Done", "board_id": 1}]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    @Test("200 returns columns")
-    func success() async throws {
-        let json = """
-            [{"id": 10, "title": "To Do", "board_id": 1}, {"id": 11, "title": "Done", "board_id": 1}]
-            """
-        let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+    let columns = try await client.getBoardColumns(boardId: 1)
+    #expect(columns.count == 2)
+    #expect(columns[0].id == 10)
+    #expect(columns[1].title == "Done")
+  }
 
-        let columns = try await client.getBoardColumns(boardId: 1)
-        #expect(columns.count == 2)
-        #expect(columns[0].id == 10)
-        #expect(columns[1].title == "Done")
-    }
+  @Test("200 empty array returns empty")
+  func emptyArray() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    @Test("200 empty array returns empty")
-    func emptyArray() async throws {
-        let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
-
-        let columns = try await client.getBoardColumns(boardId: 1)
-        #expect(columns.isEmpty)
-    }
+    let columns = try await client.getBoardColumns(boardId: 1)
+    #expect(columns.isEmpty)
+  }
 }

--- a/Tests/KaitenSDKTests/GetBoardLanesTests.swift
+++ b/Tests/KaitenSDKTests/GetBoardLanesTests.swift
@@ -7,27 +7,28 @@ import Testing
 @Suite("GetBoardLanes")
 struct GetBoardLanesTests {
 
+  @Test("200 returns lanes")
+  func success() async throws {
+    let json = """
+      [{"id": 20, "title": "Default Lane", "board_id": 1}, {"id": 21, "title": "Urgent", "board_id": 1}]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    @Test("200 returns lanes")
-    func success() async throws {
-        let json = """
-            [{"id": 20, "title": "Default Lane", "board_id": 1}, {"id": 21, "title": "Urgent", "board_id": 1}]
-            """
-        let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+    let lanes = try await client.getBoardLanes(boardId: 1)
+    #expect(lanes.count == 2)
+    #expect(lanes[0].id == 20)
+    #expect(lanes[1].title == "Urgent")
+  }
 
-        let lanes = try await client.getBoardLanes(boardId: 1)
-        #expect(lanes.count == 2)
-        #expect(lanes[0].id == 20)
-        #expect(lanes[1].title == "Urgent")
-    }
+  @Test("200 empty array returns empty")
+  func emptyArray() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    @Test("200 empty array returns empty")
-    func emptyArray() async throws {
-        let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
-
-        let lanes = try await client.getBoardLanes(boardId: 1)
-        #expect(lanes.isEmpty)
-    }
+    let lanes = try await client.getBoardLanes(boardId: 1)
+    #expect(lanes.isEmpty)
+  }
 }

--- a/Tests/KaitenSDKTests/GetBoardTests.swift
+++ b/Tests/KaitenSDKTests/GetBoardTests.swift
@@ -7,37 +7,39 @@ import Testing
 @Suite("GetBoard")
 struct GetBoardTests {
 
+  @Test("200 returns Board")
+  func success() async throws {
+    let json = """
+      {"id": 1, "title": "My Board"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    @Test("200 returns Board")
-    func success() async throws {
-        let json = """
-            {"id": 1, "title": "My Board"}
-            """
-        let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+    let board = try await client.getBoard(id: 1)
+    #expect(board.id == 1)
+    #expect(board.title == "My Board")
+  }
 
-        let board = try await client.getBoard(id: 1)
-        #expect(board.id == 1)
-        #expect(board.title == "My Board")
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.getBoard(id: 999)
     }
+  }
 
-    @Test("404 throws notFound")
-    func notFound() async throws {
-        let transport = MockClientTransport.returning(statusCode: 404)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-        await #expect(throws: KaitenError.self) {
-            _ = try await client.getBoard(id: 999)
-        }
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.getBoard(id: 1)
     }
-
-    @Test("401 throws unauthorized")
-    func unauthorized() async throws {
-        let transport = MockClientTransport.returning(statusCode: 401)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
-
-        await #expect(throws: KaitenError.self) {
-            _ = try await client.getBoard(id: 1)
-        }
-    }
+  }
 }

--- a/Tests/KaitenSDKTests/GetCardMembersTests.swift
+++ b/Tests/KaitenSDKTests/GetCardMembersTests.swift
@@ -7,26 +7,27 @@ import Testing
 @Suite("GetCardMembers")
 struct GetCardMembersTests {
 
+  @Test("200 returns members")
+  func success() async throws {
+    let json = """
+      [{"id": 1, "full_name": "Alice"}, {"id": 2, "full_name": "Bob"}]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    @Test("200 returns members")
-    func success() async throws {
-        let json = """
-            [{"id": 1, "full_name": "Alice"}, {"id": 2, "full_name": "Bob"}]
-            """
-        let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+    let members = try await client.getCardMembers(cardId: 42)
+    #expect(members.count == 2)
+    #expect(members[0].full_name == "Alice")
+  }
 
-        let members = try await client.getCardMembers(cardId: 42)
-        #expect(members.count == 2)
-        #expect(members[0].full_name == "Alice")
-    }
+  @Test("200 empty returns empty")
+  func emptyArray() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    @Test("200 empty returns empty")
-    func emptyArray() async throws {
-        let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
-
-        let members = try await client.getCardMembers(cardId: 42)
-        #expect(members.isEmpty)
-    }
+    let members = try await client.getCardMembers(cardId: 42)
+    #expect(members.isEmpty)
+  }
 }

--- a/Tests/KaitenSDKTests/GetCardTests.swift
+++ b/Tests/KaitenSDKTests/GetCardTests.swift
@@ -7,37 +7,39 @@ import Testing
 @Suite("GetCard")
 struct GetCardTests {
 
+  @Test("200 returns Card")
+  func success() async throws {
+    let json = """
+      {"id": 42, "title": "Test card"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    @Test("200 returns Card")
-    func success() async throws {
-        let json = """
-            {"id": 42, "title": "Test card"}
-            """
-        let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+    let card = try await client.getCard(id: 42)
+    #expect(card.id == 42)
+    #expect(card.title == "Test card")
+  }
 
-        let card = try await client.getCard(id: 42)
-        #expect(card.id == 42)
-        #expect(card.title == "Test card")
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.getCard(id: 999)
     }
+  }
 
-    @Test("404 throws notFound")
-    func notFound() async throws {
-        let transport = MockClientTransport.returning(statusCode: 404)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-        await #expect(throws: KaitenError.self) {
-            _ = try await client.getCard(id: 999)
-        }
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.getCard(id: 1)
     }
-
-    @Test("401 throws unauthorized")
-    func unauthorized() async throws {
-        let transport = MockClientTransport.returning(statusCode: 401)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
-
-        await #expect(throws: KaitenError.self) {
-            _ = try await client.getCard(id: 1)
-        }
-    }
+  }
 }

--- a/Tests/KaitenSDKTests/Helpers/MockTransport.swift
+++ b/Tests/KaitenSDKTests/Helpers/MockTransport.swift
@@ -5,56 +5,63 @@ import OpenAPIRuntime
 /// A mock client transport for testing that records all requests and returns configurable responses.
 final class MockClientTransport: ClientTransport, @unchecked Sendable {
 
-    /// A recorded request with all parameters passed to `send`.
-    struct RecordedRequest: Sendable {
-        let request: HTTPRequest
-        let body: HTTPBody?
-        let baseURL: URL
-        let operationID: String
+  /// A recorded request with all parameters passed to `send`.
+  struct RecordedRequest: Sendable {
+    let request: HTTPRequest
+    let body: HTTPBody?
+    let baseURL: URL
+    let operationID: String
+  }
+
+  /// The closure invoked for every call to `send`.
+  private let handler:
+    @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?)
+
+  /// All requests recorded so far.
+  private let _lock = NSLock()
+  private var _recordedRequests: [RecordedRequest] = []
+
+  var recordedRequests: [RecordedRequest] {
+    _lock.withLock { _recordedRequests }
+  }
+
+  /// Creates a mock transport with a custom handler.
+  /// - Parameter handler: A closure called for every `send` invocation.
+  init(
+    handler:
+      @escaping @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (
+        HTTPResponse, HTTPBody?
+      )
+  ) {
+    self.handler = handler
+  }
+
+  /// Convenience factory that always returns a fixed status code and body.
+  /// - Parameters:
+  ///   - statusCode: The HTTP status code to return.
+  ///   - body: An optional response body string (UTF-8 encoded).
+  /// - Returns: A configured `MockClientTransport`.
+  static func returning(statusCode: Int, body: String? = nil) -> MockClientTransport {
+    MockClientTransport { _, _, _, _ in
+      var headerFields = HTTPFields()
+      if body != nil {
+        headerFields[.contentType] = "application/json"
+      }
+      let response = HTTPResponse(status: .init(code: statusCode), headerFields: headerFields)
+      let responseBody: HTTPBody? = body.map { .init($0) }
+      return (response, responseBody)
     }
+  }
 
-    /// The closure invoked for every call to `send`.
-    private let handler: @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?)
-
-    /// All requests recorded so far.
-    private let _lock = NSLock()
-    private var _recordedRequests: [RecordedRequest] = []
-
-    var recordedRequests: [RecordedRequest] {
-        _lock.withLock { _recordedRequests }
-    }
-
-    /// Creates a mock transport with a custom handler.
-    /// - Parameter handler: A closure called for every `send` invocation.
-    init(handler: @escaping @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?)) {
-        self.handler = handler
-    }
-
-    /// Convenience factory that always returns a fixed status code and body.
-    /// - Parameters:
-    ///   - statusCode: The HTTP status code to return.
-    ///   - body: An optional response body string (UTF-8 encoded).
-    /// - Returns: A configured `MockClientTransport`.
-    static func returning(statusCode: Int, body: String? = nil) -> MockClientTransport {
-        MockClientTransport { _, _, _, _ in
-            var headerFields = HTTPFields()
-            if body != nil {
-                headerFields[.contentType] = "application/json"
-            }
-            let response = HTTPResponse(status: .init(code: statusCode), headerFields: headerFields)
-            let responseBody: HTTPBody? = body.map { .init($0) }
-            return (response, responseBody)
-        }
-    }
-
-    func send(
-        _ request: HTTPRequest,
-        body: HTTPBody?,
-        baseURL: URL,
-        operationID: String
-    ) async throws -> (HTTPResponse, HTTPBody?) {
-        let recorded = RecordedRequest(request: request, body: body, baseURL: baseURL, operationID: operationID)
-        _lock.withLock { _recordedRequests.append(recorded) }
-        return try await handler(request, body, baseURL, operationID)
-    }
+  func send(
+    _ request: HTTPRequest,
+    body: HTTPBody?,
+    baseURL: URL,
+    operationID: String
+  ) async throws -> (HTTPResponse, HTTPBody?) {
+    let recorded = RecordedRequest(
+      request: request, body: body, baseURL: baseURL, operationID: operationID)
+    _lock.withLock { _recordedRequests.append(recorded) }
+    return try await handler(request, body, baseURL, operationID)
+  }
 }

--- a/Tests/KaitenSDKTests/KaitenClientTests.swift
+++ b/Tests/KaitenSDKTests/KaitenClientTests.swift
@@ -6,10 +6,10 @@ import Testing
 @Suite("KaitenClient Configuration")
 struct KaitenClientConfigurationTests {
 
-    @Test("Fails with invalid URL")
-    func invalidURL() {
-        #expect(throws: KaitenError.self) {
-            _ = try KaitenClient(baseURL: "", token: "test-token")
-        }
+  @Test("Fails with invalid URL")
+  func invalidURL() {
+    #expect(throws: KaitenError.self) {
+      _ = try KaitenClient(baseURL: "", token: "test-token")
     }
+  }
 }

--- a/Tests/KaitenSDKTests/ListBoardsTests.swift
+++ b/Tests/KaitenSDKTests/ListBoardsTests.swift
@@ -7,27 +7,28 @@ import Testing
 @Suite("ListBoards")
 struct ListBoardsTests {
 
+  @Test("200 returns boards")
+  func success() async throws {
+    let json = """
+      [{"id": 1, "title": "Sprint Board"}, {"id": 2, "title": "Kanban"}]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    @Test("200 returns boards")
-    func success() async throws {
-        let json = """
-            [{"id": 1, "title": "Sprint Board"}, {"id": 2, "title": "Kanban"}]
-            """
-        let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+    let boards = try await client.listBoards(spaceId: 5)
+    #expect(boards.count == 2)
+    #expect(boards[0].id == 1)
+    #expect(boards[1].title == "Kanban")
+  }
 
-        let boards = try await client.listBoards(spaceId: 5)
-        #expect(boards.count == 2)
-        #expect(boards[0].id == 1)
-        #expect(boards[1].title == "Kanban")
-    }
+  @Test("200 empty array returns empty")
+  func emptyArray() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    @Test("200 empty array returns empty")
-    func emptyArray() async throws {
-        let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
-
-        let boards = try await client.listBoards(spaceId: 5)
-        #expect(boards.isEmpty)
-    }
+    let boards = try await client.listBoards(spaceId: 5)
+    #expect(boards.isEmpty)
+  }
 }

--- a/Tests/KaitenSDKTests/ListCardsTests.swift
+++ b/Tests/KaitenSDKTests/ListCardsTests.swift
@@ -7,69 +7,74 @@ import Testing
 @Suite("ListCards")
 struct ListCardsTests {
 
+  @Test("200 with array returns cards")
+  func success() async throws {
+    let json = """
+      [{"id": 1, "title": "Card A"}, {"id": 2, "title": "Card B"}]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    @Test("200 with array returns cards")
-    func success() async throws {
-        let json = """
-            [{"id": 1, "title": "Card A"}, {"id": 2, "title": "Card B"}]
-            """
-        let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+    let page = try await client.listCards(boardId: 10)
+    #expect(page.items.count == 2)
+    #expect(page.items[0].id == 1)
+    #expect(page.items[1].title == "Card B")
+    #expect(page.offset == 0)
+    #expect(page.limit == 100)
+    #expect(page.hasMore == false)
+  }
 
-        let page = try await client.listCards(boardId: 10)
-        #expect(page.items.count == 2)
-        #expect(page.items[0].id == 1)
-        #expect(page.items[1].title == "Card B")
-        #expect(page.offset == 0)
-        #expect(page.limit == 100)
-        #expect(page.hasMore == false)
+  @Test("200 empty array returns empty")
+  func emptyArray() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let page = try await client.listCards(boardId: 10)
+    #expect(page.items.isEmpty)
+  }
+
+  @Test("200 with empty body returns empty array (#84)")
+  func emptyBody() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: nil)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let page = try await client.listCards(boardId: 10)
+    #expect(page.items.isEmpty)
+  }
+
+  @Test("200 with empty string body returns empty array (#84)")
+  func emptyStringBody() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "")
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let page = try await client.listCards(boardId: 10)
+    #expect(page.items.isEmpty)
+  }
+
+  @Test("200 with invalid JSON throws decodingError (#183)")
+  func invalidJsonThrowsDecodingError() async throws {
+    // Simulate a schema mismatch: body is present but not a valid card array.
+    let transport = MockClientTransport.returning(statusCode: 200, body: "{\"not\": \"an array\"}")
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCards(boardId: 10)
     }
+  }
 
-    @Test("200 empty array returns empty")
-    func emptyArray() async throws {
-        let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-        let page = try await client.listCards(boardId: 10)
-        #expect(page.items.isEmpty)
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCards(boardId: 10)
     }
-
-    @Test("200 with empty body returns empty array (#84)")
-    func emptyBody() async throws {
-        let transport = MockClientTransport.returning(statusCode: 200, body: nil)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
-
-        let page = try await client.listCards(boardId: 10)
-        #expect(page.items.isEmpty)
-    }
-
-    @Test("200 with empty string body returns empty array (#84)")
-    func emptyStringBody() async throws {
-        let transport = MockClientTransport.returning(statusCode: 200, body: "")
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
-
-        let page = try await client.listCards(boardId: 10)
-        #expect(page.items.isEmpty)
-    }
-
-    @Test("200 with invalid JSON throws decodingError (#183)")
-    func invalidJsonThrowsDecodingError() async throws {
-        // Simulate a schema mismatch: body is present but not a valid card array.
-        let transport = MockClientTransport.returning(statusCode: 200, body: "{\"not\": \"an array\"}")
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
-
-        await #expect(throws: KaitenError.self) {
-            _ = try await client.listCards(boardId: 10)
-        }
-    }
-
-    @Test("401 throws unauthorized")
-    func unauthorized() async throws {
-        let transport = MockClientTransport.returning(statusCode: 401)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
-
-        await #expect(throws: KaitenError.self) {
-            _ = try await client.listCards(boardId: 10)
-        }
-    }
+  }
 }

--- a/Tests/KaitenSDKTests/ListSpacesTests.swift
+++ b/Tests/KaitenSDKTests/ListSpacesTests.swift
@@ -7,37 +7,39 @@ import Testing
 @Suite("ListSpaces")
 struct ListSpacesTests {
 
+  @Test("200 returns spaces")
+  func success() async throws {
+    let json = """
+      [{"id": 1, "title": "Engineering"}, {"id": 2, "title": "Design"}]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    @Test("200 returns spaces")
-    func success() async throws {
-        let json = """
-            [{"id": 1, "title": "Engineering"}, {"id": 2, "title": "Design"}]
-            """
-        let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+    let spaces = try await client.listSpaces()
+    #expect(spaces.count == 2)
+    #expect(spaces[0].id == 1)
+    #expect(spaces[1].title == "Design")
+  }
 
-        let spaces = try await client.listSpaces()
-        #expect(spaces.count == 2)
-        #expect(spaces[0].id == 1)
-        #expect(spaces[1].title == "Design")
+  @Test("200 empty array returns empty")
+  func emptyArray() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let spaces = try await client.listSpaces()
+    #expect(spaces.isEmpty)
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listSpaces()
     }
-
-    @Test("200 empty array returns empty")
-    func emptyArray() async throws {
-        let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
-
-        let spaces = try await client.listSpaces()
-        #expect(spaces.isEmpty)
-    }
-
-    @Test("401 throws unauthorized")
-    func unauthorized() async throws {
-        let transport = MockClientTransport.returning(statusCode: 401)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
-
-        await #expect(throws: KaitenError.self) {
-            _ = try await client.listSpaces()
-        }
-    }
+  }
 }

--- a/Tests/KaitenSDKTests/RetryMiddlewareTests.swift
+++ b/Tests/KaitenSDKTests/RetryMiddlewareTests.swift
@@ -9,149 +9,157 @@ import Testing
 @Suite("RetryMiddleware")
 struct RetryMiddlewareTests {
 
-    @Test("429 then 200 succeeds after retry")
-    func retryThenSuccess() async throws {
-        let middleware = RetryMiddleware(maxAttempts: 3, baseDelay: 0.01)
-        let callCount = Mutex(0)
+  @Test("429 then 200 succeeds after retry")
+  func retryThenSuccess() async throws {
+    let middleware = RetryMiddleware(maxAttempts: 3, baseDelay: 0.01)
+    let callCount = Mutex(0)
 
-        let (response, _) = try await middleware.intercept(
-            HTTPRequest(method: .get, scheme: "https", authority: "test.kaiten.ru", path: "/test"),
-            body: nil,
-            baseURL: URL(string: "https://test.kaiten.ru")!,
-            operationID: "test"
-        ) { _, _, _ in
-            let count = callCount.withLock { val in
-                val += 1
-                return val
-            }
-            if count == 1 {
-                return (HTTPResponse(status: .tooManyRequests, headerFields: HTTPFields([
-                    HTTPField(name: HTTPField.Name("Retry-After")!, value: "0"),
-                ])), nil)
-            }
-            return (HTTPResponse(status: .ok), HTTPBody("{}"))
-        }
-
-        #expect(response.status == .ok)
-        #expect(callCount.withLock { $0 } == 2)
+    let (response, _) = try await middleware.intercept(
+      HTTPRequest(method: .get, scheme: "https", authority: "test.kaiten.ru", path: "/test"),
+      body: nil,
+      baseURL: URL(string: "https://test.kaiten.ru")!,
+      operationID: "test"
+    ) { _, _, _ in
+      let count = callCount.withLock { val in
+        val += 1
+        return val
+      }
+      if count == 1 {
+        return (
+          HTTPResponse(
+            status: .tooManyRequests,
+            headerFields: HTTPFields([
+              HTTPField(name: HTTPField.Name("Retry-After")!, value: "0")
+            ])), nil
+        )
+      }
+      return (HTTPResponse(status: .ok), HTTPBody("{}"))
     }
 
-    @Test("429 three times throws rateLimited")
-    func exhaustedRetries() async throws {
-        let middleware = RetryMiddleware(maxAttempts: 3, baseDelay: 0.01)
+    #expect(response.status == .ok)
+    #expect(callCount.withLock { $0 } == 2)
+  }
 
-        await #expect(throws: KaitenError.self) {
-            _ = try await middleware.intercept(
-                HTTPRequest(method: .get, scheme: "https", authority: "test.kaiten.ru", path: "/test"),
-                body: nil,
-                baseURL: URL(string: "https://test.kaiten.ru")!,
-                operationID: "test"
-            ) { _, _, _ in
-                (HTTPResponse(status: .tooManyRequests, headerFields: HTTPFields([
-                    HTTPField(name: HTTPField.Name("Retry-After")!, value: "0"),
-                ])), nil)
-            }
-        }
+  @Test("429 three times throws rateLimited")
+  func exhaustedRetries() async throws {
+    let middleware = RetryMiddleware(maxAttempts: 3, baseDelay: 0.01)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await middleware.intercept(
+        HTTPRequest(method: .get, scheme: "https", authority: "test.kaiten.ru", path: "/test"),
+        body: nil,
+        baseURL: URL(string: "https://test.kaiten.ru")!,
+        operationID: "test"
+      ) { _, _, _ in
+        (
+          HTTPResponse(
+            status: .tooManyRequests,
+            headerFields: HTTPFields([
+              HTTPField(name: HTTPField.Name("Retry-After")!, value: "0")
+            ])), nil
+        )
+      }
+    }
+  }
+
+  @Test("500 then 200 succeeds after retry")
+  func serverErrorRetry() async throws {
+    let middleware = RetryMiddleware(maxAttempts: 3, baseDelay: 0.01)
+    let callCount = Mutex(0)
+
+    let (response, _) = try await middleware.intercept(
+      HTTPRequest(method: .get, scheme: "https", authority: "test.kaiten.ru", path: "/test"),
+      body: nil,
+      baseURL: URL(string: "https://test.kaiten.ru")!,
+      operationID: "test"
+    ) { _, _, _ in
+      let count = callCount.withLock { val in
+        val += 1
+        return val
+      }
+      if count == 1 {
+        return (HTTPResponse(status: .internalServerError), nil)
+      }
+      return (HTTPResponse(status: .ok), HTTPBody("{}"))
     }
 
-    @Test("500 then 200 succeeds after retry")
-    func serverErrorRetry() async throws {
-        let middleware = RetryMiddleware(maxAttempts: 3, baseDelay: 0.01)
-        let callCount = Mutex(0)
+    #expect(response.status == .ok)
+    #expect(callCount.withLock { $0 } == 2)
+  }
 
-        let (response, _) = try await middleware.intercept(
-            HTTPRequest(method: .get, scheme: "https", authority: "test.kaiten.ru", path: "/test"),
-            body: nil,
-            baseURL: URL(string: "https://test.kaiten.ru")!,
-            operationID: "test"
-        ) { _, _, _ in
-            let count = callCount.withLock { val in
-                val += 1
-                return val
-            }
-            if count == 1 {
-                return (HTTPResponse(status: .internalServerError), nil)
-            }
-            return (HTTPResponse(status: .ok), HTTPBody("{}"))
-        }
+  @Test("5xx exhausted retries throws serverError")
+  func serverErrorExhausted() async throws {
+    let middleware = RetryMiddleware(maxAttempts: 3, baseDelay: 0.01)
 
-        #expect(response.status == .ok)
-        #expect(callCount.withLock { $0 } == 2)
+    await #expect(throws: KaitenError.self) {
+      _ = try await middleware.intercept(
+        HTTPRequest(method: .get, scheme: "https", authority: "test.kaiten.ru", path: "/test"),
+        body: nil,
+        baseURL: URL(string: "https://test.kaiten.ru")!,
+        operationID: "test"
+      ) { _, _, _ in
+        (HTTPResponse(status: .badGateway), nil)
+      }
+    }
+  }
+
+  @Test("Network error then 200 succeeds after retry")
+  func networkErrorRetry() async throws {
+    let middleware = RetryMiddleware(maxAttempts: 3, baseDelay: 0.01)
+    let callCount = Mutex(0)
+
+    let (response, _) = try await middleware.intercept(
+      HTTPRequest(method: .get, scheme: "https", authority: "test.kaiten.ru", path: "/test"),
+      body: nil,
+      baseURL: URL(string: "https://test.kaiten.ru")!,
+      operationID: "test"
+    ) { _, _, _ in
+      let count = callCount.withLock { val in
+        val += 1
+        return val
+      }
+      if count == 1 {
+        throw URLError(.timedOut)
+      }
+      return (HTTPResponse(status: .ok), HTTPBody("{}"))
     }
 
-    @Test("5xx exhausted retries throws serverError")
-    func serverErrorExhausted() async throws {
-        let middleware = RetryMiddleware(maxAttempts: 3, baseDelay: 0.01)
+    #expect(response.status == .ok)
+    #expect(callCount.withLock { $0 } == 2)
+  }
 
-        await #expect(throws: KaitenError.self) {
-            _ = try await middleware.intercept(
-                HTTPRequest(method: .get, scheme: "https", authority: "test.kaiten.ru", path: "/test"),
-                body: nil,
-                baseURL: URL(string: "https://test.kaiten.ru")!,
-                operationID: "test"
-            ) { _, _, _ in
-                (HTTPResponse(status: .badGateway), nil)
-            }
-        }
+  @Test("Network error exhausted retries throws networkError")
+  func networkErrorExhausted() async throws {
+    let middleware = RetryMiddleware(maxAttempts: 3, baseDelay: 0.01)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await middleware.intercept(
+        HTTPRequest(method: .get, scheme: "https", authority: "test.kaiten.ru", path: "/test"),
+        body: nil,
+        baseURL: URL(string: "https://test.kaiten.ru")!,
+        operationID: "test"
+      ) { _, _, _ in
+        throw URLError(.networkConnectionLost)
+      }
+    }
+  }
+
+  @Test("Non-retryable status passes through immediately")
+  func nonRetryableStatus() async throws {
+    let middleware = RetryMiddleware(maxAttempts: 3, baseDelay: 0.01)
+    let callCount = Mutex(0)
+
+    let (response, _) = try await middleware.intercept(
+      HTTPRequest(method: .get, scheme: "https", authority: "test.kaiten.ru", path: "/test"),
+      body: nil,
+      baseURL: URL(string: "https://test.kaiten.ru")!,
+      operationID: "test"
+    ) { _, _, _ in
+      callCount.withLock { $0 += 1 }
+      return (HTTPResponse(status: .notFound), nil)
     }
 
-    @Test("Network error then 200 succeeds after retry")
-    func networkErrorRetry() async throws {
-        let middleware = RetryMiddleware(maxAttempts: 3, baseDelay: 0.01)
-        let callCount = Mutex(0)
-
-        let (response, _) = try await middleware.intercept(
-            HTTPRequest(method: .get, scheme: "https", authority: "test.kaiten.ru", path: "/test"),
-            body: nil,
-            baseURL: URL(string: "https://test.kaiten.ru")!,
-            operationID: "test"
-        ) { _, _, _ in
-            let count = callCount.withLock { val in
-                val += 1
-                return val
-            }
-            if count == 1 {
-                throw URLError(.timedOut)
-            }
-            return (HTTPResponse(status: .ok), HTTPBody("{}"))
-        }
-
-        #expect(response.status == .ok)
-        #expect(callCount.withLock { $0 } == 2)
-    }
-
-    @Test("Network error exhausted retries throws networkError")
-    func networkErrorExhausted() async throws {
-        let middleware = RetryMiddleware(maxAttempts: 3, baseDelay: 0.01)
-
-        await #expect(throws: KaitenError.self) {
-            _ = try await middleware.intercept(
-                HTTPRequest(method: .get, scheme: "https", authority: "test.kaiten.ru", path: "/test"),
-                body: nil,
-                baseURL: URL(string: "https://test.kaiten.ru")!,
-                operationID: "test"
-            ) { _, _, _ in
-                throw URLError(.networkConnectionLost)
-            }
-        }
-    }
-
-    @Test("Non-retryable status passes through immediately")
-    func nonRetryableStatus() async throws {
-        let middleware = RetryMiddleware(maxAttempts: 3, baseDelay: 0.01)
-        let callCount = Mutex(0)
-
-        let (response, _) = try await middleware.intercept(
-            HTTPRequest(method: .get, scheme: "https", authority: "test.kaiten.ru", path: "/test"),
-            body: nil,
-            baseURL: URL(string: "https://test.kaiten.ru")!,
-            operationID: "test"
-        ) { _, _, _ in
-            callCount.withLock { $0 += 1 }
-            return (HTTPResponse(status: .notFound), nil)
-        }
-
-        #expect(response.status == .notFound)
-        #expect(callCount.withLock { $0 } == 1)
-    }
+    #expect(response.status == .notFound)
+    #expect(callCount.withLock { $0 } == 1)
+  }
 }

--- a/Tests/KaitenSDKTests/UpdateCardTests.swift
+++ b/Tests/KaitenSDKTests/UpdateCardTests.swift
@@ -7,37 +7,40 @@ import Testing
 @Suite("UpdateCard")
 struct UpdateCardTests {
 
-    @Test("200 returns updated Card")
-    func success() async throws {
-        let json = """
-            {"id": 42, "title": "Updated title", "description": "New desc"}
-            """
-        let transport = MockClientTransport.returning(statusCode: 200, body: json)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  @Test("200 returns updated Card")
+  func success() async throws {
+    let json = """
+      {"id": 42, "title": "Updated title", "description": "New desc"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-        let card = try await client.updateCard(id: 42, title: "Updated title", description: "New desc")
-        #expect(card.id == 42)
-        #expect(card.title == "Updated title")
-        #expect(card.description == "New desc")
+    let card = try await client.updateCard(id: 42, title: "Updated title", description: "New desc")
+    #expect(card.id == 42)
+    #expect(card.title == "Updated title")
+    #expect(card.description == "New desc")
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.updateCard(id: 999, title: "x")
     }
+  }
 
-    @Test("404 throws notFound")
-    func notFound() async throws {
-        let transport = MockClientTransport.returning(statusCode: 404)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-        await #expect(throws: KaitenError.self) {
-            _ = try await client.updateCard(id: 999, title: "x")
-        }
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.updateCard(id: 1, title: "x")
     }
-
-    @Test("401 throws unauthorized")
-    func unauthorized() async throws {
-        let transport = MockClientTransport.returning(statusCode: 401)
-        let client = try KaitenClient(baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
-
-        await #expect(throws: KaitenError.self) {
-            _ = try await client.updateCard(id: 1, title: "x")
-        }
-    }
+  }
 }


### PR DESCRIPTION
Closes [#122](https://github.com/AllDmeat/kaiten-sdk/issues/122)

## Changes

- **New CI workflow** (`lint.yml`): runs `swift format lint --strict --recursive Sources/ Tests/` on macOS for every push/PR to main
- **Formatted all code** with default swift-format configuration (main change: 2-space → 4-space indentation)
- **Updated AGENTS.md**: documented formatting rules and the command to run before every commit

## Notes

Large diff (~4400 lines) but purely mechanical — no logic changes. All existing tests should pass as-is.