### PR TITLE
fix: rename config directory from kaiten-mcp to kaiten

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Get your API token at `https://<your-company>.kaiten.ru/profile/api-key`.
 
 **Option 1 — Config file** (recommended):
 
-Create `~/.config/kaiten-mcp/config.json`:
+Create `~/.config/kaiten/config.json`:
 
 ```json
 {
@@ -219,7 +219,7 @@ kaiten list-spaces \
 
 ## Configuration
 
-The CLI and MCP server share the same config file at `~/.config/kaiten-mcp/config.json` (see [Configure Credentials](#2-configure-credentials) above).
+The CLI and MCP server share the same config file at `~/.config/kaiten/config.json` (see [Configure Credentials](#2-configure-credentials) above).
 
 The `--url` and `--token` CLI flags take priority over the config file.
 

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -113,7 +113,7 @@ struct GlobalOptions: ParsableArguments {
 
   private static var configPath: String {
     let home = FileManager.default.homeDirectoryForCurrentUser
-    return home.appendingPathComponent(".config/kaiten-mcp/config.json").path
+    return home.appendingPathComponent(".config/kaiten/config.json").path
   }
 }
 

--- a/docs/kaiten-docs-parsing.md
+++ b/docs/kaiten-docs-parsing.md
@@ -212,8 +212,8 @@ if (dialog) {
 After parsing docs, **always verify with a real API request**:
 
 ```bash
-URL=$(jq -r .url ~/.config/kaiten-mcp/config.json)
-TOKEN=$(jq -r .token ~/.config/kaiten-mcp/config.json)
+URL=$(jq -r .url ~/.config/kaiten/config.json)
+TOKEN=$(jq -r .token ~/.config/kaiten/config.json)
 
 curl -s -H "Authorization: Bearer $TOKEN" \
     "$URL/cards/47271507/checklists/12345" | python3 -m json.tool

--- a/specs/002-kaiten-cli/spec.md
+++ b/specs/002-kaiten-cli/spec.md
@@ -27,7 +27,7 @@ stdout confirms it works.
    user runs a subcommand (e.g. `list-spaces`), **Then** the
    CLI outputs structured data to stdout.
 2. **Given** a valid config file exists at
-   `~/.config/kaiten-mcp/config.json`, **When** the user runs
+   `~/.config/kaiten/config.json`, **When** the user runs
    a subcommand without flags, **Then** the CLI reads parameters
    from the config file.
 3. **Given** both flags and a config file with different values
@@ -51,7 +51,7 @@ stdout confirms it works.
   MUST output an error describing the configuration problem.
 - What if the config file does not exist and no flags are passed?
   The CLI MUST output an error with instructions: pass flags or
-  create `~/.config/kaiten-mcp/config.json`.
+  create `~/.config/kaiten/config.json`.
 
 ## Requirements *(mandatory)*
 
@@ -72,7 +72,7 @@ stdout confirms it works.
 - **FR-006**: The CLI MUST compile and run on macOS (ARM) and
   Linux (x86-64 and ARM).
 - **FR-007**: Configuration is stored in two files in a shared
-  directory `~/.config/kaiten-mcp/` (all platforms):
+  directory `~/.config/kaiten/` (all platforms):
   - **`config.json`** — connection settings (url, token):
     ```json
     {


### PR DESCRIPTION
## Summary

Rename the shared config directory from `~/.config/kaiten-mcp/` to `~/.config/kaiten/` (drop the `-mcp` suffix).

## Changes
- **Sources/kaiten/Kaiten.swift** — update `configPath`
- **README.md** — update all config path references
- **specs/002-kaiten-cli/spec.md** — update 3 config path references
- **docs/kaiten-docs-parsing.md** — update shell examples

Closes #250