### PR TITLE
feat: add time log, card type, sprint, and card history endpoints

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -1401,6 +1401,95 @@ extension KaitenClient {
   }
 }
 
+// MARK: - Time Logs
+
+extension KaitenClient {
+  /// Creates a time log on a card.
+  public func createTimeLog(
+    cardId: Int, roleId: Int, timeSpent: Int, forDate: String, comment: String? = nil
+  ) async throws(KaitenError) -> Components.Schemas.TimeLog {
+    let response = try await call {
+      try await client.create_time_log(
+        path: .init(card_id: cardId),
+        body: .json(
+          .init(role_id: roleId, time_spent: timeSpent, for_date: forDate, comment: comment))
+      )
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) { try $0.json }
+  }
+
+  /// Lists time logs for a card.
+  public func listTimeLogs(
+    cardId: Int, forDate: String? = nil, personal: Bool? = nil
+  ) async throws(KaitenError) -> [Components.Schemas.TimeLog] {
+    guard
+      let response = try await callList({
+        try await client.list_time_logs(
+          path: .init(card_id: cardId),
+          query: .init(for_date: forDate, personal: personal)
+        )
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) { try $0.json }
+  }
+}
+
+// MARK: - Card Types
+
+extension KaitenClient {
+  /// Lists card types.
+  public func listCardTypes(
+    limit: Int? = nil, offset: Int? = nil
+  ) async throws(KaitenError) -> [Components.Schemas.CardType] {
+    guard
+      let response = try await callList({
+        try await client.list_card_types(query: .init(limit: limit, offset: offset))
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+}
+
+// MARK: - Sprints
+
+extension KaitenClient {
+  /// Lists sprints.
+  public func listSprints(
+    active: Bool? = nil, limit: Int? = nil, offset: Int? = nil
+  ) async throws(KaitenError) -> [Components.Schemas.Sprint] {
+    guard
+      let response = try await callList({
+        try await client.list_sprints(query: .init(active: active, limit: limit, offset: offset))
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+}
+
+// MARK: - Card Location History
+
+extension KaitenClient {
+  /// Gets card location history.
+  public func getCardLocationHistory(
+    cardId: Int
+  ) async throws(KaitenError) -> [Components.Schemas.CardLocationHistory] {
+    guard
+      let response = try await callList({
+        try await client.get_card_location_history(path: .init(card_id: cardId))
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) { try $0.json }
+  }
+}
+
 // MARK: - Helpers
 
 extension Optional {

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -481,3 +481,71 @@ extension Operations.delete_card_blocker.Output {
     }
   }
 }
+
+// MARK: - Time Logs
+
+extension Operations.create_time_log.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.create_time_log.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.list_time_logs.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_time_logs.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+// MARK: - Card Types
+
+extension Operations.list_card_types.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_card_types.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+// MARK: - Sprints
+
+extension Operations.list_sprints.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_sprints.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+// MARK: - Card Location History
+
+extension Operations.get_card_location_history.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.get_card_location_history.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/CardTypeCommands.swift
+++ b/Sources/kaiten/CardTypeCommands.swift
@@ -1,0 +1,23 @@
+import ArgumentParser
+import KaitenSDK
+
+struct ListCardTypes: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-card-types",
+    abstract: "List card types"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Limit the number of card types returned (max 100)")
+  var limit: Int?
+
+  @Option(name: .long, help: "Offset for pagination")
+  var offset: Int?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let types = try await client.listCardTypes(limit: limit, offset: offset)
+    try printJSON(types)
+  }
+}

--- a/Sources/kaiten/HistoryCommands.swift
+++ b/Sources/kaiten/HistoryCommands.swift
@@ -1,0 +1,20 @@
+import ArgumentParser
+import KaitenSDK
+
+struct GetCardHistory: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "get-card-history",
+    abstract: "Get card location history"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let history = try await client.getCardLocationHistory(cardId: cardId)
+    try printJSON(history)
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -49,6 +49,11 @@ struct Kaiten: AsyncParsableCommand {
       CreateCardBlocker.self,
       UpdateCardBlocker.self,
       DeleteCardBlocker.self,
+      CreateTimeLog.self,
+      ListTimeLogs.self,
+      ListCardTypes.self,
+      ListSprints.self,
+      GetCardHistory.self,
     ]
   )
 }

--- a/Sources/kaiten/SprintCommands.swift
+++ b/Sources/kaiten/SprintCommands.swift
@@ -1,0 +1,27 @@
+import ArgumentParser
+import KaitenSDK
+
+struct ListSprints: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-sprints",
+    abstract: "List sprints"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Flag(name: .long, help: "Filter by active sprints")
+  var active: Bool = false
+
+  @Option(name: .long, help: "Limit the number of sprints returned (max 100)")
+  var limit: Int?
+
+  @Option(name: .long, help: "Offset for pagination")
+  var offset: Int?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let sprints = try await client.listSprints(
+      active: active ? true : nil, limit: limit, offset: offset)
+    try printJSON(sprints)
+  }
+}

--- a/Sources/kaiten/TimeLogCommands.swift
+++ b/Sources/kaiten/TimeLogCommands.swift
@@ -1,0 +1,58 @@
+import ArgumentParser
+import KaitenSDK
+
+struct CreateTimeLog: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "create-time-log",
+    abstract: "Create a time log on a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Role ID (-1 = Employee)")
+  var roleId: Int
+
+  @Option(name: .long, help: "Minutes to log")
+  var timeSpent: Int
+
+  @Option(name: .long, help: "Log date (YYYY-MM-DD)")
+  var forDate: String
+
+  @Option(name: .long, help: "Comment for time log")
+  var comment: String?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let timeLog = try await client.createTimeLog(
+      cardId: cardId, roleId: roleId, timeSpent: timeSpent, forDate: forDate, comment: comment)
+    try printJSON(timeLog)
+  }
+}
+
+struct ListTimeLogs: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-time-logs",
+    abstract: "List time logs for a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Filter by date (YYYY-MM-DD)")
+  var forDate: String?
+
+  @Flag(name: .long, help: "Filter time logs by current user")
+  var personal: Bool = false
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let timeLogs = try await client.listTimeLogs(
+      cardId: cardId, forDate: forDate, personal: personal ? true : nil)
+    try printJSON(timeLogs)
+  }
+}

--- a/Tests/KaitenSDKTests/CreateTimeLogTests.swift
+++ b/Tests/KaitenSDKTests/CreateTimeLogTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("CreateTimeLog")
+struct CreateTimeLogTests {
+
+  @Test("200 returns created time log")
+  func success() async throws {
+    let json = """
+      {"id": 1, "card_id": 42, "user_id": 10, "role_id": -1, "author_id": 10, "updater_id": 10, "time_spent": 60, "for_date": "2025-01-15", "comment": "Work done", "created": "2025-01-15T10:00:00Z", "updated": "2025-01-15T10:00:00Z"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let timeLog = try await client.createTimeLog(
+      cardId: 42, roleId: -1, timeSpent: 60, forDate: "2025-01-15", comment: "Work done")
+    #expect(timeLog.id == 1)
+    #expect(timeLog.time_spent == 60)
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createTimeLog(
+        cardId: 999, roleId: -1, timeSpent: 60, forDate: "2025-01-15")
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createTimeLog(
+        cardId: 42, roleId: -1, timeSpent: 60, forDate: "2025-01-15")
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/GetCardLocationHistoryTests.swift
+++ b/Tests/KaitenSDKTests/GetCardLocationHistoryTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("GetCardLocationHistory")
+struct GetCardLocationHistoryTests {
+
+  @Test("200 returns array of history entries")
+  func success() async throws {
+    let json = """
+      [{"id": 1, "card_id": 42, "board_id": 10, "column_id": 100, "subcolumn_id": null, "lane_id": 200, "sprint_id": null, "author_id": 5, "condition": 1, "changed": "2025-01-15T10:00:00Z"}]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let history = try await client.getCardLocationHistory(cardId: 42)
+    #expect(history.count == 1)
+    #expect(history[0].card_id == 42)
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.getCardLocationHistory(cardId: 999)
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.getCardLocationHistory(cardId: 42)
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/ListCardTypesTests.swift
+++ b/Tests/KaitenSDKTests/ListCardTypesTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("ListCardTypes")
+struct ListCardTypesTests {
+
+  @Test("200 returns array of card types")
+  func success() async throws {
+    let json = """
+      [{"id": 1, "name": "Epic", "letter": "E", "color": 11, "company_id": 1, "archived": false, "suggest_fields": true, "created": "2025-01-01T00:00:00Z", "updated": "2025-01-01T00:00:00Z"}]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let types = try await client.listCardTypes()
+    #expect(types.count == 1)
+    #expect(types[0].name == "Epic")
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCardTypes()
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/ListSprintsTests.swift
+++ b/Tests/KaitenSDKTests/ListSprintsTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("ListSprints")
+struct ListSprintsTests {
+
+  @Test("200 returns array of sprints")
+  func success() async throws {
+    let json = """
+      [{"id": 1, "board_id": 10, "title": "Sprint 1", "goal": null, "active": true, "committed": 5, "velocity": 21.0, "creator_id": 1, "updater_id": 1, "start_date": "2025-01-01", "finish_date": "2025-01-14", "actual_finish_date": null, "archived": false, "created": "2025-01-01T00:00:00Z", "updated": "2025-01-01T00:00:00Z"}]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let sprints = try await client.listSprints()
+    #expect(sprints.count == 1)
+    #expect(sprints[0].title == "Sprint 1")
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listSprints()
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/ListTimeLogsTests.swift
+++ b/Tests/KaitenSDKTests/ListTimeLogsTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("ListTimeLogs")
+struct ListTimeLogsTests {
+
+  @Test("200 returns array of time logs")
+  func success() async throws {
+    let json = """
+      [{"id": 1, "card_id": 42, "user_id": 10, "role_id": -1, "author_id": 10, "updater_id": 10, "time_spent": 60, "for_date": "2025-01-15", "comment": null, "created": "2025-01-15T10:00:00Z", "updated": "2025-01-15T10:00:00Z"}]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let timeLogs = try await client.listTimeLogs(cardId: 42)
+    #expect(timeLogs.count == 1)
+    #expect(timeLogs[0].time_spent == 60)
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listTimeLogs(cardId: 999)
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listTimeLogs(cardId: 42)
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -1419,6 +1419,158 @@ paths:
                 $ref: '#/components/schemas/User'
         '401':
           description: Invalid token
+  /cards/{card_id}/time-logs:
+    get:
+      summary: List time logs for a card
+      operationId: list_time_logs
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      - name: for_date
+        in: query
+        schema:
+          type: string
+        description: Filter by date (YYYY-MM-DD)
+      - name: personal
+        in: query
+        schema:
+          type: boolean
+        description: Filter time logs by current user
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TimeLog'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    post:
+      summary: Create a time log on a card
+      operationId: create_time_log
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTimeLogRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TimeLog'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+  /cards/{card_id}/location-history:
+    get:
+      summary: Get card location history
+      operationId: get_card_location_history
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CardLocationHistory'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+  /card-types:
+    get:
+      summary: List card types
+      operationId: list_card_types
+      parameters:
+      - name: limit
+        in: query
+        schema:
+          type: integer
+        description: Maximum amount of types in response (max 100)
+      - name: offset
+        in: query
+        schema:
+          type: integer
+        description: Number of records to skip
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CardType'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+  /sprints:
+    get:
+      summary: List sprints
+      operationId: list_sprints
+      parameters:
+      - name: active
+        in: query
+        schema:
+          type: boolean
+        description: Filter by sprint active status
+      - name: limit
+        in: query
+        schema:
+          type: integer
+        description: Maximum amount of sprints (max 100)
+      - name: offset
+        in: query
+        schema:
+          type: integer
+        description: Number of records to skip
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Sprint'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
 components:
   securitySchemes:
     bearerAuth:
@@ -3373,3 +3525,151 @@ components:
         blocker_card_id:
           type: integer
           description: Blocker card ID
+    TimeLog:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Time log ID
+        card_id:
+          type: integer
+          description: Card ID
+        user_id:
+          type: integer
+          description: User ID
+        role_id:
+          type: integer
+          description: Role ID (-1 = Employee)
+        author_id:
+          type: integer
+          description: Author ID
+        updater_id:
+          type: integer
+          description: Last updater ID
+        time_spent:
+          type: integer
+          description: Minutes logged
+        for_date:
+          type: string
+          description: Log date (YYYY-MM-DD)
+        comment:
+          type:
+          - string
+          - 'null'
+          description: Time log comment
+        created:
+          type: string
+          description: Create date
+        updated:
+          type: string
+          description: Last update timestamp
+    CreateTimeLogRequest:
+      type: object
+      required:
+      - role_id
+      - time_spent
+      - for_date
+      properties:
+        role_id:
+          type: integer
+          description: Role ID (-1 = Employee)
+        time_spent:
+          type: integer
+          minimum: 1
+          description: Minutes to log
+        for_date:
+          type: string
+          description: Log date (YYYY-MM-DD)
+        comment:
+          type: string
+          maxLength: 4096
+          description: Comment for time log
+    CardLocationHistory:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Movement event ID
+        card_id:
+          type: integer
+          description: Card ID
+        board_id:
+          type: integer
+          description: Board ID
+        column_id:
+          type: integer
+          description: Column ID
+        subcolumn_id:
+          type:
+          - integer
+          - 'null'
+          description: Subcolumn ID
+        lane_id:
+          type: integer
+          description: Lane ID
+        sprint_id:
+          type:
+          - integer
+          - 'null'
+          description: Sprint ID
+        author_id:
+          type: integer
+          description: Author user ID
+        condition:
+          type: integer
+          description: 1 = Active, 2 = Archived, 3 = Deleted
+        changed:
+          type: string
+          description: Movement event timestamp
+    Sprint:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Sprint ID
+        board_id:
+          type: integer
+          description: Board ID
+        title:
+          type: string
+          description: Sprint title
+        goal:
+          type:
+          - string
+          - 'null'
+          description: Sprint goal
+        active:
+          type: boolean
+          description: Sprint active status
+        committed:
+          type: integer
+          description: Number of committed cards
+        velocity:
+          type: number
+          description: Sprint velocity
+        creator_id:
+          type: integer
+          description: Creator user ID
+        updater_id:
+          type: integer
+          description: Last updater user ID
+        start_date:
+          type: string
+          description: Sprint start date
+        finish_date:
+          type: string
+          description: Sprint planned finish date
+        actual_finish_date:
+          type:
+          - string
+          - 'null'
+          description: Sprint actual finish date
+        archived:
+          type: boolean
+          description: Archived flag
+        created:
+          type: string
+          description: Creation timestamp
+        updated:
+          type: string
+          description: Last update timestamp


### PR DESCRIPTION
Closes #225, closes #226, closes #227, closes #228, closes #229

## Changes
- **Time Logs**: `POST /cards/{card_id}/time-logs` (create) and `GET /cards/{card_id}/time-logs` (list)
- **Card Types**: `GET /card-types` (list)
- **Sprints**: `GET /sprints` (list)
- **Card Location History**: `GET /cards/{card_id}/location-history`

New CLI commands: `create-time-log`, `list-time-logs`, `list-card-types`, `list-sprints`, `get-card-history`
Tests for all endpoints.