### PR TITLE
chore: annotate MemberDetailed.ui_version discrepancy with Kaiten docs

### DIFF
--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -3218,6 +3218,8 @@ components:
           description: User activated flag
         ui_version:
           type: integer
+          # NOTE: Kaiten API docs declare this as string, but actual API returns integer.
+          # Verified by direct API call — response contains numeric value (e.g. 2).
           description: 1 - old ui, 2 - new ui
         virtual:
           type: boolean


### PR DESCRIPTION
Adds a comment in the OpenAPI spec noting that `ui_version` is documented as `string` in Kaiten API docs but actually returns `integer`. Same pattern as the `blocker_card_id` annotation in `CardBlocker`.