### PR TITLE
feat: add external link endpoints (#221, #222, #223, #224)

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -1337,6 +1337,96 @@ extension KaitenClient {
   }
 }
 
+// MARK: - External Links
+
+extension KaitenClient {
+  /// Lists all external links on a card.
+  ///
+  /// - Parameter cardId: The card identifier.
+  /// - Returns: An array of external links.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card does not exist.
+  public func listExternalLinks(cardId: Int) async throws(KaitenError)
+    -> [Components.Schemas.ExternalLink]
+  {
+    guard
+      let response = try await callList({
+        try await client.list_external_links(path: .init(card_id: cardId))
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) {
+      try $0.json
+    }
+  }
+
+  /// Creates an external link on a card.
+  ///
+  /// - Parameters:
+  ///   - cardId: The card identifier.
+  ///   - url: The link URL.
+  ///   - description: Optional link description.
+  /// - Returns: The created external link.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card does not exist.
+  public func createExternalLink(
+    cardId: Int, url: String, description: String? = nil
+  ) async throws(KaitenError) -> Components.Schemas.ExternalLink {
+    let response = try await call {
+      try await client.create_external_link(
+        path: .init(card_id: cardId),
+        body: .json(.init(url: url, description: description))
+      )
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) {
+      try $0.json
+    }
+  }
+
+  /// Updates an external link on a card.
+  ///
+  /// - Parameters:
+  ///   - cardId: The card identifier.
+  ///   - linkId: The external link identifier.
+  ///   - url: Optional new URL.
+  ///   - description: Optional new description.
+  /// - Returns: The updated external link.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card or link does not exist.
+  public func updateExternalLink(
+    cardId: Int, linkId: Int, url: String? = nil, description: String? = nil
+  ) async throws(KaitenError) -> Components.Schemas.ExternalLink {
+    let response = try await call {
+      try await client.update_external_link(
+        path: .init(card_id: cardId, id: linkId),
+        body: .json(.init(url: url, description: description))
+      )
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("external link", linkId)) {
+      try $0.json
+    }
+  }
+
+  /// Removes an external link from a card.
+  ///
+  /// - Parameters:
+  ///   - cardId: The card identifier.
+  ///   - linkId: The external link identifier.
+  /// - Returns: The deleted external link ID.
+  /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card or link does not exist.
+  public func removeExternalLink(cardId: Int, linkId: Int) async throws(KaitenError) -> Int {
+    let response = try await call {
+      try await client.remove_external_link(
+        path: .init(card_id: cardId, id: linkId)
+      )
+    }
+    let body = try decodeResponse(
+      response.toCase(), notFoundResource: ("external link", linkId)
+    ) {
+      try $0.json
+    }
+    return body.id!
+  }
+}
+
 // MARK: - Helpers
 
 extension Optional {

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -336,6 +336,56 @@ extension Operations.get_list_of_boards.Output {
   }
 }
 
+// MARK: - External Links
+
+extension Operations.list_external_links.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_external_links.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.create_external_link.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.create_external_link.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.update_external_link.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.update_external_link.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.remove_external_link.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.remove_external_link.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
 // MARK: - Card Tags
 
 extension Operations.list_card_children.Output {

--- a/Sources/kaiten/ExternalLinkCommands.swift
+++ b/Sources/kaiten/ExternalLinkCommands.swift
@@ -1,0 +1,103 @@
+import ArgumentParser
+import Foundation
+import KaitenSDK
+
+// MARK: - List External Links
+
+struct ListExternalLinks: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-external-links",
+    abstract: "List external links on a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let links = try await client.listExternalLinks(cardId: cardId)
+    try printJSON(links)
+  }
+}
+
+// MARK: - Create External Link
+
+struct CreateExternalLink: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "create-external-link",
+    abstract: "Create an external link on a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "URL")
+  var url: String
+
+  @Option(name: .long, help: "Description")
+  var description: String?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let link = try await client.createExternalLink(
+      cardId: cardId, url: url, description: description)
+    try printJSON(link)
+  }
+}
+
+// MARK: - Update External Link
+
+struct UpdateExternalLink: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "update-external-link",
+    abstract: "Update an external link on a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "External link ID")
+  var linkId: Int
+
+  @Option(name: .long, help: "URL")
+  var url: String?
+
+  @Option(name: .long, help: "Description")
+  var description: String?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let link = try await client.updateExternalLink(
+      cardId: cardId, linkId: linkId, url: url, description: description)
+    try printJSON(link)
+  }
+}
+
+// MARK: - Remove External Link
+
+struct RemoveExternalLink: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "remove-external-link",
+    abstract: "Remove an external link from a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "External link ID")
+  var linkId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let deletedId = try await client.removeExternalLink(cardId: cardId, linkId: linkId)
+    try printJSON(["id": deletedId])
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -45,6 +45,10 @@ struct Kaiten: AsyncParsableCommand {
       ListCardChildren.self,
       AddCardChild.self,
       RemoveCardChild.self,
+      ListExternalLinks.self,
+      CreateExternalLink.self,
+      UpdateExternalLink.self,
+      RemoveExternalLink.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/CreateExternalLinkTests.swift
+++ b/Tests/KaitenSDKTests/CreateExternalLinkTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("CreateExternalLink")
+struct CreateExternalLinkTests {
+
+  @Test("200 returns ExternalLink")
+  func success() async throws {
+    let json = """
+      {"id": 5, "url": "https://example.com", "description": "My link", "card_id": 42, "external_link_id": 5, "created": "2025-01-01", "updated": "2025-01-01"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let link = try await client.createExternalLink(
+      cardId: 42, url: "https://example.com", description: "My link")
+    #expect(link.id == 5)
+    #expect(link.url == "https://example.com")
+    #expect(link.description == "My link")
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createExternalLink(cardId: 999, url: "https://example.com")
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createExternalLink(cardId: 1, url: "https://example.com")
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/ListExternalLinksTests.swift
+++ b/Tests/KaitenSDKTests/ListExternalLinksTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("ListExternalLinks")
+struct ListExternalLinksTests {
+
+  @Test("200 returns array of ExternalLink")
+  func success() async throws {
+    let json = """
+      [{"id": 1, "url": "https://example.com", "description": "Example", "card_id": 42, "external_link_id": 1, "created": "2025-01-01", "updated": "2025-01-01"}]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let links = try await client.listExternalLinks(cardId: 42)
+    #expect(links.count == 1)
+    #expect(links[0].id == 1)
+    #expect(links[0].url == "https://example.com")
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listExternalLinks(cardId: 999)
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listExternalLinks(cardId: 1)
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/RemoveExternalLinkTests.swift
+++ b/Tests/KaitenSDKTests/RemoveExternalLinkTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("RemoveExternalLink")
+struct RemoveExternalLinkTests {
+
+  @Test("200 returns deleted ID")
+  func success() async throws {
+    let json = """
+      {"id": 5}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let deletedId = try await client.removeExternalLink(cardId: 42, linkId: 5)
+    #expect(deletedId == 5)
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.removeExternalLink(cardId: 42, linkId: 999)
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.removeExternalLink(cardId: 1, linkId: 1)
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/UpdateExternalLinkTests.swift
+++ b/Tests/KaitenSDKTests/UpdateExternalLinkTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("UpdateExternalLink")
+struct UpdateExternalLinkTests {
+
+  @Test("200 returns updated ExternalLink")
+  func success() async throws {
+    let json = """
+      {"id": 5, "url": "https://updated.com", "description": "Updated", "card_id": 42, "external_link_id": 5, "created": "2025-01-01", "updated": "2025-01-02"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let link = try await client.updateExternalLink(
+      cardId: 42, linkId: 5, url: "https://updated.com", description: "Updated")
+    #expect(link.id == 5)
+    #expect(link.url == "https://updated.com")
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.updateExternalLink(cardId: 42, linkId: 999, url: "https://example.com")
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.updateExternalLink(cardId: 1, linkId: 1, url: "https://example.com")
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -1105,6 +1105,126 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /cards/{card_id}/external-links:
+    get:
+      summary: List external links on a card
+      operationId: list_external_links
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ExternalLink'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    post:
+      summary: Create external link on a card
+      operationId: create_external_link
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateExternalLinkRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalLink'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+  /cards/{card_id}/external-links/{id}:
+    patch:
+      summary: Update external link
+      operationId: update_external_link
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: External link ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateExternalLinkRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalLink'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    delete:
+      summary: Remove external link
+      operationId: remove_external_link
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: External link ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeletedExternalLinkResponse'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
   /company/custom-properties:
     get:
       summary: Get list of properties
@@ -3181,8 +3301,39 @@ components:
           type: integer
           description: ID of child card
     DeletedChildResponse:
+    CreateExternalLinkRequest:
+      type: object
+      required:
+      - url
+      properties:
+        url:
+          type: string
+          minLength: 1
+          maxLength: 16384
+          description: URL
+        description:
+          type:
+          - string
+          - 'null'
+          maxLength: 512
+          description: Description
+    UpdateExternalLinkRequest:
+      type: object
+      properties:
+        url:
+          type: string
+          minLength: 1
+          maxLength: 16384
+          description: URL
+        description:
+          type:
+          - string
+          - 'null'
+          maxLength: 512
+          description: Description
+    DeletedExternalLinkResponse:
       type: object
       properties:
         id:
           type: integer
-          description: Deleted card child ID
+          description: Deleted external link ID


### PR DESCRIPTION
Closes #221, closes #222, closes #223, closes #224

Adds CRUD endpoints for card external links:
- `POST /cards/{card_id}/external-links` — create external link
- `GET /cards/{card_id}/external-links` — list external links
- `PATCH /cards/{card_id}/external-links/{id}` — update external link
- `DELETE /cards/{card_id}/external-links/{id}` — remove external link

Includes OpenAPI spec, KaitenClient methods, CLI commands, and tests.