### PR TITLE
sdk: enforce HTTPS-only baseURL

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -18,7 +18,10 @@ public struct KaitenClient: Sendable {
   ///   - transport: Custom `ClientTransport` implementation.
   /// - Throws: ``KaitenError/invalidURL(_:)`` if `baseURL` cannot be parsed.
   init(baseURL: String, token: String, transport: any ClientTransport) throws(KaitenError) {
-    guard let url = URL(string: baseURL) else {
+    guard
+      let url = URL(string: baseURL),
+      url.scheme?.lowercased() == "https"
+    else {
       throw KaitenError.invalidURL(baseURL)
     }
     self.client = Client(
@@ -38,7 +41,10 @@ public struct KaitenClient: Sendable {
   ///   - token: API bearer token.
   /// - Throws: ``KaitenError/invalidURL(_:)`` if `baseURL` cannot be parsed.
   public init(baseURL: String, token: String) throws(KaitenError) {
-    guard let url = URL(string: baseURL) else {
+    guard
+      let url = URL(string: baseURL),
+      url.scheme?.lowercased() == "https"
+    else {
       throw KaitenError.invalidURL(baseURL)
     }
 

--- a/Tests/KaitenSDKTests/KaitenClientTests.swift
+++ b/Tests/KaitenSDKTests/KaitenClientTests.swift
@@ -12,4 +12,20 @@ struct KaitenClientConfigurationTests {
       _ = try KaitenClient(baseURL: "", token: "test-token")
     }
   }
+
+  @Test("Fails with non-HTTPS URL")
+  func nonHTTPSURL() {
+    #expect(throws: KaitenError.self) {
+      _ = try KaitenClient(baseURL: "http://test.kaiten.ru/api/latest", token: "test-token")
+    }
+  }
+
+  @Test("Fails with non-HTTPS URL for custom transport init")
+  func nonHTTPSURLWithTransport() {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "{}")
+    #expect(throws: KaitenError.self) {
+      _ = try KaitenClient(
+        baseURL: "http://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- enforce HTTPS-only baseURL in both KaitenClient initializers
- keep typed error behavior by reusing KaitenError.invalidURL
- add regression tests for non-HTTPS URLs (default and custom transport inits)

## Validation
- swift test --quiet --filter KaitenClientConfigurationTests
- swift test --quiet