### PR TITLE
Add tests for CRUD endpoints: Spaces, Boards, Columns, Lanes, Subcolumns, Baselines, Sprint Summary

### DIFF
--- a/Tests/KaitenSDKTests/BoardsCRUDTests.swift
+++ b/Tests/KaitenSDKTests/BoardsCRUDTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Boards CRUD")
+struct BoardsCRUDTests {
+
+  // MARK: - createBoard
+
+  @Test("createBoard 200 returns created Board")
+  func createBoardSuccess() async throws {
+    let json = """
+      {"id": 10, "title": "Sprint Board", "space_id": 1}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let board = try await client.createBoard(spaceId: 1, title: "Sprint Board")
+    #expect(board.id == 10)
+    #expect(board.title == "Sprint Board")
+  }
+
+  @Test("createBoard 401 throws unauthorized")
+  func createBoardUnauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createBoard(spaceId: 1, title: "Test")
+    }
+  }
+
+  @Test("createBoard 404 throws notFound (space not found)")
+  func createBoardSpaceNotFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createBoard(spaceId: 999, title: "Test")
+    }
+  }
+
+  // MARK: - updateBoard
+
+  @Test("updateBoard 200 returns updated Board")
+  func updateBoardSuccess() async throws {
+    let json = """
+      {"id": 10, "title": "Renamed Board", "space_id": 1}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let board = try await client.updateBoard(spaceId: 1, id: 10, title: "Renamed Board")
+    #expect(board.id == 10)
+    #expect(board.title == "Renamed Board")
+  }
+
+  @Test("updateBoard 404 throws notFound")
+  func updateBoardNotFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.updateBoard(spaceId: 1, id: 999, title: "Test")
+    }
+  }
+
+  // MARK: - deleteBoard
+
+  @Test("deleteBoard 200 returns deleted id")
+  func deleteBoardSuccess() async throws {
+    let json = """
+      {"id": 10}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let deletedId = try await client.deleteBoard(spaceId: 1, id: 10)
+    #expect(deletedId == 10)
+  }
+
+  @Test("deleteBoard 404 throws notFound")
+  func deleteBoardNotFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.deleteBoard(spaceId: 1, id: 999)
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/CardBaselinesTests.swift
+++ b/Tests/KaitenSDKTests/CardBaselinesTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Card Baselines")
+struct CardBaselinesTests {
+
+  @Test("getCardBaselines 200 returns array")
+  func success() async throws {
+    let json = """
+      [{"id": 1, "card_id": 123}]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let baselines = try await client.getCardBaselines(cardId: 123)
+    #expect(baselines.count == 1)
+  }
+
+  @Test("getCardBaselines 200 empty body returns empty array")
+  func emptyBody() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: nil)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let baselines = try await client.getCardBaselines(cardId: 123)
+    #expect(baselines.isEmpty)
+  }
+
+  @Test("getCardBaselines 401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.getCardBaselines(cardId: 123)
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/ColumnsCRUDTests.swift
+++ b/Tests/KaitenSDKTests/ColumnsCRUDTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Columns CRUD")
+struct ColumnsCRUDTests {
+
+  // MARK: - createColumn
+
+  @Test("createColumn 200 returns created Column")
+  func createColumnSuccess() async throws {
+    let json = """
+      {"id": 100, "title": "To Do", "board_id": 10}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let column = try await client.createColumn(boardId: 10, title: "To Do")
+    #expect(column.id == 100)
+    #expect(column.title == "To Do")
+  }
+
+  @Test("createColumn 401 throws unauthorized")
+  func createColumnUnauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createColumn(boardId: 10, title: "Test")
+    }
+  }
+
+  @Test("createColumn 404 throws notFound (board not found)")
+  func createColumnBoardNotFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createColumn(boardId: 999, title: "Test")
+    }
+  }
+
+  // MARK: - updateColumn
+
+  @Test("updateColumn 200 returns updated Column")
+  func updateColumnSuccess() async throws {
+    let json = """
+      {"id": 100, "title": "In Progress", "board_id": 10}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let column = try await client.updateColumn(boardId: 10, id: 100, title: "In Progress")
+    #expect(column.id == 100)
+    #expect(column.title == "In Progress")
+  }
+
+  @Test("updateColumn 404 throws notFound")
+  func updateColumnNotFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.updateColumn(boardId: 10, id: 999, title: "Test")
+    }
+  }
+
+  // MARK: - deleteColumn
+
+  @Test("deleteColumn 200 returns deleted id")
+  func deleteColumnSuccess() async throws {
+    let json = """
+      {"id": 100}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let deletedId = try await client.deleteColumn(boardId: 10, id: 100)
+    #expect(deletedId == 100)
+  }
+
+  @Test("deleteColumn 404 throws notFound")
+  func deleteColumnNotFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.deleteColumn(boardId: 10, id: 999)
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/LanesCRUDTests.swift
+++ b/Tests/KaitenSDKTests/LanesCRUDTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Lanes CRUD")
+struct LanesCRUDTests {
+
+  // MARK: - createLane
+
+  @Test("createLane 200 returns created Lane")
+  func createLaneSuccess() async throws {
+    let json = """
+      {"id": 200, "title": "Default Lane", "board_id": 10}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let lane = try await client.createLane(boardId: 10, title: "Default Lane")
+    #expect(lane.id == 200)
+    #expect(lane.title == "Default Lane")
+  }
+
+  @Test("createLane 401 throws unauthorized")
+  func createLaneUnauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createLane(boardId: 10, title: "Test")
+    }
+  }
+
+  @Test("createLane 404 throws notFound (board not found)")
+  func createLaneBoardNotFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createLane(boardId: 999, title: "Test")
+    }
+  }
+
+  // MARK: - updateLane
+
+  @Test("updateLane 200 returns updated Lane")
+  func updateLaneSuccess() async throws {
+    let json = """
+      {"id": 200, "title": "Urgent Lane", "board_id": 10}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let lane = try await client.updateLane(boardId: 10, id: 200, title: "Urgent Lane")
+    #expect(lane.id == 200)
+    #expect(lane.title == "Urgent Lane")
+  }
+
+  @Test("updateLane 404 throws notFound")
+  func updateLaneNotFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.updateLane(boardId: 10, id: 999, title: "Test")
+    }
+  }
+
+  // MARK: - deleteLane
+
+  @Test("deleteLane 200 returns deleted id")
+  func deleteLaneSuccess() async throws {
+    let json = """
+      {"id": 200}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let deletedId = try await client.deleteLane(boardId: 10, id: 200)
+    #expect(deletedId == 200)
+  }
+
+  @Test("deleteLane 404 throws notFound")
+  func deleteLaneNotFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.deleteLane(boardId: 10, id: 999)
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/SpacesCRUDTests.swift
+++ b/Tests/KaitenSDKTests/SpacesCRUDTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Spaces CRUD")
+struct SpacesCRUDTests {
+
+  // MARK: - getSpace
+
+  @Test("getSpace 200 returns Space")
+  func getSpaceSuccess() async throws {
+    let json = """
+      {"id": 1, "title": "My Space"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let space = try await client.getSpace(id: 1)
+    #expect(space.id == 1)
+    #expect(space.title == "My Space")
+  }
+
+  @Test("getSpace 404 throws notFound")
+  func getSpaceNotFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.getSpace(id: 999)
+    }
+  }
+
+  @Test("getSpace 401 throws unauthorized")
+  func getSpaceUnauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.getSpace(id: 1)
+    }
+  }
+
+  // MARK: - createSpace
+
+  @Test("createSpace 200 returns created Space")
+  func createSpaceSuccess() async throws {
+    let json = """
+      {"id": 2, "title": "New Space"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let space = try await client.createSpace(title: "New Space")
+    #expect(space.id == 2)
+    #expect(space.title == "New Space")
+  }
+
+  @Test("createSpace 401 throws unauthorized")
+  func createSpaceUnauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createSpace(title: "Test")
+    }
+  }
+
+  @Test("createSpace 403 throws error")
+  func createSpaceForbidden() async throws {
+    let transport = MockClientTransport.returning(statusCode: 403)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createSpace(title: "Test")
+    }
+  }
+
+  // MARK: - updateSpace
+
+  @Test("updateSpace 200 returns updated Space")
+  func updateSpaceSuccess() async throws {
+    let json = """
+      {"id": 1, "title": "Updated Space"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let space = try await client.updateSpace(id: 1, title: "Updated Space")
+    #expect(space.id == 1)
+    #expect(space.title == "Updated Space")
+  }
+
+  @Test("updateSpace 404 throws notFound")
+  func updateSpaceNotFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.updateSpace(id: 999, title: "Test")
+    }
+  }
+
+  // MARK: - deleteSpace
+
+  @Test("deleteSpace 200 returns deleted id")
+  func deleteSpaceSuccess() async throws {
+    let json = """
+      {"id": 1}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let deletedId = try await client.deleteSpace(id: 1)
+    #expect(deletedId == 1)
+  }
+
+  @Test("deleteSpace 404 throws notFound")
+  func deleteSpaceNotFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.deleteSpace(id: 999)
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/SprintSummaryTests.swift
+++ b/Tests/KaitenSDKTests/SprintSummaryTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Sprint Summary")
+struct SprintSummaryTests {
+
+  @Test("getSprintSummary 200 returns summary")
+  func success() async throws {
+    let json = """
+      {"id": 5, "title": "Sprint 5"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let summary = try await client.getSprintSummary(id: 5)
+    #expect(summary.id == 5)
+  }
+
+  @Test("getSprintSummary 404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.getSprintSummary(id: 999)
+    }
+  }
+
+  @Test("getSprintSummary 401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.getSprintSummary(id: 5)
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/SubcolumnsCRUDTests.swift
+++ b/Tests/KaitenSDKTests/SubcolumnsCRUDTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Subcolumns CRUD")
+struct SubcolumnsCRUDTests {
+
+  // MARK: - listSubcolumns
+
+  @Test("listSubcolumns 200 returns array")
+  func listSubcolumnsSuccess() async throws {
+    let json = """
+      [{"id": 301, "title": "Sub A"}, {"id": 302, "title": "Sub B"}]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let subcolumns = try await client.listSubcolumns(columnId: 100)
+    #expect(subcolumns.count == 2)
+    #expect(subcolumns[0].id == 301)
+  }
+
+  @Test("listSubcolumns 200 empty body returns empty array")
+  func listSubcolumnsEmpty() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: nil)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let subcolumns = try await client.listSubcolumns(columnId: 100)
+    #expect(subcolumns.isEmpty)
+  }
+
+  @Test("listSubcolumns 404 throws notFound")
+  func listSubcolumnsNotFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listSubcolumns(columnId: 999)
+    }
+  }
+
+  // MARK: - createSubcolumn
+
+  @Test("createSubcolumn 200 returns created Column")
+  func createSubcolumnSuccess() async throws {
+    let json = """
+      {"id": 301, "title": "Review"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let sub = try await client.createSubcolumn(columnId: 100, title: "Review")
+    #expect(sub.id == 301)
+    #expect(sub.title == "Review")
+  }
+
+  @Test("createSubcolumn 404 throws notFound")
+  func createSubcolumnNotFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createSubcolumn(columnId: 999, title: "Test")
+    }
+  }
+
+  // MARK: - updateSubcolumn
+
+  @Test("updateSubcolumn 200 returns updated Column")
+  func updateSubcolumnSuccess() async throws {
+    let json = """
+      {"id": 301, "title": "Code Review"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let sub = try await client.updateSubcolumn(columnId: 100, id: 301, title: "Code Review")
+    #expect(sub.id == 301)
+    #expect(sub.title == "Code Review")
+  }
+
+  @Test("updateSubcolumn 404 throws notFound")
+  func updateSubcolumnNotFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.updateSubcolumn(columnId: 100, id: 999, title: "Test")
+    }
+  }
+
+  // MARK: - deleteSubcolumn
+
+  @Test("deleteSubcolumn 200 returns deleted id")
+  func deleteSubcolumnSuccess() async throws {
+    let json = """
+      {"id": 301}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    let deletedId = try await client.deleteSubcolumn(columnId: 100, id: 301)
+    #expect(deletedId == 301)
+  }
+
+  @Test("deleteSubcolumn 404 throws notFound")
+  func deleteSubcolumnNotFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.deleteSubcolumn(columnId: 100, id: 999)
+    }
+  }
+}


### PR DESCRIPTION
Adds 37 tests covering 19 previously untested methods:

- **SpacesCRUDTests** — getSpace, createSpace, updateSpace, deleteSpace
- **BoardsCRUDTests** — createBoard, updateBoard, deleteBoard
- **ColumnsCRUDTests** — createColumn, updateColumn, deleteColumn
- **LanesCRUDTests** — createLane, updateLane, deleteLane
- **SubcolumnsCRUDTests** — listSubcolumns, createSubcolumn, updateSubcolumn, deleteSubcolumn
- **CardBaselinesTests** — getCardBaselines
- **SprintSummaryTests** — getSprintSummary

Each test covers success (200), error cases (401/403/404), and empty body handling where applicable.