### PR TITLE
cli: strict enum validation and lane row-count forwarding

### DIFF
--- a/Sources/kaiten/Boards/LaneCommands.swift
+++ b/Sources/kaiten/Boards/LaneCommands.swift
@@ -1,6 +1,15 @@
 import ArgumentParser
 import KaitenSDK
 
+func parseLaneCondition(_ rawValue: Int?) throws -> LaneCondition? {
+  guard let rawValue else { return nil }
+  guard let condition = LaneCondition(rawValue: rawValue) else {
+    throw ValidationError(
+      "Invalid lane condition: \(rawValue). Allowed values: 1 (live), 2 (archived)")
+  }
+  return condition
+}
+
 struct CreateLane: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "create-lane",
@@ -66,7 +75,8 @@ struct UpdateLane: AsyncParsableCommand {
       id: id,
       title: title,
       sortOrder: sortOrder,
-      condition: condition.flatMap(LaneCondition.init(rawValue:))
+      rowCount: rowCount,
+      condition: try parseLaneCondition(condition)
     )
     try printJSON(lane)
   }

--- a/Sources/kaiten/Cards/MemberCommands.swift
+++ b/Sources/kaiten/Cards/MemberCommands.swift
@@ -1,6 +1,13 @@
 import ArgumentParser
 import KaitenSDK
 
+func parseCardMemberRoleType(_ rawValue: Int) throws -> CardMemberRoleType {
+  guard let roleType = CardMemberRoleType(rawValue: rawValue) else {
+    throw ValidationError("Invalid role type: \(rawValue). Allowed values: 2 (responsible)")
+  }
+  return roleType
+}
+
 struct AddCardMember: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "add-card-member",
@@ -41,9 +48,7 @@ struct UpdateCardMemberRole: AsyncParsableCommand {
 
   func run() async throws {
     let client = try await global.makeClient()
-    guard let roleType = CardMemberRoleType(rawValue: type) else {
-      throw KaitenError.unexpectedResponse(statusCode: 0)
-    }
+    let roleType = try parseCardMemberRoleType(type)
     let role = try await client.updateCardMemberRole(cardId: cardId, userId: userId, type: roleType)
     try printJSON(role)
   }

--- a/Tests/KaitenSDKTests/CLIValidationTests.swift
+++ b/Tests/KaitenSDKTests/CLIValidationTests.swift
@@ -1,0 +1,34 @@
+import ArgumentParser
+import Testing
+
+@testable import kaiten
+
+@Suite("CLI validation")
+struct CLIValidationTests {
+  @Test("Card member role parser rejects unknown value")
+  func cardMemberRoleRejectsUnknown() {
+    #expect(throws: ValidationError.self) {
+      _ = try parseCardMemberRoleType(999)
+    }
+  }
+
+  @Test("Card states parser trims whitespace")
+  func cardStatesTrimsWhitespace() throws {
+    let parsed = try parseCardStates("1, 2")
+    #expect(parsed?.count == 2)
+  }
+
+  @Test("Card states parser rejects invalid token")
+  func cardStatesRejectsInvalidToken() {
+    #expect(throws: ValidationError.self) {
+      _ = try parseCardStates("1,abc")
+    }
+  }
+
+  @Test("Lane condition parser rejects unknown value")
+  func laneConditionRejectsUnknown() {
+    #expect(throws: ValidationError.self) {
+      _ = try parseLaneCondition(999)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add strict CLI parsing helpers for card member role, card states, and lane condition
- reject invalid tokens with ValidationError instead of silently dropping values
- forward update-lane --row-count to SDK updateLane call
- add CLI validation tests

## Validation
- swift test --quiet --filter CLIValidationTests
- swift test --quiet