### PR TITLE
Add create checklist endpoint (#188)

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -667,6 +667,29 @@ public struct KaitenClient: Sendable {
     }
     return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) { try $0.json }
   }
+  // MARK: - Checklists
+
+  /// Creates a checklist on a card.
+  ///
+  /// - Parameters:
+  ///   - cardId: The card identifier.
+  ///   - name: Checklist name (required).
+  ///   - sortOrder: Position (optional).
+  /// - Returns: The created checklist.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card does not exist.
+  public func createChecklist(cardId: Int, name: String, sortOrder: Double? = nil)
+    async throws(KaitenError) -> Components.Schemas.Checklist
+  {
+    let response = try await call {
+      try await client.create_checklist(
+        path: .init(card_id: cardId),
+        body: .json(.init(name: name, sort_order: sortOrder))
+      )
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) {
+      try $0.json
+    }
+  }
 }
 
 // MARK: - Custom Properties

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -89,6 +89,20 @@ extension Operations.create_card_comment.Output {
   }
 }
 
+// MARK: - Checklists
+
+extension Operations.create_checklist.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.create_checklist.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
 // MARK: - Custom Properties
 
 extension Operations.get_list_of_properties.Output {

--- a/Sources/kaiten/ChecklistCommands.swift
+++ b/Sources/kaiten/ChecklistCommands.swift
@@ -1,0 +1,27 @@
+import ArgumentParser
+import KaitenSDK
+
+struct CreateChecklist: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "create-checklist",
+    abstract: "Create a checklist on a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Checklist name")
+  var name: String
+
+  @Option(name: .long, help: "Position (sort order)")
+  var sortOrder: Double?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let checklist = try await client.createChecklist(
+      cardId: cardId, name: name, sortOrder: sortOrder)
+    try printJSON(checklist)
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -22,6 +22,7 @@ struct Kaiten: AsyncParsableCommand {
       GetCardComments.self,
       AddComment.self,
       GetCardMembers.self,
+      CreateChecklist.self,
       ListCustomProperties.self,
       GetCustomProperty.self,
     ]

--- a/Tests/KaitenSDKTests/CreateChecklistTests.swift
+++ b/Tests/KaitenSDKTests/CreateChecklistTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("CreateChecklist")
+struct CreateChecklistTests {
+
+  @Test("200 returns created Checklist")
+  func success() async throws {
+    let json = """
+      {"id": 100, "name": "Test checklist", "uid": "b5971c69-571a-43dc-81e6-31987f2d5254", "card_id": 42, "checklist_id": 100, "sort_order": 1.5, "policy_id": null, "fts_version": "-574871004", "deleted": false, "created": "2026-02-18T03:13:03Z", "updated": "2026-02-18T03:13:03Z"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let checklist = try await client.createChecklist(cardId: 42, name: "Test checklist")
+    #expect(checklist.id == 100)
+    #expect(checklist.name == "Test checklist")
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createChecklist(cardId: 999, name: "x")
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createChecklist(cardId: 42, name: "x")
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -516,6 +516,36 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /cards/{card_id}/checklists:
+    post:
+      summary: Add checklist to card
+      operationId: create_checklist
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateChecklistRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Checklist'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
   /company/custom-properties:
     get:
       summary: Get list of properties
@@ -1904,6 +1934,17 @@ components:
         updated:
           type: string
           description: Last update timestamp
+    CreateChecklistRequest:
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          type: string
+          description: Checklist name
+        sort_order:
+          type: number
+          description: Position
     Checklist:
       type: object
       properties:


### PR DESCRIPTION
Closes #188

Adds POST /cards/{card_id}/checklists endpoint:
- New schemas: Checklist, ChecklistItem, CreateChecklistRequest, DeleteResponse
- SDK method: createChecklist(cardId:name:sortOrder:)
- CLI command: create-checklist