### PR TITLE
sdk: avoid masking non-empty list stream failures

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -97,7 +97,10 @@ public struct KaitenClient: Sendable {
           throw .decodingError(underlying: error)
         }
       }
-      return nil
+      if await isEmptyBody(error.responseBody) {
+        return nil
+      }
+      throw .networkError(underlying: error)
     } catch let error as KaitenError {
       throw error
     } catch {


### PR DESCRIPTION
## Summary
- keep empty-list fallback only for truly empty 200 response bodies
- for non-empty body stream failures, surface networkError instead of returning empty list
- add regression test with throwing response stream to verify behavior

## Validation
- swift test --quiet --filter ListCardsTests/streamFailureThrows
- swift test --quiet