### PR TITLE
Add createChecklistItem endpoint

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -760,6 +760,47 @@ extension KaitenClient {
 // MARK: - Checklist Items
 
 extension KaitenClient {
+  /// Creates a new checklist item.
+  ///
+  /// - Parameters:
+  ///   - cardId: The card identifier.
+  ///   - checklistId: The checklist identifier.
+  ///   - text: Item content (1–4096 characters).
+  ///   - sortOrder: Position (must be > 0).
+  ///   - checked: Checked state.
+  ///   - dueDate: Due date in YYYY-MM-DD format.
+  ///   - responsibleId: Responsible user ID.
+  /// - Returns: The created checklist item.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card or checklist does not exist.
+  public func createChecklistItem(
+    cardId: Int,
+    checklistId: Int,
+    text: String,
+    sortOrder: Double? = nil,
+    checked: Bool? = nil,
+    dueDate: String? = nil,
+    responsibleId: Int? = nil
+  ) async throws(KaitenError) -> Components.Schemas.ChecklistItem {
+    let response = try await call {
+      try await client.create_checklist_item(
+        path: .init(card_id: cardId, checklist_id: checklistId),
+        body: .json(
+          .init(
+            text: text,
+            sort_order: sortOrder,
+            checked: checked,
+            due_date: dueDate,
+            responsible_id: responsibleId
+          ))
+      )
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("checklist", checklistId)) {
+      try $0.json
+    }
+  }
+}
+
+extension KaitenClient {
   /// Updates a checklist item on a card.
   ///
   /// All body parameters are optional — only provided values are changed.

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -153,6 +153,18 @@ extension Operations.update_checklist.Output {
 
 // MARK: - Checklist Items
 
+extension Operations.create_checklist_item.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.create_checklist_item.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
 extension Operations.update_checklist_item.Output {
   func toCase() -> KaitenClient.ResponseCase<Operations.update_checklist_item.Output.Ok.Body> {
     switch self {

--- a/Sources/kaiten/ChecklistCommands.swift
+++ b/Sources/kaiten/ChecklistCommands.swift
@@ -159,3 +159,47 @@ struct UpdateChecklistItem: AsyncParsableCommand {
     try printJSON(item)
   }
 }
+
+struct CreateChecklistItem: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "create-checklist-item",
+    abstract: "Add an item to a checklist"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Checklist ID")
+  var checklistId: Int
+
+  @Option(name: .long, help: "Item text")
+  var text: String
+
+  @Option(name: .long, help: "Sort order")
+  var sortOrder: Double?
+
+  @Option(name: .long, help: "Checked state")
+  var checked: Bool?
+
+  @Option(name: .long, help: "Due date (YYYY-MM-DD)")
+  var dueDate: String?
+
+  @Option(name: .long, help: "Responsible user ID")
+  var responsibleId: Int?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let item = try await client.createChecklistItem(
+      cardId: cardId,
+      checklistId: checklistId,
+      text: text,
+      sortOrder: sortOrder,
+      checked: checked,
+      dueDate: dueDate,
+      responsibleId: responsibleId
+    )
+    try printJSON(item)
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -25,6 +25,7 @@ struct Kaiten: AsyncParsableCommand {
       GetCardMembers.self,
       CreateChecklist.self,
       RemoveChecklist.self,
+      CreateChecklistItem.self,
       UpdateChecklistItem.self,
       UpdateChecklist.self,
       ListCustomProperties.self,

--- a/Tests/KaitenSDKTests/CreateChecklistItemTests.swift
+++ b/Tests/KaitenSDKTests/CreateChecklistItemTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("CreateChecklistItem")
+struct CreateChecklistItemTests {
+  @Test("200 returns created ChecklistItem")
+  func success() async throws {
+    let json = """
+      {"id": 100, "text": "Buy milk", "sort_order": 1.5, "checked": false, "checklist_id": 10, "checker_id": null, "user_id": 1, "checked_at": null, "responsible_id": null, "deleted": false, "due_date": null, "created": "2026-01-01T00:00:00Z", "updated": "2026-01-01T00:00:00Z"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+    let item = try await client.createChecklistItem(
+      cardId: 1, checklistId: 10, text: "Buy milk")
+    #expect(item.id == 100)
+    #expect(item.text == "Buy milk")
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createChecklistItem(
+        cardId: 999, checklistId: 10, text: "Test")
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createChecklistItem(
+        cardId: 1, checklistId: 10, text: "Test")
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -676,6 +676,42 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /cards/{card_id}/checklists/{checklist_id}/items:
+    post:
+      summary: Add item to checklist
+      operationId: create_checklist_item
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      - name: checklist_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Checklist ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateChecklistItemRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChecklistItem'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
   /cards/{card_id}/checklists/{checklist_id}/items/{id}:
     patch:
       summary: Update checklist item
@@ -2558,3 +2594,25 @@ components:
           - integer
           - 'null'
           description: Responsible user ID (null to clear)
+    CreateChecklistItemRequest:
+      type: object
+      required:
+      - text
+      properties:
+        text:
+          type: string
+          description: Item content
+        sort_order:
+          type: number
+          description: Position
+        checked:
+          type: boolean
+          description: Checked state
+        due_date:
+          type:
+          - string
+          - 'null'
+          description: Due date (YYYY-MM-DD)
+        responsible_id:
+          type: integer
+          description: Responsible user ID


### PR DESCRIPTION
Add POST /cards/{card_id}/checklists/{checklist_id}/items endpoint to the SDK.

- OpenAPI spec: POST endpoint with CreateChecklistItemRequest schema
- KaitenClient: createChecklistItem(cardId:checklistId:text:sortOrder:checked:dueDate:responsibleId:) method
- CLI: create-checklist-item command
- Tests: success, notFound, unauthorized

Closes #192