### PR TITLE
cli: enforce strict config and remaining enum/CSV parsing

### DIFF
--- a/Sources/kaiten/Boards/BoardCommands.swift
+++ b/Sources/kaiten/Boards/BoardCommands.swift
@@ -74,7 +74,9 @@ struct GetBoardLanes: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let lanes = try await client.getBoardLanes(
-      boardId: boardId, condition: condition.flatMap(LaneCondition.init(rawValue:)))
+      boardId: boardId,
+      condition: try parseLaneCondition(condition)
+    )
     try printJSON(lanes)
   }
 }

--- a/Sources/kaiten/Boards/ColumnCommands.swift
+++ b/Sources/kaiten/Boards/ColumnCommands.swift
@@ -1,6 +1,16 @@
 import ArgumentParser
 import KaitenSDK
 
+func parseColumnType(_ rawValue: Int?) throws -> ColumnType? {
+  guard let rawValue else { return nil }
+  guard let type = ColumnType(rawValue: rawValue) else {
+    throw ValidationError(
+      "Invalid column type: \(rawValue). Allowed values: 1 (queue), 2 (in progress), 3 (done)"
+    )
+  }
+  return type
+}
+
 struct CreateColumn: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "create-column",
@@ -27,7 +37,7 @@ struct CreateColumn: AsyncParsableCommand {
       boardId: boardId,
       title: title,
       sortOrder: sortOrder,
-      type: columnType.flatMap(ColumnType.init(rawValue:))
+      type: try parseColumnType(columnType)
     )
     try printJSON(column)
   }
@@ -63,7 +73,7 @@ struct UpdateColumn: AsyncParsableCommand {
       id: id,
       title: title,
       sortOrder: sortOrder,
-      type: columnType.flatMap(ColumnType.init(rawValue:))
+      type: try parseColumnType(columnType)
     )
     try printJSON(column)
   }

--- a/Sources/kaiten/Cards/CardCommands.swift
+++ b/Sources/kaiten/Cards/CardCommands.swift
@@ -22,6 +22,16 @@ func parseCardStates(_ rawValue: String?) throws -> [CardState]? {
   return states
 }
 
+func parseCardCondition(_ rawValue: Int?) throws -> CardCondition? {
+  guard let rawValue else { return nil }
+  guard let condition = CardCondition(rawValue: rawValue) else {
+    throw ValidationError(
+      "Invalid card condition: \(rawValue). Allowed values: 1 (on board), 2 (archived)"
+    )
+  }
+  return condition
+}
+
 struct ListCards: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "list-cards",
@@ -212,7 +222,7 @@ struct ListCards: AsyncParsableCommand {
       excludeColumnIds: excludeColumnIds,
       excludeOwnerIds: excludeOwnerIds,
       excludeCardIds: excludeCardIds,
-      condition: condition.flatMap(CardCondition.init(rawValue:)),
+      condition: try parseCardCondition(condition),
       states: try parseCardStates(states),
       archived: archived,
       asap: asap,

--- a/Sources/kaiten/CustomProperties/CustomPropertyCommands.swift
+++ b/Sources/kaiten/CustomProperties/CustomPropertyCommands.swift
@@ -43,9 +43,7 @@ struct ListCustomProperties: AsyncParsableCommand {
 
   func run() async throws {
     let client = try await global.makeClient()
-    let parsedIds = ids?.split(separator: ",").compactMap {
-      Int($0.trimmingCharacters(in: .whitespaces))
-    }
+    let parsedIds = try parseIntegerCSV(ids, fieldName: "ids")
     let page = try await client.listCustomProperties(
       offset: offset,
       limit: limit,
@@ -116,12 +114,8 @@ struct ListCustomPropertySelectValues: AsyncParsableCommand {
 
   func run() async throws {
     let client = try await global.makeClient()
-    let parsedIds = ids?.split(separator: ",").compactMap {
-      Int($0.trimmingCharacters(in: .whitespaces))
-    }
-    let parsedConditions = conditions?.split(separator: ",").map {
-      String($0.trimmingCharacters(in: .whitespaces))
-    }
+    let parsedIds = try parseIntegerCSV(ids, fieldName: "ids")
+    let parsedConditions = try parseStringCSV(conditions, fieldName: "conditions")
     let values = try await client.listCustomPropertySelectValues(
       propertyId: propertyId,
       v2SelectSearch: v2SelectSearch,

--- a/Tests/KaitenSDKTests/CLIValidationTests.swift
+++ b/Tests/KaitenSDKTests/CLIValidationTests.swift
@@ -31,4 +31,18 @@ struct CLIValidationTests {
       _ = try parseLaneCondition(999)
     }
   }
+
+  @Test("Column type parser rejects unknown value")
+  func columnTypeRejectsUnknown() {
+    #expect(throws: ValidationError.self) {
+      _ = try parseColumnType(999)
+    }
+  }
+
+  @Test("Integer CSV parser rejects invalid token")
+  func integerCSVRejectsInvalidToken() {
+    #expect(throws: ValidationError.self) {
+      _ = try parseIntegerCSV("1,abc", fieldName: "ids")
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- stop swallowing config file read/parse errors when config.json exists
- add shared strict CSV parsers for integer/string lists
- enforce strict validation for board lane condition, column type, card condition, and custom property IDs/conditions
- extend CLI validation tests

## Validation
- swift test --quiet --filter CLIValidationTests
- swift test --quiet