### PR TITLE
feat: add card tag endpoints (#209, #210, #211)

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -1163,6 +1163,69 @@ extension KaitenClient {
   }
 }
 
+// MARK: - Card Tags
+
+extension KaitenClient {
+  /// Lists all tags on a card.
+  ///
+  /// - Parameter cardId: The card identifier.
+  /// - Returns: An array of card tags.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card does not exist.
+  public func listCardTags(cardId: Int) async throws(KaitenError) -> [Components.Schemas.CardTag] {
+    guard
+      let response = try await callList({
+        try await client.list_card_tags(path: .init(card_id: cardId))
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) {
+      try $0.json
+    }
+  }
+
+  /// Adds a tag to a card.
+  ///
+  /// - Parameters:
+  ///   - cardId: The card identifier.
+  ///   - name: The tag name.
+  /// - Returns: The created tag.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card does not exist.
+  public func addCardTag(cardId: Int, name: String) async throws(KaitenError)
+    -> Components
+    .Schemas.Tag
+  {
+    let response = try await call {
+      try await client.add_card_tag(
+        path: .init(card_id: cardId),
+        body: .json(.init(name: name))
+      )
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) {
+      try $0.json
+    }
+  }
+
+  /// Removes a tag from a card.
+  ///
+  /// - Parameters:
+  ///   - cardId: The card identifier.
+  ///   - tagId: The tag identifier.
+  /// - Returns: The deleted tag ID.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card or tag does not exist.
+  public func removeCardTag(cardId: Int, tagId: Int) async throws(KaitenError) -> Int {
+    let response = try await call {
+      try await client.remove_card_tag(
+        path: .init(card_id: cardId, tag_id: tagId)
+      )
+    }
+    let body = try decodeResponse(response.toCase(), notFoundResource: ("tag", tagId)) {
+      try $0.json
+    }
+    return body.id!
+  }
+}
+
 // MARK: - Helpers
 
 extension Optional {

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -335,3 +335,41 @@ extension Operations.get_list_of_boards.Output {
     }
   }
 }
+
+// MARK: - Card Tags
+
+extension Operations.list_card_tags.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_card_tags.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.add_card_tag.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.add_card_tag.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.remove_card_tag.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.remove_card_tag.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -37,6 +37,9 @@ struct Kaiten: AsyncParsableCommand {
       GetChecklist.self,
       DeleteCard.self,
       DeleteComment.self,
+      ListCardTags.self,
+      AddCardTag.self,
+      RemoveCardTag.self,
     ]
   )
 }

--- a/Sources/kaiten/TagCommands.swift
+++ b/Sources/kaiten/TagCommands.swift
@@ -1,0 +1,69 @@
+import ArgumentParser
+import Foundation
+import KaitenSDK
+
+// MARK: - List Card Tags
+
+struct ListCardTags: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-card-tags",
+    abstract: "List tags on a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let tags = try await client.listCardTags(cardId: cardId)
+    try printJSON(tags)
+  }
+}
+
+// MARK: - Add Card Tag
+
+struct AddCardTag: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "add-card-tag",
+    abstract: "Add a tag to a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Tag name")
+  var name: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let tag = try await client.addCardTag(cardId: cardId, name: name)
+    try printJSON(tag)
+  }
+}
+
+// MARK: - Remove Card Tag
+
+struct RemoveCardTag: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "remove-card-tag",
+    abstract: "Remove a tag from a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Tag ID")
+  var tagId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let deletedId = try await client.removeCardTag(cardId: cardId, tagId: tagId)
+    try printJSON(["id": deletedId])
+  }
+}

--- a/Tests/KaitenSDKTests/AddCardTagTests.swift
+++ b/Tests/KaitenSDKTests/AddCardTagTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("AddCardTag")
+struct AddCardTagTests {
+
+  @Test("200 returns Tag")
+  func success() async throws {
+    let json = """
+      {"id": 10, "name": "urgent", "color": 2, "company_id": 1, "archived": false, "created": "2025-01-01", "updated": "2025-01-01"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let tag = try await client.addCardTag(cardId: 42, name: "urgent")
+    #expect(tag.id == 10)
+    #expect(tag.name == "urgent")
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.addCardTag(cardId: 999, name: "test")
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.addCardTag(cardId: 1, name: "test")
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/ListCardTagsTests.swift
+++ b/Tests/KaitenSDKTests/ListCardTagsTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("ListCardTags")
+struct ListCardTagsTests {
+
+  @Test("200 returns array of CardTag")
+  func success() async throws {
+    let json = """
+      [{"id": 1, "name": "urgent", "color": 2, "card_id": 42, "tag_id": 10}]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let tags = try await client.listCardTags(cardId: 42)
+    #expect(tags.count == 1)
+    #expect(tags[0].name == "urgent")
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCardTags(cardId: 999)
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCardTags(cardId: 1)
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/RemoveCardTagTests.swift
+++ b/Tests/KaitenSDKTests/RemoveCardTagTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("RemoveCardTag")
+struct RemoveCardTagTests {
+
+  @Test("200 returns deleted tag ID")
+  func success() async throws {
+    let json = """
+      {"id": 10}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let deletedId = try await client.removeCardTag(cardId: 42, tagId: 10)
+    #expect(deletedId == 10)
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.removeCardTag(cardId: 42, tagId: 999)
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.removeCardTag(cardId: 1, tagId: 1)
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -935,6 +935,91 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /cards/{card_id}/tags:
+    get:
+      summary: List card tags
+      operationId: list_card_tags
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CardTag'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    post:
+      summary: Add card tag
+      operationId: add_card_tag
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddCardTagRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tag'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+  /cards/{card_id}/tags/{tag_id}:
+    delete:
+      summary: Remove card tag
+      operationId: remove_card_tag
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      - name: tag_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Tag ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeletedTagResponse'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
   /company/custom-properties:
     get:
       summary: Get list of properties
@@ -2849,3 +2934,37 @@ components:
         id:
           type: integer
           description: Removed user ID
+    CardTag:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Card tag ID
+        name:
+          type: string
+          description: Tag name
+        color:
+          type: integer
+          description: Tag color number
+        card_id:
+          type: integer
+          description: Card ID
+        tag_id:
+          type: integer
+          description: Tag ID
+    AddCardTagRequest:
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: Tag name
+    DeletedTagResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Deleted card tag ID


### PR DESCRIPTION
Adds three card tag endpoints:

- **Add card tag** — `POST /cards/{card_id}/tags` (Closes #209)
- **List card tags** — `GET /cards/{card_id}/tags` (Closes #210)
- **Remove card tag** — `DELETE /cards/{card_id}/tags/{tag_id}` (Closes #211)

Includes OpenAPI spec, KaitenClient methods, ResponseMapping extensions, CLI commands, and tests.