### PR TITLE
feat: add card blocker endpoints (#214, #215, #216, #217)

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -1337,6 +1337,70 @@ extension KaitenClient {
   }
 }
 
+// MARK: - Card Blockers
+
+extension KaitenClient {
+  /// Lists all blockers on a card.
+  public func listCardBlockers(cardId: Int) async throws(KaitenError) -> [Components.Schemas
+    .CardBlocker]
+  {
+    guard
+      let response = try await callList({
+        try await client.list_card_blockers(path: .init(card_id: cardId))
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) {
+      try $0.json
+    }
+  }
+
+  /// Creates a blocker on a card.
+  public func createCardBlocker(cardId: Int, reason: String? = nil, blockerCardId: Int? = nil)
+    async throws(KaitenError) -> Components.Schemas.CardBlocker
+  {
+    let response = try await call {
+      try await client.create_card_blocker(
+        path: .init(card_id: cardId),
+        body: .json(.init(reason: reason, blocker_card_id: blockerCardId))
+      )
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) {
+      try $0.json
+    }
+  }
+
+  /// Updates a card blocker.
+  public func updateCardBlocker(
+    cardId: Int, blockerId: Int, reason: String? = nil, blockerCardId: Int? = nil
+  ) async throws(KaitenError) -> Components.Schemas.CardBlocker {
+    let response = try await call {
+      try await client.update_card_blocker(
+        path: .init(card_id: cardId, id: blockerId),
+        body: .json(.init(reason: reason, blocker_card_id: blockerCardId))
+      )
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("blocker", blockerId)) {
+      try $0.json
+    }
+  }
+
+  /// Deletes a card blocker.
+  public func deleteCardBlocker(cardId: Int, blockerId: Int) async throws(KaitenError)
+    -> Components.Schemas.CardBlocker
+  {
+    let response = try await call {
+      try await client.delete_card_blocker(
+        path: .init(card_id: cardId, id: blockerId)
+      )
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("blocker", blockerId)) {
+      try $0.json
+    }
+  }
+}
+
 // MARK: - Helpers
 
 extension Optional {

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -431,3 +431,53 @@ extension Operations.retrieve_current_user.Output {
     }
   }
 }
+
+// MARK: - Card Blockers
+
+extension Operations.list_card_blockers.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_card_blockers.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.create_card_blocker.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.create_card_blocker.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.update_card_blocker.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.update_card_blocker.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.delete_card_blocker.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.delete_card_blocker.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/BlockerCommands.swift
+++ b/Sources/kaiten/BlockerCommands.swift
@@ -1,0 +1,103 @@
+import ArgumentParser
+import Foundation
+import KaitenSDK
+
+// MARK: - List Card Blockers
+
+struct ListCardBlockers: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-card-blockers",
+    abstract: "List blockers on a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let blockers = try await client.listCardBlockers(cardId: cardId)
+    try printJSON(blockers)
+  }
+}
+
+// MARK: - Create Card Blocker
+
+struct CreateCardBlocker: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "create-card-blocker",
+    abstract: "Create a blocker on a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Block reason")
+  var reason: String?
+
+  @Option(name: .long, help: "Blocker card ID")
+  var blockerCardId: Int?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let blocker = try await client.createCardBlocker(
+      cardId: cardId, reason: reason, blockerCardId: blockerCardId)
+    try printJSON(blocker)
+  }
+}
+
+// MARK: - Update Card Blocker
+
+struct UpdateCardBlocker: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "update-card-blocker",
+    abstract: "Update a card blocker"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Blocker ID")
+  var blockerId: Int
+
+  @Option(name: .long, help: "Block reason")
+  var reason: String?
+
+  @Option(name: .long, help: "Blocker card ID")
+  var blockerCardId: Int?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let blocker = try await client.updateCardBlocker(
+      cardId: cardId, blockerId: blockerId, reason: reason, blockerCardId: blockerCardId)
+    try printJSON(blocker)
+  }
+}
+
+// MARK: - Delete Card Blocker
+
+struct DeleteCardBlocker: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "delete-card-blocker",
+    abstract: "Delete a card blocker"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Blocker ID")
+  var blockerId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let blocker = try await client.deleteCardBlocker(cardId: cardId, blockerId: blockerId)
+    try printJSON(blocker)
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -45,6 +45,10 @@ struct Kaiten: AsyncParsableCommand {
       ListCardChildren.self,
       AddCardChild.self,
       RemoveCardChild.self,
+      ListCardBlockers.self,
+      CreateCardBlocker.self,
+      UpdateCardBlocker.self,
+      DeleteCardBlocker.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/CreateCardBlockerTests.swift
+++ b/Tests/KaitenSDKTests/CreateCardBlockerTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("CreateCardBlocker")
+struct CreateCardBlockerTests {
+
+  @Test("200 returns created CardBlocker")
+  func success() async throws {
+    let json = """
+      {"id": 10, "reason": "Blocked by dependency", "card_id": 42, "blocker_id": 5, "released": false}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let blocker = try await client.createCardBlocker(cardId: 42, reason: "Blocked by dependency")
+    #expect(blocker.id == 10)
+    #expect(blocker.reason == "Blocked by dependency")
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createCardBlocker(cardId: 999, reason: "test")
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createCardBlocker(cardId: 1, reason: "test")
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/DeleteCardBlockerTests.swift
+++ b/Tests/KaitenSDKTests/DeleteCardBlockerTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("DeleteCardBlocker")
+struct DeleteCardBlockerTests {
+
+  @Test("200 returns deleted CardBlocker")
+  func success() async throws {
+    let json = """
+      {"id": 10, "reason": "Old blocker", "card_id": 42, "blocker_id": 5, "released": true}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let blocker = try await client.deleteCardBlocker(cardId: 42, blockerId: 10)
+    #expect(blocker.id == 10)
+    #expect(blocker.released == true)
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.deleteCardBlocker(cardId: 42, blockerId: 999)
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.deleteCardBlocker(cardId: 1, blockerId: 1)
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/ListCardBlockersTests.swift
+++ b/Tests/KaitenSDKTests/ListCardBlockersTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("ListCardBlockers")
+struct ListCardBlockersTests {
+
+  @Test("200 returns array of CardBlocker")
+  func success() async throws {
+    let json = """
+      [{"id": 1, "reason": "Waiting for design", "card_id": 42, "blocker_id": 5, "released": false}]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let blockers = try await client.listCardBlockers(cardId: 42)
+    #expect(blockers.count == 1)
+    #expect(blockers[0].reason == "Waiting for design")
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCardBlockers(cardId: 999)
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCardBlockers(cardId: 1)
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/UpdateCardBlockerTests.swift
+++ b/Tests/KaitenSDKTests/UpdateCardBlockerTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("UpdateCardBlocker")
+struct UpdateCardBlockerTests {
+
+  @Test("200 returns updated CardBlocker")
+  func success() async throws {
+    let json = """
+      {"id": 10, "reason": "Updated reason", "card_id": 42, "blocker_id": 5, "released": false}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let blocker = try await client.updateCardBlocker(
+      cardId: 42, blockerId: 10, reason: "Updated reason")
+    #expect(blocker.id == 10)
+    #expect(blocker.reason == "Updated reason")
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.updateCardBlocker(cardId: 42, blockerId: 999, reason: "test")
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.updateCardBlocker(cardId: 1, blockerId: 1, reason: "test")
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -1105,6 +1105,126 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /cards/{card_id}/blockers:
+    get:
+      summary: List card blockers
+      operationId: list_card_blockers
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CardBlocker'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    post:
+      summary: Create card blocker
+      operationId: create_card_blocker
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCardBlockerRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CardBlocker'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+  /cards/{card_id}/blockers/{id}:
+    patch:
+      summary: Update card blocker
+      operationId: update_card_blocker
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Blocker ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateCardBlockerRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CardBlocker'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    delete:
+      summary: Delete card blocker
+      operationId: delete_card_blocker
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Blocker ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CardBlocker'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
   /company/custom-properties:
     get:
       summary: Get list of properties
@@ -3186,3 +3306,70 @@ components:
         id:
           type: integer
           description: Deleted card child ID
+    CardBlocker:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Blocker ID
+        reason:
+          type: string
+          description: Block reason
+        card_id:
+          type: integer
+          description: Blocked card ID
+        blocker_id:
+          type: integer
+          description: User ID who blocked card
+        blocker_card_id:
+          type:
+          - string
+          - 'null'
+          description: ID of blocking card
+        blocker_card_title:
+          type:
+          - string
+          - 'null'
+          description: Title of blocking card
+        released:
+          type: boolean
+          description: Is block released
+        released_by_id:
+          type: integer
+          description: ID of user who released block
+        due_date:
+          type:
+          - string
+          - 'null'
+          description: Block deadline
+        due_date_time_present:
+          type: boolean
+          description: Deadline has time component
+        created:
+          type: string
+          description: Create date
+        updated:
+          type: string
+          description: Last update timestamp
+    CreateCardBlockerRequest:
+      type: object
+      properties:
+        reason:
+          type: string
+          minLength: 1
+          maxLength: 4096
+          description: Block reason
+        blocker_card_id:
+          type: integer
+          description: Blocker card ID
+    UpdateCardBlockerRequest:
+      type: object
+      properties:
+        reason:
+          type: string
+          minLength: 1
+          maxLength: 4096
+          description: Block reason
+        blocker_card_id:
+          type: integer
+          description: Blocker card ID


### PR DESCRIPTION
Closes #214, closes #215, closes #216, closes #217

Adds CRUD endpoints for card blockers:
- `POST /cards/{card_id}/blockers` — create card blocker
- `GET /cards/{card_id}/blockers` — list card blockers
- `PATCH /cards/{card_id}/blockers/{id}` — update card blocker
- `DELETE /cards/{card_id}/blockers/{id}` — delete card blocker

Includes CardBlocker schema, KaitenClient methods, CLI commands, and tests.