### PR TITLE
feat: add card children endpoints (#218, #219, #220)

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -1206,6 +1206,68 @@ extension KaitenClient {
     }
   }
 
+  // MARK: - Card Children
+
+  /// Lists children of a card.
+  ///
+  /// - Parameter cardId: The card identifier.
+  /// - Returns: An array of card children.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card does not exist.
+  public func listCardChildren(cardId: Int) async throws(KaitenError) -> [Components.Schemas
+    .CardChild]
+  {
+    guard
+      let response = try await callList({
+        try await client.list_card_children(path: .init(card_id: cardId))
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) {
+      try $0.json
+    }
+  }
+
+  /// Adds a child card to a parent card.
+  ///
+  /// - Parameters:
+  ///   - cardId: The parent card identifier.
+  ///   - childCardId: The child card identifier.
+  /// - Returns: The created card child.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card does not exist.
+  public func addCardChild(cardId: Int, childCardId: Int) async throws(KaitenError)
+    -> Components.Schemas.CardChild
+  {
+    let response = try await call {
+      try await client.add_card_child(
+        path: .init(card_id: cardId),
+        body: .json(.init(card_id: childCardId))
+      )
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) {
+      try $0.json
+    }
+  }
+
+  /// Removes a child card from a parent card.
+  ///
+  /// - Parameters:
+  ///   - cardId: The parent card identifier.
+  ///   - childId: The child card identifier.
+  /// - Returns: The deleted child ID.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card or child does not exist.
+  public func removeCardChild(cardId: Int, childId: Int) async throws(KaitenError) -> Int {
+    let response = try await call {
+      try await client.remove_card_child(
+        path: .init(card_id: cardId, id: childId)
+      )
+    }
+    let body = try decodeResponse(response.toCase(), notFoundResource: ("child", childId)) {
+      try $0.json
+    }
+    return body.id!
+  }
+
   /// Removes a tag from a card.
   ///
   /// - Parameters:

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -338,6 +338,42 @@ extension Operations.get_list_of_boards.Output {
 
 // MARK: - Card Tags
 
+extension Operations.list_card_children.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_card_children.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.add_card_child.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.add_card_child.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.remove_card_child.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.remove_card_child.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
 extension Operations.list_card_tags.Output {
   func toCase() -> KaitenClient.ResponseCase<Operations.list_card_tags.Output.Ok.Body> {
     switch self {

--- a/Sources/kaiten/ChildCommands.swift
+++ b/Sources/kaiten/ChildCommands.swift
@@ -1,0 +1,69 @@
+import ArgumentParser
+import Foundation
+import KaitenSDK
+
+// MARK: - List Card Children
+
+struct ListCardChildren: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-card-children",
+    abstract: "List children of a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let children = try await client.listCardChildren(cardId: cardId)
+    try printJSON(children)
+  }
+}
+
+// MARK: - Add Card Child
+
+struct AddCardChild: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "add-card-child",
+    abstract: "Add a child card to a parent card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Parent Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Child Card ID")
+  var childCardId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let child = try await client.addCardChild(cardId: cardId, childCardId: childCardId)
+    try printJSON(child)
+  }
+}
+
+// MARK: - Remove Card Child
+
+struct RemoveCardChild: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "remove-card-child",
+    abstract: "Remove a child card from a parent card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Parent Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Child Card ID")
+  var childId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let deletedId = try await client.removeCardChild(cardId: cardId, childId: childId)
+    try printJSON(["id": deletedId])
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -42,6 +42,9 @@ struct Kaiten: AsyncParsableCommand {
       RemoveCardTag.self,
       ListUsers.self,
       GetCurrentUser.self,
+      ListCardChildren.self,
+      AddCardChild.self,
+      RemoveCardChild.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/AddCardChildTests.swift
+++ b/Tests/KaitenSDKTests/AddCardChildTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("AddCardChild")
+struct AddCardChildTests {
+
+  @Test("200 returns CardChild")
+  func success() async throws {
+    let json = """
+      {"id": 5, "title": "Child card", "state": 1, "condition": 1, "board_id": 10, "column_id": 20, "lane_id": 30, "card_id": 42, "depends_on_card_id": 5}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let child = try await client.addCardChild(cardId: 42, childCardId: 5)
+    #expect(child.id == 5)
+    #expect(child.title == "Child card")
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.addCardChild(cardId: 999, childCardId: 5)
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.addCardChild(cardId: 1, childCardId: 2)
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/ListCardChildrenTests.swift
+++ b/Tests/KaitenSDKTests/ListCardChildrenTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("ListCardChildren")
+struct ListCardChildrenTests {
+
+  @Test("200 returns array of CardChild")
+  func success() async throws {
+    let json = """
+      [{"id": 1, "title": "Child card", "state": 1, "condition": 1, "board_id": 10, "column_id": 20, "lane_id": 30, "card_id": 42, "depends_on_card_id": 1}]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let children = try await client.listCardChildren(cardId: 42)
+    #expect(children.count == 1)
+    #expect(children[0].title == "Child card")
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCardChildren(cardId: 999)
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCardChildren(cardId: 1)
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/RemoveCardChildTests.swift
+++ b/Tests/KaitenSDKTests/RemoveCardChildTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("RemoveCardChild")
+struct RemoveCardChildTests {
+
+  @Test("200 returns deleted child ID")
+  func success() async throws {
+    let json = """
+      {"id": 5}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let deletedId = try await client.removeCardChild(cardId: 42, childId: 5)
+    #expect(deletedId == 5)
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.removeCardChild(cardId: 42, childId: 999)
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.removeCardChild(cardId: 1, childId: 1)
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -1020,6 +1020,91 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /cards/{card_id}/children:
+    get:
+      summary: List card children
+      operationId: list_card_children
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CardChild'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    post:
+      summary: Add card child
+      operationId: add_card_child
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Parent Card ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddCardChildRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CardChild'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+  /cards/{card_id}/children/{id}:
+    delete:
+      summary: Remove card child
+      operationId: remove_card_child
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Parent Card ID
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Child Card ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeletedChildResponse'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
   /company/custom-properties:
     get:
       summary: Get list of properties
@@ -3044,3 +3129,60 @@ components:
         id:
           type: integer
           description: Deleted card tag ID
+    CardChild:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Children card id
+        title:
+          type: string
+          description: Card title
+        description:
+          type: string
+          nullable: true
+          description: Card description
+        state:
+          type: integer
+          description: "Card state: 1-queued, 2-inProgress, 3-done"
+        condition:
+          type: integer
+          description: "Card condition: 1-live, 2-archived"
+        board_id:
+          type: integer
+          description: Board id
+        column_id:
+          type: integer
+          description: Column id
+        lane_id:
+          type: integer
+          description: Lane id
+        owner_id:
+          type: integer
+          description: Card owner id
+        type_id:
+          type: integer
+          description: Card type id
+        card_id:
+          type: integer
+          description: Parent card id
+        depends_on_card_id:
+          type: integer
+          description: Children card id
+        space_id:
+          type: integer
+          description: Space id
+    AddCardChildRequest:
+      type: object
+      required:
+      - card_id
+      properties:
+        card_id:
+          type: integer
+          description: ID of child card
+    DeletedChildResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Deleted card child ID


### PR DESCRIPTION
Closes #218, closes #219, closes #220

Adds three card children endpoints:
- `POST /cards/{card_id}/children` — add card child
- `GET /cards/{card_id}/children` — list card children  
- `DELETE /cards/{card_id}/children/{id}` — remove card child

New file: `Sources/kaiten/ChildCommands.swift`
Tests for each endpoint.