### PR TITLE
Avoid force unwrap in CLI JSON output

### DIFF
--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -122,5 +122,5 @@ func printJSON(_ value: some Encodable) throws {
   let encoder = JSONEncoder()
   encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
   let data = try encoder.encode(value)
-  print(String(data: data, encoding: .utf8)!)
+  print(String(decoding: data, as: UTF8.self))
 }


### PR DESCRIPTION
## Summary
- replace force-unwrapped UTF-8 string conversion in  with 
- keep output behavior unchanged while removing crash risk in CLI output code

Closes #284