### PR TITLE
Improve hasMore semantics with explicit override

### DIFF
--- a/Sources/KaitenSDK/Page.swift
+++ b/Sources/KaitenSDK/Page.swift
@@ -7,14 +7,14 @@ public struct Page<T: Sendable>: Sendable {
   /// The limit used to fetch this page.
   public let limit: Int
   /// Whether there are likely more results available.
-  /// Determined by `items.count == limit`.
+  /// Uses explicit server-provided value when available, otherwise falls back to `items.count == limit`.
   public let hasMore: Bool
 
-  public init(items: [T], offset: Int, limit: Int) {
+  public init(items: [T], offset: Int, limit: Int, hasMore: Bool? = nil) {
     self.items = items
     self.offset = offset
     self.limit = limit
-    self.hasMore = items.count == limit
+    self.hasMore = hasMore ?? (items.count == limit)
   }
 }
 

--- a/Tests/KaitenSDKTests/PageTests.swift
+++ b/Tests/KaitenSDKTests/PageTests.swift
@@ -53,4 +53,10 @@ struct PageTests {
     #expect(decoded.limit == 2)
     #expect(decoded.hasMore == true)
   }
+
+  @Test("explicit hasMore overrides count-based fallback")
+  func explicitHasMoreOverride() {
+    let page = Page(items: [1], offset: 0, limit: 10, hasMore: true)
+    #expect(page.hasMore == true)
+  }
 }


### PR DESCRIPTION
## Summary
- extend  with optional explicit  input
- prefer explicit server-driven continuation when provided
- keep count-based inference as backward-compatible fallback
- add regression test for explicit override behavior

Closes #289