### PR TITLE
Add get checklist endpoint

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -714,6 +714,28 @@ public struct KaitenClient: Sendable {
   }
 }
 
+// MARK: - Checklists
+
+extension KaitenClient {
+  /// Fetches a single checklist by its identifier.
+  ///
+  /// - Parameters:
+  ///   - cardId: The card identifier.
+  ///   - checklistId: The checklist identifier.
+  /// - Returns: The checklist object.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card or checklist does not exist.
+  public func getChecklist(cardId: Int, checklistId: Int) async throws(KaitenError)
+    -> Components.Schemas.Checklist
+  {
+    let response = try await call {
+      try await client.get_checklist(path: .init(card_id: cardId, id: checklistId))
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("checklist", checklistId)) {
+      try $0.json
+    }
+  }
+}
+
 // MARK: - Custom Properties
 
 extension KaitenClient {

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -115,6 +115,18 @@ extension Operations.create_checklist.Output {
   }
 }
 
+extension Operations.get_checklist.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_checklist.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
 // MARK: - Custom Properties
 
 extension Operations.get_list_of_properties.Output {

--- a/Sources/kaiten/ChecklistCommands.swift
+++ b/Sources/kaiten/ChecklistCommands.swift
@@ -25,3 +25,26 @@ struct CreateChecklist: AsyncParsableCommand {
     try printJSON(checklist)
   }
 }
+
+// MARK: - Checklists
+
+struct GetChecklist: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "get-checklist",
+    abstract: "Retrieve a card checklist"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Checklist ID")
+  var checklistId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let checklist = try await client.getChecklist(cardId: cardId, checklistId: checklistId)
+    try printJSON(checklist)
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -26,6 +26,7 @@ struct Kaiten: AsyncParsableCommand {
       CreateChecklist.self,
       ListCustomProperties.self,
       GetCustomProperty.self,
+      GetChecklist.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/GetChecklistTests.swift
+++ b/Tests/KaitenSDKTests/GetChecklistTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("GetChecklist")
+struct GetChecklistTests {
+
+  @Test("200 returns Checklist")
+  func success() async throws {
+    let json = """
+      {"id": 100, "name": "My checklist"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let checklist = try await client.getChecklist(cardId: 1, checklistId: 100)
+    #expect(checklist.id == 100)
+    #expect(checklist.name == "My checklist")
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.getChecklist(cardId: 1, checklistId: 999)
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.getChecklist(cardId: 1, checklistId: 1)
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -582,6 +582,36 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /cards/{card_id}/checklists/{id}:
+    get:
+      summary: Retrieve card checklist
+      operationId: get_checklist
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Checklist ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Checklist'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
   /company/custom-properties:
     get:
       summary: Get list of properties


### PR DESCRIPTION
Adds `GET /cards/{card_id}/checklists/{id}` endpoint to retrieve a single checklist.

Closes #189