### PR TITLE
Do not hide corrupted 200 list payloads as empty results

### DIFF
--- a/Tests/KaitenSDKTests/ListCardsTests.swift
+++ b/Tests/KaitenSDKTests/ListCardsTests.swift
@@ -67,6 +67,17 @@ struct ListCardsTests {
     }
   }
 
+  @Test("200 with malformed JSON body throws decodingError")
+  func malformedJsonThrowsDecodingError() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "[")
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCards(boardId: 10)
+    }
+  }
+
   @Test("401 throws unauthorized")
   func unauthorized() async throws {
     let transport = MockClientTransport.returning(statusCode: 401)


### PR DESCRIPTION
## Summary
- refine  handling for HTTP 200  decoding failures
- preserve empty-list fallback only for truly empty response bodies
- surface non-empty malformed payloads as 
- add regression test for malformed JSON body behavior

Closes #290