### PR TITLE
feat: add delete card and delete comment endpoints

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -689,6 +689,38 @@ public struct KaitenClient: Sendable {
     }
     return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) { try $0.json }
   }
+  // MARK: - Delete Card
+
+  /// Deletes a card.
+  ///
+  /// - Parameter id: The card identifier.
+  /// - Returns: The deleted card.
+  public func deleteCard(id: Int) async throws(KaitenError) -> Components.Schemas.Card {
+    let response = try await call {
+      try await client.delete_card(path: .init(card_id: id))
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", id)) { try $0.json }
+  }
+
+  // MARK: - Delete Comment
+
+  /// Deletes a comment from a card.
+  ///
+  /// - Parameters:
+  ///   - cardId: The card identifier.
+  ///   - commentId: The comment identifier.
+  /// - Returns: The deleted comment ID.
+  public func deleteComment(cardId: Int, commentId: Int) async throws(KaitenError) -> Int {
+    let response = try await call {
+      try await client.delete_card_comment(
+        path: .init(card_id: cardId, comment_id: commentId))
+    }
+    let result: Components.Schemas.DeletedCommentResponse = try decodeResponse(
+      response.toCase(), notFoundResource: ("comment", commentId)
+    ) { try $0.json }
+    return result.id!
+  }
+
   // MARK: - Checklists
 
   /// Creates a checklist on a card.

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -127,6 +127,30 @@ extension Operations.get_checklist.Output {
   }
 }
 
+extension Operations.delete_card.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.delete_card.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.delete_card_comment.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.delete_card_comment.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
 extension Operations.remove_checklist.Output {
   func toCase() -> KaitenClient.ResponseCase<Operations.remove_checklist.Output.Ok.Body> {
     switch self {

--- a/Sources/kaiten/CardCommands.swift
+++ b/Sources/kaiten/CardCommands.swift
@@ -504,3 +504,42 @@ struct AddComment: AsyncParsableCommand {
     try printJSON(comment)
   }
 }
+
+struct DeleteCard: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "delete-card",
+    abstract: "Delete a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let card = try await client.deleteCard(id: cardId)
+    try printJSON(card)
+  }
+}
+
+struct DeleteComment: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "delete-comment",
+    abstract: "Delete a comment from a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Comment ID")
+  var commentId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let deletedId = try await client.deleteComment(cardId: cardId, commentId: commentId)
+    try printJSON(["id": deletedId])
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -32,6 +32,8 @@ struct Kaiten: AsyncParsableCommand {
       ListCustomProperties.self,
       GetCustomProperty.self,
       GetChecklist.self,
+      DeleteCard.self,
+      DeleteComment.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/DeleteCardTests.swift
+++ b/Tests/KaitenSDKTests/DeleteCardTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("DeleteCard")
+struct DeleteCardTests {
+
+  @Test("200 returns deleted Card")
+  func success() async throws {
+    let json = """
+      {"id": 42, "title": "Deleted card", "condition": 3}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let card = try await client.deleteCard(id: 42)
+    #expect(card.id == 42)
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.deleteCard(id: 999)
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.deleteCard(id: 1)
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/DeleteCommentTests.swift
+++ b/Tests/KaitenSDKTests/DeleteCommentTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("DeleteComment")
+struct DeleteCommentTests {
+
+  @Test("200 returns deleted comment ID")
+  func success() async throws {
+    let json = """
+      {"id": 456}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let deletedId = try await client.deleteComment(cardId: 42, commentId: 456)
+    #expect(deletedId == 456)
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.deleteComment(cardId: 42, commentId: 999)
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.deleteComment(cardId: 42, commentId: 456)
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -437,6 +437,29 @@ paths:
           description: Unauthorized
         '404':
           description: Card not found
+    delete:
+      summary: Delete card
+      operationId: delete_card
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      responses:
+        '200':
+          description: Card deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Card'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Card not found
   /cards/{card_id}/members:
     get:
       summary: Retrieve list of card members
@@ -546,6 +569,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Comment'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    delete:
+      summary: Delete comment
+      operationId: delete_card_comment
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      - name: comment_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Comment ID
+      responses:
+        '200':
+          description: Comment deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeletedCommentResponse'
         '401':
           description: Invalid token
         '403':
@@ -2594,6 +2646,12 @@ components:
           type: object
           additionalProperties: true
           description: "Custom properties. Format: 'id_{custom_property_id}: value'"
+    DeletedCommentResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Deleted comment ID
     DeletedChecklistResponse:
       type: object
       properties:


### PR DESCRIPTION
Closes #212, closes #213

- Add `DELETE /cards/{card_id}` endpoint (returns full Card object)
- Add `DELETE /cards/{card_id}/comments/{comment_id}` endpoint (returns deleted comment ID)
- Add `deleteCard` and `deleteComment` methods to KaitenClient
- Add CLI commands: `delete-card`, `delete-comment`
- Add tests for both endpoints