### PR TITLE
Add missing tests for pagination enums page errors and createComment

### DIFF
--- a/Tests/KaitenSDKTests/CreateCommentTests.swift
+++ b/Tests/KaitenSDKTests/CreateCommentTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import HTTPTypes
+import OpenAPIRuntime
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("CreateComment")
+struct CreateCommentTests {
+  private func bodyString(_ body: HTTPBody?) async throws -> String {
+    guard let body else { return "" }
+    var bytes = [UInt8]()
+    for try await chunk in body {
+      bytes.append(contentsOf: chunk)
+    }
+    return String(decoding: bytes, as: UTF8.self)
+  }
+
+  @Test("200 returns created Comment and sends expected payload")
+  func success() async throws {
+    let json = """
+      {"id": 100, "uid": "abc-123", "text": "Hello", "type": 1, "edited": false, "card_id": 42, "author_id": 5, "internal": false, "deleted": false, "sd_description": false, "updated": "2026-02-18T03:13:29Z", "created": "2026-02-17T13:05:28Z"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest",
+      token: "test-token",
+      transport: transport
+    )
+
+    let comment = try await client.createComment(cardId: 42, text: "Hello")
+    #expect(comment.id == 100)
+    #expect(comment.text == "Hello")
+
+    #expect(transport.recordedRequests.count == 1)
+    let request = transport.recordedRequests[0]
+    #expect(request.request.method == .post)
+    #expect(String(describing: request.request.path).contains("/cards/42/comments"))
+
+    let payload = try await bodyString(request.body)
+    let payloadObject =
+      try JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: String]
+    #expect(payloadObject?["text"] == "Hello")
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest",
+      token: "test-token",
+      transport: transport
+    )
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createComment(cardId: 42, text: "Hello")
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/EnumsTests.swift
+++ b/Tests/KaitenSDKTests/EnumsTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Enums")
+struct EnumsTests {
+  private func assertRoundTrip<T: CaseIterable & RawRepresentable & Equatable>(
+    _ type: T.Type
+  ) where T.RawValue == Int {
+    for value in T.allCases {
+      #expect(T(rawValue: value.rawValue) == value)
+    }
+  }
+
+  @Test("all public enums support raw value round-trip")
+  func roundTrip() {
+    assertRoundTrip(CardCondition.self)
+    assertRoundTrip(LaneCondition.self)
+    assertRoundTrip(CardState.self)
+    assertRoundTrip(CardMemberRoleType.self)
+    assertRoundTrip(TextFormatType.self)
+    assertRoundTrip(CardPosition.self)
+    assertRoundTrip(ColumnType.self)
+    assertRoundTrip(WipLimitType.self)
+  }
+
+  @Test("invalid raw values return nil for all public enums")
+  func invalidRawValue() {
+    #expect(CardCondition(rawValue: 999) == nil)
+    #expect(LaneCondition(rawValue: 999) == nil)
+    #expect(CardState(rawValue: 999) == nil)
+    #expect(CardMemberRoleType(rawValue: 999) == nil)
+    #expect(TextFormatType(rawValue: 999) == nil)
+    #expect(CardPosition(rawValue: 999) == nil)
+    #expect(ColumnType(rawValue: 999) == nil)
+    #expect(WipLimitType(rawValue: 999) == nil)
+  }
+
+  @Test("case counts are stable for public enums")
+  func caseCounts() {
+    #expect(CardCondition.allCases.count == 2)
+    #expect(LaneCondition.allCases.count == 3)
+    #expect(CardState.allCases.count == 3)
+    #expect(CardMemberRoleType.allCases.count == 2)
+    #expect(TextFormatType.allCases.count == 3)
+    #expect(CardPosition.allCases.count == 2)
+    #expect(ColumnType.allCases.count == 3)
+    #expect(WipLimitType.allCases.count == 2)
+  }
+
+  @Test("listCards query uses expected enum raw values")
+  func queryEncodingUsesRawValues() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest",
+      token: "test-token",
+      transport: transport
+    )
+    let filter = KaitenClient.CardFilter(
+      condition: .archived,
+      states: [.queued, .done]
+    )
+
+    _ = try await client.listCards(boardId: 10, filter: filter)
+
+    #expect(transport.recordedRequests.count == 1)
+    let requestPath = String(describing: transport.recordedRequests[0].request.path)
+    #expect(requestPath.contains("condition=2"))
+    #expect(requestPath.contains("states=1,3") || requestPath.contains("states=1%2C3"))
+  }
+}

--- a/Tests/KaitenSDKTests/KaitenErrorTests.swift
+++ b/Tests/KaitenSDKTests/KaitenErrorTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("KaitenError")
+struct KaitenErrorTests {
+  private struct UnderlyingError: Error, LocalizedError {
+    var errorDescription: String? { "underlying error" }
+  }
+
+  @Test("all relevant error descriptions are non-empty and stable")
+  func errorDescriptions() {
+    let cases: [(KaitenError, String)] = [
+      (.missingConfiguration("TOKEN"), "Missing required configuration: TOKEN"),
+      (.invalidURL("not a url"), "Invalid URL: not a url"),
+      (.unauthorized, "Unauthorized – check your API token"),
+      (.notFound(resource: "card", id: 42), "card with id 42 not found"),
+      (.rateLimited(retryAfter: nil), "Rate limited – retry later"),
+      (.rateLimited(retryAfter: 5), "Rate limited – retry after 5s"),
+      (.serverError(statusCode: 500, body: "oops"), "Server error 500: oops"),
+      (.networkError(underlying: UnderlyingError()), "Network error: underlying error"),
+      (.decodingError(underlying: UnderlyingError()), "Decoding error: underlying error"),
+      (
+        .unexpectedResponse(statusCode: 418, body: "teapot"),
+        "Unexpected HTTP response: 418: teapot"
+      ),
+    ]
+
+    for (error, expected) in cases {
+      let description = error.errorDescription
+      #expect(description == expected)
+      #expect(description?.isEmpty == false)
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/PageTests.swift
+++ b/Tests/KaitenSDKTests/PageTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Page")
+struct PageTests {
+  private struct EncodedPage<T: Decodable>: Decodable {
+    let items: [T]
+    let offset: Int
+    let limit: Int
+    let hasMore: Bool
+  }
+
+  @Test("hasMore is true when items count equals limit")
+  func hasMoreWhenFull() {
+    let page = Page(items: [1, 2], offset: 0, limit: 2)
+    #expect(page.hasMore == true)
+  }
+
+  @Test("hasMore is false when items count is less than limit")
+  func hasMoreWhenPartial() {
+    let page = Page(items: [1], offset: 0, limit: 2)
+    #expect(page.hasMore == false)
+  }
+
+  @Test("empty page has no items and no more pages")
+  func emptyPage() {
+    let page = Page(items: [Int](), offset: 20, limit: 50)
+    #expect(page.items.isEmpty)
+    #expect(page.hasMore == false)
+    #expect(page.offset == 20)
+    #expect(page.limit == 50)
+  }
+
+  @Test("Page supports Equatable when item type is Equatable")
+  func equatable() {
+    let lhs = Page(items: [1, 2, 3], offset: 0, limit: 3)
+    let rhs = Page(items: [1, 2, 3], offset: 0, limit: 3)
+    let different = Page(items: [1, 2], offset: 0, limit: 3)
+    #expect(lhs == rhs)
+    #expect(lhs != different)
+  }
+
+  @Test("Page supports encoding round-trip of encoded fields")
+  func encodingRoundTrip() throws {
+    let page = Page(items: [1, 2], offset: 10, limit: 2)
+    let data = try JSONEncoder().encode(page)
+    let decoded = try JSONDecoder().decode(EncodedPage<Int>.self, from: data)
+
+    #expect(decoded.items == [1, 2])
+    #expect(decoded.offset == 10)
+    #expect(decoded.limit == 2)
+    #expect(decoded.hasMore == true)
+  }
+}

--- a/Tests/KaitenSDKTests/PaginationTests.swift
+++ b/Tests/KaitenSDKTests/PaginationTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Pagination")
+struct PaginationTests {
+  private enum StubError: Error {
+    case laterPageFailed
+  }
+
+  private actor CallCounter {
+    private(set) var count = 0
+    func increment() { count += 1 }
+  }
+
+  private func collect<T: Sendable>(_ stream: AsyncThrowingStream<T, Error>) async throws -> [T] {
+    var result: [T] = []
+    for try await item in stream {
+      result.append(item)
+    }
+    return result
+  }
+
+  @Test("allPages yields all items in order across multiple pages")
+  func multiPageOrder() async throws {
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest",
+      token: "test-token",
+      transport: MockClientTransport.returning(statusCode: 200, body: "[]")
+    )
+
+    let stream: AsyncThrowingStream<Int, Error> = client.allPages(pageSize: 2) {
+      (offset: Int, limit: Int) async throws -> Page<Int> in
+      #expect(limit == 2)
+      switch offset {
+      case 0: return Page(items: [1, 2], offset: offset, limit: limit)
+      case 2: return Page(items: [3, 4], offset: offset, limit: limit)
+      case 4: return Page(items: [5], offset: offset, limit: limit)
+      default: return Page(items: [], offset: offset, limit: limit)
+      }
+    }
+
+    let items = try await collect(stream)
+    #expect(items == [1, 2, 3, 4, 5])
+  }
+
+  @Test("allPages completes immediately for empty first page")
+  func emptyFirstPage() async throws {
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest",
+      token: "test-token",
+      transport: MockClientTransport.returning(statusCode: 200, body: "[]")
+    )
+
+    let stream: AsyncThrowingStream<Int, Error> = client.allPages(pageSize: 10) {
+      (offset: Int, limit: Int) async throws -> Page<Int> in
+      Page(items: [Int](), offset: offset, limit: limit)
+    }
+
+    let items = try await collect(stream)
+    #expect(items.isEmpty)
+  }
+
+  @Test("allPages stops on a single partial page")
+  func singlePartialPage() async throws {
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest",
+      token: "test-token",
+      transport: MockClientTransport.returning(statusCode: 200, body: "[]")
+    )
+
+    let stream: AsyncThrowingStream<Int, Error> = client.allPages(pageSize: 5) {
+      (offset: Int, limit: Int) async throws -> Page<Int> in
+      Page(items: [42], offset: offset, limit: limit)
+    }
+
+    let items = try await collect(stream)
+    #expect(items == [42])
+  }
+
+  @Test("allPages propagates an error from a later page")
+  func laterPageFailure() async throws {
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest",
+      token: "test-token",
+      transport: MockClientTransport.returning(statusCode: 200, body: "[]")
+    )
+
+    let stream: AsyncThrowingStream<Int, Error> = client.allPages(pageSize: 2) {
+      (offset: Int, limit: Int) async throws -> Page<Int> in
+      if offset == 0 {
+        return Page(items: [1, 2], offset: offset, limit: limit)
+      }
+      throw StubError.laterPageFailed
+    }
+
+    var collected: [Int] = []
+    await #expect(throws: StubError.self) {
+      for try await item in stream {
+        collected.append(item)
+      }
+    }
+    #expect(collected == [1, 2])
+  }
+
+  @Test("allPages stops after stream cancellation")
+  func cancellationStopsPagination() async throws {
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest",
+      token: "test-token",
+      transport: MockClientTransport.returning(statusCode: 200, body: "[]")
+    )
+
+    let counter = CallCounter()
+    let stream: AsyncThrowingStream<Int, Error> = client.allPages(pageSize: 1) {
+      (offset: Int, limit: Int) async throws -> Page<Int> in
+      await counter.increment()
+      if offset > 0 {
+        try await Task.sleep(nanoseconds: 100_000_000)
+      }
+      return Page(items: [offset + 1], offset: offset, limit: limit)
+    }
+
+    let consumer = Task {
+      for try await _ in stream {
+        break
+      }
+    }
+    try await consumer.value
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    let totalCalls = await counter.count
+    #expect(totalCalls <= 2)
+  }
+}


### PR DESCRIPTION
## Summary
- add focused pagination tests for multi-page, empty, partial, later-failure, and cancellation behavior
- add enum coverage for raw-value round-trip, invalid values, case counts, and listCards query encoding
- add Page model tests for hasMore semantics, equatable behavior, and encoding round-trip
- add direct KaitenError errorDescription assertions including rate-limited variants
- add createComment success/not-found tests with request payload validation

Closes #280