### PR TITLE
Unify CLI output format across all commands

### DIFF
--- a/Sources/kaiten/Boards/ColumnCommands.swift
+++ b/Sources/kaiten/Boards/ColumnCommands.swift
@@ -89,7 +89,7 @@ struct DeleteColumn: AsyncParsableCommand {
       boardId: boardId,
       id: id
     )
-    print("{\"id\": \(deletedId)}")
+    try printJSON(["id": deletedId])
   }
 }
 
@@ -195,6 +195,6 @@ struct DeleteSubcolumn: AsyncParsableCommand {
       columnId: columnId,
       id: id
     )
-    print("{\"id\": \(deletedId)}")
+    try printJSON(["id": deletedId])
   }
 }

--- a/Sources/kaiten/Cards/ChecklistCommands.swift
+++ b/Sources/kaiten/Cards/ChecklistCommands.swift
@@ -228,6 +228,6 @@ struct RemoveChecklistItem: AsyncParsableCommand {
       checklistId: checklistId,
       itemId: itemId
     )
-    print(deletedId)
+    try printJSON(["id": deletedId])
   }
 }


### PR DESCRIPTION
## Summary
- replace ad-hoc delete output in column and subcolumn commands with shared  helper
- replace plain integer output in  command with consistent JSON object payload
- preserve existing command semantics while standardizing success output shape

Closes #292