### PR TITLE
ci: skip build-and-test on push to main

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,8 +1,6 @@
 name: Build and Test
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
Closes #336

Tests already run (and pass) on every PR before merge. Re-running them on every push to `main` wastes CI minutes without adding value.

## Changes
- Remove `push: branches: [main]` trigger from `build-and-test.yml`
- Workflow now runs only on `pull_request`