### PR TITLE
sdk: validate pagination and bound retry delays

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -114,6 +114,12 @@ public struct KaitenClient: Sendable {
     }
   }
 
+  private func validatePagination(offset: Int, limit: Int) throws(KaitenError) {
+    guard offset >= 0, (1...100).contains(limit) else {
+      throw .invalidPaginationRange(offset: offset, limit: limit)
+    }
+  }
+
   private func isEmptyBody(_ body: HTTPBody?) async -> Bool {
     guard let body else { return true }
 
@@ -380,6 +386,7 @@ public struct KaitenClient: Sendable {
     boardId: Int? = nil, columnId: Int? = nil, laneId: Int? = nil, offset: Int = 0,
     limit: Int = 100, filter: CardFilter? = nil
   ) async throws(KaitenError) -> Page<Components.Schemas.Card> {
+    try validatePagination(offset: offset, limit: limit)
     let f = filter
     let queryParams = Operations.get_cards.Input.Query(
       board_id: boardId,
@@ -1038,6 +1045,7 @@ extension KaitenClient {
     orderBy: String? = nil,
     orderDirection: String? = nil
   ) async throws(KaitenError) -> Page<Components.Schemas.CustomProperty> {
+    try validatePagination(offset: offset, limit: limit)
     guard
       let response = try await callList({
         try await client.get_list_of_properties(
@@ -1092,6 +1100,7 @@ extension KaitenClient {
     offset: Int = 0,
     limit: Int = 100
   ) async throws(KaitenError) -> Page<Components.Schemas.CustomPropertySelectValue> {
+    try validatePagination(offset: offset, limit: limit)
     guard
       let response = try await callList({
         try await client.get_list_of_select_values(

--- a/Sources/KaitenSDK/KaitenError.swift
+++ b/Sources/KaitenSDK/KaitenError.swift
@@ -20,6 +20,8 @@ public enum KaitenError: Error, Sendable {
   case decodingError(underlying: any Error)
   /// Invalid pagination parameters were provided.
   case invalidPagination(pageSize: Int)
+  /// Invalid pagination range was provided.
+  case invalidPaginationRange(offset: Int, limit: Int)
   /// The API returned an unexpected HTTP status code.
   case unexpectedResponse(statusCode: Int, body: String? = nil)
 }
@@ -51,6 +53,8 @@ extension KaitenError: LocalizedError {
       "Decoding error: \(underlying.localizedDescription)"
     case .invalidPagination(let pageSize):
       "Invalid pageSize: \(pageSize). pageSize must be greater than 0"
+    case .invalidPaginationRange(let offset, let limit):
+      "Invalid pagination: offset=\(offset), limit=\(limit). offset must be >= 0 and limit must be in 1...100"
     case .unexpectedResponse(let statusCode, let body):
       "Unexpected HTTP response: \(statusCode)" + (body.map { ": \($0)" } ?? "")
     }

--- a/Tests/KaitenSDKTests/CustomPropertiesTests.swift
+++ b/Tests/KaitenSDKTests/CustomPropertiesTests.swift
@@ -46,4 +46,21 @@ struct CustomPropertiesTests {
       _ = try await client.getCustomProperty(id: 999)
     }
   }
+
+  @Test("listCustomProperties invalid pagination throws invalidPagination")
+  func listInvalidPagination() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCustomProperties(offset: -1, limit: 100)
+    }
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCustomProperties(offset: 0, limit: 0)
+    }
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCustomProperties(offset: 0, limit: 101)
+    }
+  }
 }

--- a/Tests/KaitenSDKTests/ListCardsTests.swift
+++ b/Tests/KaitenSDKTests/ListCardsTests.swift
@@ -88,4 +88,21 @@ struct ListCardsTests {
       _ = try await client.listCards(boardId: 10)
     }
   }
+
+  @Test("invalid pagination throws invalidPagination")
+  func invalidPagination() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCards(boardId: 10, offset: -1, limit: 100)
+    }
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCards(boardId: 10, offset: 0, limit: 0)
+    }
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCards(boardId: 10, offset: 0, limit: 101)
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add strict pagination validation (offset >= 0, limit in 1...100) for listCards, listCustomProperties, and listCustomPropertySelectValues
- add typed KaitenError.invalidPaginationRange for invalid offset/limit
- cap retry delays in RetryMiddleware (including Retry-After and X-RateLimit-Reset)
- add regression tests for invalid pagination and delay capping

## Validation
- swift test --quiet --filter "(ListCardsTests|CustomPropertiesTests|RetryMiddlewareTests)"
- swift test --quiet