### PR TITLE
Remove destructive delete operations for spaces boards and lanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ kaiten list-spaces \
 | `createSpace(...)` | Create a space |
 | `getSpace(...)` | Get a space by ID |
 | `updateSpace(...)` | Update a space |
-| `deleteSpace(...)` | Delete a space |
 
 ### Boards
 
@@ -171,7 +170,6 @@ kaiten list-spaces \
 | `getBoard(id:)` | Fetch a board by ID |
 | `createBoard(...)` | Create a board |
 | `updateBoard(...)` | Update a board |
-| `deleteBoard(...)` | Delete a board |
 
 ### Columns
 
@@ -193,7 +191,6 @@ kaiten list-spaces \
 | `getBoardLanes(boardId:)` | Get lanes for a board |
 | `createLane(...)` | Create a lane |
 | `updateLane(...)` | Update a lane |
-| `deleteLane(...)` | Delete a lane |
 
 ### Custom Properties
 

--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -1642,19 +1642,6 @@ extension KaitenClient {
     ) { try $0.json }
   }
 
-  /// Deletes a space.
-  public func deleteSpace(
-    id: Int
-  ) async throws(KaitenError) -> Int {
-    let response = try await call {
-      try await client.remove_space(path: .init(space_id: id))
-    }
-    let result: Components.Schemas.DeletedIdResponse =
-      try decodeResponse(
-        response.toCase(), notFoundResource: ("space", id)
-      ) { try $0.json }
-    return result.id
-  }
 }
 
 // MARK: - Boards CRUD
@@ -1709,21 +1696,6 @@ extension KaitenClient {
     ) { try $0.json }
   }
 
-  /// Deletes a board.
-  public func deleteBoard(
-    spaceId: Int, id: Int
-  ) async throws(KaitenError) -> Int {
-    let response = try await call {
-      try await client.remove_board(
-        path: .init(space_id: spaceId, id: id)
-      )
-    }
-    let result: Components.Schemas.DeletedIdResponse =
-      try decodeResponse(
-        response.toCase(), notFoundResource: ("board", id)
-      ) { try $0.json }
-    return result.id
-  }
 }
 
 // MARK: - Columns CRUD
@@ -1944,21 +1916,6 @@ extension KaitenClient {
     ) { try $0.json }
   }
 
-  /// Deletes a lane.
-  public func deleteLane(
-    boardId: Int, id: Int
-  ) async throws(KaitenError) -> Int {
-    let response = try await call {
-      try await client.remove_lane(
-        path: .init(board_id: boardId, id: id)
-      )
-    }
-    let result: Components.Schemas.DeletedIdResponse =
-      try decodeResponse(
-        response.toCase(), notFoundResource: ("lane", id)
-      ) { try $0.json }
-    return result.id
-  }
 }
 
 // MARK: - Card Baselines

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -689,18 +689,6 @@ extension Operations.update_space.Output {
   }
 }
 
-extension Operations.remove_space.Output {
-  func toCase() -> KaitenClient.ResponseCase<Operations.remove_space.Output.Ok.Body> {
-    switch self {
-    case .ok(let ok): .ok(ok.body)
-    case .unauthorized: .unauthorized
-    case .forbidden: .forbidden
-    case .notFound: .notFound
-    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
-    }
-  }
-}
-
 // MARK: - Boards CRUD
 
 extension Operations.create_board.Output {
@@ -718,19 +706,6 @@ extension Operations.create_board.Output {
 
 extension Operations.update_board.Output {
   func toCase() -> KaitenClient.ResponseCase<Operations.update_board.Output.Ok.Body> {
-    switch self {
-    case .ok(let ok): .ok(ok.body)
-    case .badRequest: .undocumented(statusCode: 400)
-    case .unauthorized: .unauthorized
-    case .forbidden: .forbidden
-    case .notFound: .notFound
-    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
-    }
-  }
-}
-
-extension Operations.remove_board.Output {
-  func toCase() -> KaitenClient.ResponseCase<Operations.remove_board.Output.Ok.Body> {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .badRequest: .undocumented(statusCode: 400)
@@ -853,19 +828,6 @@ extension Operations.create_lane.Output {
 
 extension Operations.update_lane.Output {
   func toCase() -> KaitenClient.ResponseCase<Operations.update_lane.Output.Ok.Body> {
-    switch self {
-    case .ok(let ok): .ok(ok.body)
-    case .badRequest: .undocumented(statusCode: 400)
-    case .unauthorized: .unauthorized
-    case .forbidden: .forbidden
-    case .notFound: .notFound
-    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
-    }
-  }
-}
-
-extension Operations.remove_lane.Output {
-  func toCase() -> KaitenClient.ResponseCase<Operations.remove_lane.Output.Ok.Body> {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .badRequest: .undocumented(statusCode: 400)

--- a/Sources/kaiten/Boards/BoardCRUDCommands.swift
+++ b/Sources/kaiten/Boards/BoardCRUDCommands.swift
@@ -68,27 +68,3 @@ struct UpdateBoard: AsyncParsableCommand {
     try printJSON(board)
   }
 }
-
-struct DeleteBoard: AsyncParsableCommand {
-  static let configuration = CommandConfiguration(
-    commandName: "delete-board",
-    abstract: "Delete a board"
-  )
-
-  @OptionGroup var global: GlobalOptions
-
-  @Option(name: .long, help: "Space ID")
-  var spaceId: Int
-
-  @Option(name: .long, help: "Board ID")
-  var id: Int
-
-  func run() async throws {
-    let client = try await global.makeClient()
-    let deletedId = try await client.deleteBoard(
-      spaceId: spaceId,
-      id: id
-    )
-    print("{\"id\": \(deletedId)}")
-  }
-}

--- a/Sources/kaiten/Boards/LaneCommands.swift
+++ b/Sources/kaiten/Boards/LaneCommands.swift
@@ -71,27 +71,3 @@ struct UpdateLane: AsyncParsableCommand {
     try printJSON(lane)
   }
 }
-
-struct DeleteLane: AsyncParsableCommand {
-  static let configuration = CommandConfiguration(
-    commandName: "delete-lane",
-    abstract: "Delete a lane"
-  )
-
-  @OptionGroup var global: GlobalOptions
-
-  @Option(name: .long, help: "Board ID")
-  var boardId: Int
-
-  @Option(name: .long, help: "Lane ID")
-  var id: Int
-
-  func run() async throws {
-    let client = try await global.makeClient()
-    let deletedId = try await client.deleteLane(
-      boardId: boardId,
-      id: id
-    )
-    print("{\"id\": \(deletedId)}")
-  }
-}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -62,10 +62,8 @@ struct Kaiten: AsyncParsableCommand {
       CreateSpace.self,
       GetSpace.self,
       UpdateSpace.self,
-      DeleteSpace.self,
       CreateBoard.self,
       UpdateBoard.self,
-      DeleteBoard.self,
       CreateColumn.self,
       UpdateColumn.self,
       DeleteColumn.self,
@@ -75,7 +73,6 @@ struct Kaiten: AsyncParsableCommand {
       DeleteSubcolumn.self,
       CreateLane.self,
       UpdateLane.self,
-      DeleteLane.self,
       GetCardBaselines.self,
     ]
   )

--- a/Sources/kaiten/Spaces/SpaceCRUDCommands.swift
+++ b/Sources/kaiten/Spaces/SpaceCRUDCommands.swift
@@ -78,21 +78,3 @@ struct UpdateSpace: AsyncParsableCommand {
     try printJSON(space)
   }
 }
-
-struct DeleteSpace: AsyncParsableCommand {
-  static let configuration = CommandConfiguration(
-    commandName: "delete-space",
-    abstract: "Delete a space"
-  )
-
-  @OptionGroup var global: GlobalOptions
-
-  @Option(name: .long, help: "Space ID")
-  var id: Int
-
-  func run() async throws {
-    let client = try await global.makeClient()
-    let deletedId = try await client.deleteSpace(id: id)
-    print("{\"id\": \(deletedId)}")
-  }
-}

--- a/Tests/KaitenSDKTests/BoardsCRUDTests.swift
+++ b/Tests/KaitenSDKTests/BoardsCRUDTests.swift
@@ -72,29 +72,4 @@ struct BoardsCRUDTests {
     }
   }
 
-  // MARK: - deleteBoard
-
-  @Test("deleteBoard 200 returns deleted id")
-  func deleteBoardSuccess() async throws {
-    let json = """
-      {"id": 10}
-      """
-    let transport = MockClientTransport.returning(statusCode: 200, body: json)
-    let client = try KaitenClient(
-      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
-
-    let deletedId = try await client.deleteBoard(spaceId: 1, id: 10)
-    #expect(deletedId == 10)
-  }
-
-  @Test("deleteBoard 404 throws notFound")
-  func deleteBoardNotFound() async throws {
-    let transport = MockClientTransport.returning(statusCode: 404)
-    let client = try KaitenClient(
-      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
-
-    await #expect(throws: KaitenError.self) {
-      _ = try await client.deleteBoard(spaceId: 1, id: 999)
-    }
-  }
 }

--- a/Tests/KaitenSDKTests/LanesCRUDTests.swift
+++ b/Tests/KaitenSDKTests/LanesCRUDTests.swift
@@ -72,29 +72,4 @@ struct LanesCRUDTests {
     }
   }
 
-  // MARK: - deleteLane
-
-  @Test("deleteLane 200 returns deleted id")
-  func deleteLaneSuccess() async throws {
-    let json = """
-      {"id": 200}
-      """
-    let transport = MockClientTransport.returning(statusCode: 200, body: json)
-    let client = try KaitenClient(
-      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
-
-    let deletedId = try await client.deleteLane(boardId: 10, id: 200)
-    #expect(deletedId == 200)
-  }
-
-  @Test("deleteLane 404 throws notFound")
-  func deleteLaneNotFound() async throws {
-    let transport = MockClientTransport.returning(statusCode: 404)
-    let client = try KaitenClient(
-      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
-
-    await #expect(throws: KaitenError.self) {
-      _ = try await client.deleteLane(boardId: 10, id: 999)
-    }
-  }
 }

--- a/Tests/KaitenSDKTests/SpacesCRUDTests.swift
+++ b/Tests/KaitenSDKTests/SpacesCRUDTests.swift
@@ -110,29 +110,4 @@ struct SpacesCRUDTests {
     }
   }
 
-  // MARK: - deleteSpace
-
-  @Test("deleteSpace 200 returns deleted id")
-  func deleteSpaceSuccess() async throws {
-    let json = """
-      {"id": 1}
-      """
-    let transport = MockClientTransport.returning(statusCode: 200, body: json)
-    let client = try KaitenClient(
-      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
-
-    let deletedId = try await client.deleteSpace(id: 1)
-    #expect(deletedId == 1)
-  }
-
-  @Test("deleteSpace 404 throws notFound")
-  func deleteSpaceNotFound() async throws {
-    let transport = MockClientTransport.returning(statusCode: 404)
-    let client = try KaitenClient(
-      baseURL: "https://test.kaiten.ru/api/latest", token: "t", transport: transport)
-
-    await #expect(throws: KaitenError.self) {
-      _ = try await client.deleteSpace(id: 999)
-    }
-  }
 }

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -1920,29 +1920,6 @@ paths:
           description: Forbidden
         '404':
           description: Not found
-    delete:
-      summary: Remove space
-      operationId: remove_space
-      parameters:
-      - name: space_id
-        in: path
-        required: true
-        schema:
-          type: integer
-        description: Space ID
-      responses:
-        '200':
-          description: success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DeletedIdResponse'
-        '401':
-          description: Invalid token
-        '403':
-          description: Forbidden
-        '404':
-          description: Not found
   /spaces/{space_id}/boards/{id}:
     patch:
       summary: Update board
@@ -1973,37 +1950,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Board'
-        '400':
-          description: Bad request
-        '401':
-          description: Invalid token
-        '403':
-          description: Forbidden
-        '404':
-          description: Not found
-    delete:
-      summary: Remove board
-      operationId: remove_board
-      parameters:
-      - name: space_id
-        in: path
-        required: true
-        schema:
-          type: integer
-        description: Space ID
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: integer
-        description: Board ID
-      responses:
-        '200':
-          description: success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DeletedIdResponse'
         '400':
           description: Bad request
         '401':
@@ -2237,37 +2183,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Lane'
-        '400':
-          description: Bad request
-        '401':
-          description: Invalid token
-        '403':
-          description: Forbidden
-        '404':
-          description: Not found
-    delete:
-      summary: Remove lane
-      operationId: remove_lane
-      parameters:
-      - name: board_id
-        in: path
-        required: true
-        schema:
-          type: integer
-        description: Board ID
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: integer
-        description: Lane ID
-      responses:
-        '200':
-          description: success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DeletedIdResponse'
         '400':
           description: Bad request
         '401':

--- a/specs/001-kaiten-sdk-core/spec.md
+++ b/specs/001-kaiten-sdk-core/spec.md
@@ -112,6 +112,7 @@ A developer requests all spaces and boards — for navigation.
   - **Nullable and required strictly per the real API** — verify through requests, not just docs.
   - **Cross-checking is mandatory** — for any spec change, compare with documentation + verify against the real API. Documentation parsing guide: [docs/kaiten-docs-parsing.md](../../docs/kaiten-docs-parsing.md).
 - **FR-010**: SDK MUST support ALL query parameters documented in the Kaiten API for every endpoint in the spec. No subset, no phasing — every filter the API accepts MUST be present in the OpenAPI spec and exposed in the SDK's public API with backward-compatible optional defaults.
+- **FR-011**: SDK MUST NOT expose destructive delete operations for spaces, boards, and lanes.
 
 ### Non-Functional Requirements
 

--- a/specs/002-kaiten-cli/spec.md
+++ b/specs/002-kaiten-cli/spec.md
@@ -87,6 +87,8 @@ stdout confirms it works.
   (`ConfigReader` + `FileProvider<JSONSnapshot>`) to read the
   config file. `swift-configuration` is a dependency of the CLI
   target only, not the SDK.
+- **FR-008**: The CLI MUST NOT expose destructive delete commands for
+  spaces, boards, or lanes.
 
 ### Non-Functional Requirements
 


### PR DESCRIPTION
## Summary
- remove SDK delete methods for spaces, boards, and lanes
- remove corresponding CLI commands and registration
- remove delete operations from OpenAPI spec and response mapping
- remove related tests and README API entries
- document the non-destructive policy in SDK and CLI specs

Closes #283