### PR TITLE
Fix numeric avatar_type decoding in addCardMember

### DIFF
--- a/Tests/KaitenSDKTests/AddCardMemberTests.swift
+++ b/Tests/KaitenSDKTests/AddCardMemberTests.swift
@@ -10,7 +10,7 @@ struct AddCardMemberTests {
   @Test("200 returns member")
   func success() async throws {
     let json = """
-      {"id": 10, "full_name": "Alice", "type": 1}
+      {"id": 10, "full_name": "Alice", "type": 1, "avatar_type": 2}
       """
     let transport = MockClientTransport.returning(statusCode: 200, body: json)
     let client = try KaitenClient(
@@ -19,6 +19,7 @@ struct AddCardMemberTests {
     let member = try await client.addCardMember(cardId: 42, userId: 10)
     #expect(member.id == 10)
     #expect(member.full_name == "Alice")
+    #expect(member.avatar_type == 2)
   }
 
   @Test("404 throws notFound")

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -3281,7 +3281,7 @@ components:
           type: string
           description: User initials
         avatar_type:
-          type: string
+          type: integer
           description: 1 – gravatar, 2 – initials, 3 - uploaded
         lng:
           type: string


### PR DESCRIPTION
## Summary
- align MemberDetailed.avatar_type schema with Kaiten docs by using integer type
- keep user avatar enum semantics unchanged (1 gravatar, 2 initials, 3 uploaded)
- add regression coverage for addCardMember success payload containing numeric avatar_type

Closes #282