### PR TITLE
Add update comment endpoint

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -651,6 +651,28 @@ public struct KaitenClient: Sendable {
     return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) { try $0.json }
   }
 
+  /// Updates a comment on a card.
+  ///
+  /// - Parameters:
+  ///   - cardId: The card identifier.
+  ///   - commentId: The comment identifier.
+  ///   - text: New comment text (markdown).
+  /// - Returns: The updated comment.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card or comment does not exist.
+  public func updateComment(cardId: Int, commentId: Int, text: String) async throws(KaitenError)
+    -> Components.Schemas.Comment
+  {
+    let response = try await call {
+      try await client.update_card_comment(
+        path: .init(card_id: cardId, comment_id: commentId),
+        body: .json(.init(text: text))
+      )
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("comment", commentId)) {
+      try $0.json
+    }
+  }
+
   /// Fetches all comments on a card.
   ///
   /// - Parameter cardId: The card identifier.

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -89,6 +89,18 @@ extension Operations.create_card_comment.Output {
   }
 }
 
+extension Operations.update_card_comment.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.update_card_comment.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
 // MARK: - Checklists
 
 extension Operations.create_checklist.Output {

--- a/Sources/kaiten/CardCommands.swift
+++ b/Sources/kaiten/CardCommands.swift
@@ -459,6 +459,31 @@ struct GetCardMembers: AsyncParsableCommand {
   }
 }
 
+struct UpdateComment: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "update-comment",
+    abstract: "Update a comment on a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Comment ID")
+  var commentId: Int
+
+  @Option(name: .long, help: "New comment text (markdown)")
+  var text: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let comment = try await client.updateComment(
+      cardId: cardId, commentId: commentId, text: text)
+    try printJSON(comment)
+  }
+}
+
 struct AddComment: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "add-comment",

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -21,6 +21,7 @@ struct Kaiten: AsyncParsableCommand {
       UpdateCard.self,
       GetCardComments.self,
       AddComment.self,
+      UpdateComment.self,
       GetCardMembers.self,
       CreateChecklist.self,
       ListCustomProperties.self,

--- a/Tests/KaitenSDKTests/UpdateCommentTests.swift
+++ b/Tests/KaitenSDKTests/UpdateCommentTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("UpdateComment")
+struct UpdateCommentTests {
+
+  @Test("200 returns updated Comment")
+  func success() async throws {
+    let json = """
+      {"id": 100, "uid": "abc-123", "text": "Updated text", "type": 1, "edited": true, "card_id": 42, "author_id": 5, "internal": false, "deleted": false, "sd_description": false, "updated": "2026-02-18T03:13:29Z", "created": "2026-02-17T13:05:28Z"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let comment = try await client.updateComment(cardId: 42, commentId: 100, text: "Updated text")
+    #expect(comment.id == 100)
+    #expect(comment.text == "Updated text")
+    #expect(comment.edited == true)
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.updateComment(cardId: 42, commentId: 999, text: "x")
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.updateComment(cardId: 42, commentId: 100, text: "x")
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -516,6 +516,42 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /cards/{card_id}/comments/{comment_id}:
+    patch:
+      summary: Update comment
+      operationId: update_card_comment
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      - name: comment_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Comment ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateCommentRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Comment'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
   /cards/{card_id}/checklists:
     post:
       summary: Add checklist to card
@@ -1515,6 +1551,14 @@ components:
           - 'null'
           description: Calculation method
     CreateCommentRequest:
+      type: object
+      required:
+      - text
+      properties:
+        text:
+          type: string
+          description: Comment text (markdown)
+    UpdateCommentRequest:
       type: object
       required:
       - text


### PR DESCRIPTION
Add PATCH /cards/{card_id}/comments/{comment_id} endpoint to update card comments.

- OpenAPI spec with UpdateCommentRequest schema
- KaitenClient.updateComment(cardId:commentId:text:) method
- ResponseMapping for update_card_comment
- CLI update-comment command
- Tests for 200, 404, 401

Closes #187