### PR TITLE
fix: MemberDetailed.ui_version is integer, not string

### DIFF
--- a/Tests/KaitenSDKTests/AddCardMemberTests.swift
+++ b/Tests/KaitenSDKTests/AddCardMemberTests.swift
@@ -22,6 +22,21 @@ struct AddCardMemberTests {
     #expect(member.avatar_type == 2)
   }
 
+  @Test("200 decodes ui_version as integer (not string)")
+  func uiVersionIsInteger() async throws {
+    // Regression test for #321: MemberDetailed.ui_version was typed as String
+    // but the Kaiten API returns a Number (e.g. 2). Verified by direct API call.
+    let json = """
+      {"id": 10, "full_name": "Alice", "type": 1, "avatar_type": 2, "ui_version": 2}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let member = try await client.addCardMember(cardId: 42, userId: 10)
+    #expect(member.ui_version == 2)
+  }
+
   @Test("404 throws notFound")
   func notFound() async throws {
     let transport = MockClientTransport.returning(statusCode: 404)

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -3217,8 +3217,8 @@ components:
           type: boolean
           description: User activated flag
         ui_version:
-          type: string
-          description: 1 - old ui. 2 - new ui
+          type: integer
+          description: 1 - old ui, 2 - new ui
         virtual:
           type: boolean
           description: Virtual user flag


### PR DESCRIPTION
Fixes #321

## Problem

`add_card_member` returned HTTP 200 but SDK threw `DecodingError` because `MemberDetailed.ui_version` was typed as `String` in the schema, while the Kaiten API returns a `Number` (e.g. `2`).

Interestingly, the `User` schema already had `ui_version: integer` — the bug was only in `MemberDetailed`.

## Verification

Direct API call to `POST /api/latest/cards/{id}/members`:
```json
{ "ui_version": 2 }
```
Returns integer, not string.

## Fix

- `MemberDetailed.ui_version`: `string` → `integer`
- Added regression test with `ui_version: 2` in JSON payload