### PR TITLE
feat: add external link endpoints (#221, #222, #223, #224)

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -1490,6 +1490,65 @@ extension KaitenClient {
   }
 }
 
+// MARK: - External Links
+
+extension KaitenClient {
+  /// Lists all external links on a card.
+  public func listExternalLinks(cardId: Int) async throws(KaitenError) -> [Components.Schemas
+    .ExternalLink]
+  {
+    guard
+      let response = try await callList({
+        try await client.list_card_external_links(path: .init(card_id: cardId))
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) { try $0.json }
+  }
+
+  /// Creates an external link on a card.
+  public func createExternalLink(cardId: Int, url: String, description: String? = nil)
+    async throws(KaitenError) -> Components.Schemas.ExternalLink
+  {
+    let response = try await call {
+      try await client.create_card_external_link(
+        path: .init(card_id: cardId),
+        body: .json(.init(url: url, description: description))
+      )
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) { try $0.json }
+  }
+
+  /// Updates an external link on a card.
+  public func updateExternalLink(
+    cardId: Int, linkId: Int, url: String? = nil, description: String? = nil
+  )
+    async throws(KaitenError) -> Components.Schemas.ExternalLink
+  {
+    let response = try await call {
+      try await client.update_card_external_link(
+        path: .init(card_id: cardId, id: linkId),
+        body: .json(.init(url: url, description: description))
+      )
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("externalLink", linkId)) {
+      try $0.json
+    }
+  }
+
+  /// Removes an external link from a card.
+  public func removeExternalLink(cardId: Int, linkId: Int) async throws(KaitenError) -> Int {
+    let response = try await call {
+      try await client.remove_card_external_link(path: .init(card_id: cardId, id: linkId))
+    }
+    let result: Components.Schemas.DeletedExternalLinkResponse = try decodeResponse(
+      response.toCase(), notFoundResource: ("externalLink", linkId)
+    ) { try $0.json }
+    return result.id!
+  }
+}
+
 // MARK: - Helpers
 
 extension Optional {

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -534,6 +534,64 @@ extension Operations.list_sprints.Output {
   }
 }
 
+// MARK: - External Links
+
+extension Operations.list_card_external_links.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.list_card_external_links.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.create_card_external_link.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.create_card_external_link.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.update_card_external_link.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.update_card_external_link.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.remove_card_external_link.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.remove_card_external_link.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
 // MARK: - Card Location History
 
 extension Operations.get_card_location_history.Output {

--- a/Sources/kaiten/ExternalLinkCommands.swift
+++ b/Sources/kaiten/ExternalLinkCommands.swift
@@ -1,0 +1,103 @@
+import ArgumentParser
+import Foundation
+import KaitenSDK
+
+// MARK: - List External Links
+
+struct ListExternalLinks: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-external-links",
+    abstract: "List external links on a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let links = try await client.listExternalLinks(cardId: cardId)
+    try printJSON(links)
+  }
+}
+
+// MARK: - Create External Link
+
+struct CreateExternalLink: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "create-external-link",
+    abstract: "Add an external link to a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "URL")
+  var url: String
+
+  @Option(name: .long, help: "Description")
+  var description: String?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let link = try await client.createExternalLink(
+      cardId: cardId, url: url, description: description)
+    try printJSON(link)
+  }
+}
+
+// MARK: - Update External Link
+
+struct UpdateExternalLink: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "update-external-link",
+    abstract: "Update an external link on a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "External link ID")
+  var linkId: Int
+
+  @Option(name: .long, help: "URL")
+  var url: String?
+
+  @Option(name: .long, help: "Description")
+  var description: String?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let link = try await client.updateExternalLink(
+      cardId: cardId, linkId: linkId, url: url, description: description)
+    try printJSON(link)
+  }
+}
+
+// MARK: - Remove External Link
+
+struct RemoveExternalLink: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "remove-external-link",
+    abstract: "Remove an external link from a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "External link ID")
+  var linkId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let deletedId = try await client.removeExternalLink(cardId: cardId, linkId: linkId)
+    try printJSON(["id": deletedId])
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -54,6 +54,10 @@ struct Kaiten: AsyncParsableCommand {
       ListCardTypes.self,
       ListSprints.self,
       GetCardHistory.self,
+      ListExternalLinks.self,
+      CreateExternalLink.self,
+      UpdateExternalLink.self,
+      RemoveExternalLink.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/CreateExternalLinkTests.swift
+++ b/Tests/KaitenSDKTests/CreateExternalLinkTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("CreateExternalLink")
+struct CreateExternalLinkTests {
+
+  @Test("200 returns ExternalLink")
+  func success() async throws {
+    let json = """
+      {"id": 5, "url": "https://example.com", "description": "Example", "card_id": 42, "external_link_id": 5, "created": "2025-01-01", "updated": "2025-01-01"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let link = try await client.createExternalLink(
+      cardId: 42, url: "https://example.com", description: "Example")
+    #expect(link.id == 5)
+    #expect(link.url == "https://example.com")
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createExternalLink(cardId: 999, url: "https://example.com")
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createExternalLink(cardId: 1, url: "https://example.com")
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/ListExternalLinksTests.swift
+++ b/Tests/KaitenSDKTests/ListExternalLinksTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("ListExternalLinks")
+struct ListExternalLinksTests {
+
+  @Test("200 returns array of ExternalLink")
+  func success() async throws {
+    let json = """
+      [{"id": 5, "url": "https://example.com", "description": "Example", "card_id": 42, "external_link_id": 5, "created": "2025-01-01", "updated": "2025-01-01"}]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let links = try await client.listExternalLinks(cardId: 42)
+    #expect(links.count == 1)
+    #expect(links[0].id == 5)
+  }
+
+  @Test("200 empty body returns empty array")
+  func emptyBody() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "")
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let links = try await client.listExternalLinks(cardId: 42)
+    #expect(links.isEmpty)
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listExternalLinks(cardId: 1)
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/RemoveExternalLinkTests.swift
+++ b/Tests/KaitenSDKTests/RemoveExternalLinkTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("RemoveExternalLink")
+struct RemoveExternalLinkTests {
+
+  @Test("200 returns deleted ID")
+  func success() async throws {
+    let json = """
+      {"id": 5}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let deletedId = try await client.removeExternalLink(cardId: 42, linkId: 5)
+    #expect(deletedId == 5)
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.removeExternalLink(cardId: 42, linkId: 999)
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.removeExternalLink(cardId: 1, linkId: 1)
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/UpdateExternalLinkTests.swift
+++ b/Tests/KaitenSDKTests/UpdateExternalLinkTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("UpdateExternalLink")
+struct UpdateExternalLinkTests {
+
+  @Test("200 returns updated ExternalLink")
+  func success() async throws {
+    let json = """
+      {"id": 5, "url": "https://updated.com", "description": "Updated", "card_id": 42, "external_link_id": 5, "created": "2025-01-01", "updated": "2025-01-02"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let link = try await client.updateExternalLink(
+      cardId: 42, linkId: 5, url: "https://updated.com")
+    #expect(link.id == 5)
+    #expect(link.url == "https://updated.com")
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.updateExternalLink(cardId: 42, linkId: 999, url: "https://example.com")
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.updateExternalLink(cardId: 1, linkId: 1, url: "https://example.com")
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -1510,6 +1510,126 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /cards/{card_id}/external-links:
+    get:
+      summary: Retrieve card external links
+      operationId: list_card_external_links
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ExternalLink'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    post:
+      summary: Add external link to card
+      operationId: create_card_external_link
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateExternalLinkRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalLink'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+  /cards/{card_id}/external-links/{id}:
+    patch:
+      summary: Update external link
+      operationId: update_card_external_link
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: External link ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateExternalLinkRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalLink'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    delete:
+      summary: Remove external link from card
+      operationId: remove_card_external_link
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: External link ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeletedExternalLinkResponse'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
   /card-types:
     get:
       summary: List card types
@@ -3458,6 +3578,42 @@ components:
         id:
           type: integer
           description: Deleted card child ID
+    CreateExternalLinkRequest:
+      type: object
+      required:
+      - url
+      properties:
+        url:
+          type: string
+          description: URL
+          minLength: 1
+          maxLength: 16384
+        description:
+          type:
+          - string
+          - 'null'
+          description: Description
+          maxLength: 512
+    UpdateExternalLinkRequest:
+      type: object
+      properties:
+        url:
+          type: string
+          description: URL
+          minLength: 1
+          maxLength: 16384
+        description:
+          type:
+          - string
+          - 'null'
+          description: Description
+          maxLength: 512
+    DeletedExternalLinkResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Deleted external link ID
     CardBlocker:
       type: object
       properties:


### PR DESCRIPTION
Add CRUD endpoints for card external links.

## Changes
- **OpenAPI spec**: Added 4 endpoints under `/cards/{card_id}/external-links` (GET, POST, PATCH, DELETE) with request/response schemas
- **KaitenClient**: Added `listExternalLinks`, `createExternalLink`, `updateExternalLink`, `removeExternalLink` methods
- **ResponseMapping**: Added `toCase()` extensions for all 4 operations
- **CLI**: Added `list-external-links`, `create-external-link`, `update-external-link`, `remove-external-link` commands
- **Tests**: Added test suites for all 4 endpoints

Closes #221, closes #222, closes #223, closes #224