### PR TITLE
Add removeChecklist endpoint

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -736,6 +736,27 @@ extension KaitenClient {
   }
 }
 
+// MARK: - Remove Checklist
+
+extension KaitenClient {
+  /// Removes a checklist from a card.
+  ///
+  /// - Parameters:
+  ///   - cardId: The card identifier.
+  ///   - checklistId: The checklist identifier.
+  /// - Returns: The deleted checklist ID.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card or checklist does not exist.
+  public func removeChecklist(cardId: Int, checklistId: Int) async throws(KaitenError) -> Int {
+    let response = try await call {
+      try await client.remove_checklist(path: .init(card_id: cardId, id: checklistId))
+    }
+    let result: Components.Schemas.DeletedChecklistResponse = try decodeResponse(
+      response.toCase(), notFoundResource: ("checklist", checklistId)
+    ) { try $0.json }
+    return result.id!
+  }
+}
+
 // MARK: - Custom Properties
 
 extension KaitenClient {

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -127,6 +127,18 @@ extension Operations.get_checklist.Output {
   }
 }
 
+extension Operations.remove_checklist.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.remove_checklist.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
 // MARK: - Custom Properties
 
 extension Operations.get_list_of_properties.Output {

--- a/Sources/kaiten/ChecklistCommands.swift
+++ b/Sources/kaiten/ChecklistCommands.swift
@@ -48,3 +48,24 @@ struct GetChecklist: AsyncParsableCommand {
     try printJSON(checklist)
   }
 }
+
+struct RemoveChecklist: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "remove-checklist",
+    abstract: "Remove a checklist from a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Checklist ID")
+  var checklistId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let deletedId = try await client.removeChecklist(cardId: cardId, checklistId: checklistId)
+    try printJSON(["id": deletedId])
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -24,6 +24,7 @@ struct Kaiten: AsyncParsableCommand {
       UpdateComment.self,
       GetCardMembers.self,
       CreateChecklist.self,
+      RemoveChecklist.self,
       ListCustomProperties.self,
       GetCustomProperty.self,
       GetChecklist.self,

--- a/Tests/KaitenSDKTests/RemoveChecklistTests.swift
+++ b/Tests/KaitenSDKTests/RemoveChecklistTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("RemoveChecklist")
+struct RemoveChecklistTests {
+
+  @Test("200 returns deleted checklist ID")
+  func success() async throws {
+    let json = """
+      {"id": 123}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let deletedId = try await client.removeChecklist(cardId: 42, checklistId: 123)
+    #expect(deletedId == 123)
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.removeChecklist(cardId: 42, checklistId: 999)
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.removeChecklist(cardId: 42, checklistId: 123)
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -612,6 +612,35 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+    delete:
+      summary: Remove checklist from card
+      operationId: remove_checklist
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Checklist ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeletedChecklistResponse'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
   /company/custom-properties:
     get:
       summary: Get list of properties
@@ -2402,3 +2431,9 @@ components:
           type: object
           additionalProperties: true
           description: "Custom properties. Format: 'id_{custom_property_id}: value'"
+    DeletedChecklistResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Deleted checklist ID


### PR DESCRIPTION
Add DELETE /cards/{card_id}/checklists/{id} endpoint to the SDK.

- OpenAPI spec: DELETE endpoint with DeletedChecklistResponse schema
- KaitenClient: removeChecklist(cardId:checklistId:) method returning deleted ID
- CLI: remove-checklist command
- Tests: success, notFound, unauthorized

Closes #191