### PR TITLE
docs: add documentation for CardFilter

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -171,117 +171,161 @@ public struct KaitenClient: Sendable {
 
   // MARK: - Cards
 
-  /// Filters for listing cards.
+  /// Filters for querying cards from the Kaiten API.
   ///
-  /// All fields are optional. Only non-nil values are sent to the API.
-  /// Every query parameter supported by GET /cards is exposed here.
+  /// Use `CardFilter` to narrow down results when calling ``listCards(boardId:columnId:laneId:offset:limit:filter:)``.
+  /// All properties are optional — only set the ones you need. Non-`nil` values are sent as
+  /// query parameters to the `GET /cards` endpoint; `nil` values are omitted.
+  ///
+  /// ### Example: Find overdue cards assigned to specific members
+  /// ```swift
+  /// let cards = try await client.listCards(
+  ///   filter: CardFilter(
+  ///     memberIds: "10,25",
+  ///     overdue: true
+  ///   )
+  /// )
+  /// ```
+  ///
+  /// ### Example: Search cards by text within a space
+  /// ```swift
+  /// let results = try await client.listCards(
+  ///   filter: CardFilter(
+  ///     query: "login bug",
+  ///     searchFields: "title,description",
+  ///     spaceId: 42
+  ///   )
+  /// )
+  /// ```
+  ///
+  /// ### Example: Filter by workflow state and date range
+  /// ```swift
+  /// let done = try await client.listCards(
+  ///   filter: CardFilter(
+  ///     createdAfter: oneWeekAgo,
+  ///     states: [.done],
+  ///     orderBy: "updated_at",
+  ///     orderDirection: "desc"
+  ///   )
+  /// )
+  /// ```
+  ///
+  /// - SeeAlso: [Kaiten API – Cards](https://developers.kaiten.ru/cards/retrieve-card-list)
   public struct CardFilter: Sendable {
     // MARK: - Date filters
 
-    /// Filter cards created before this date.
+    /// Filter cards created before this date (inclusive, ISO 8601).
     public let createdBefore: Date?
-    /// Filter cards created after this date.
+    /// Filter cards created after this date (inclusive, ISO 8601).
     public let createdAfter: Date?
     /// Filter cards updated before this date.
     public let updatedBefore: Date?
     /// Filter cards updated after this date.
     public let updatedAfter: Date?
-    /// Filter cards first moved to in-progress after this date.
+    /// Filter cards that first entered an "in progress" column after this date.
     public let firstMovedInProgressAfter: Date?
-    /// Filter cards first moved to in-progress before this date.
+    /// Filter cards that first entered an "in progress" column before this date.
     public let firstMovedInProgressBefore: Date?
-    /// Filter cards last moved to done after this date.
+    /// Filter cards whose most recent move to a "done" column happened after this date.
     public let lastMovedToDoneAtAfter: Date?
-    /// Filter cards last moved to done before this date.
+    /// Filter cards whose most recent move to a "done" column happened before this date.
     public let lastMovedToDoneAtBefore: Date?
-    /// Filter cards with due date after this date.
+    /// Filter cards whose due date is after this date.
     public let dueDateAfter: Date?
-    /// Filter cards with due date before this date.
+    /// Filter cards whose due date is before this date.
     public let dueDateBefore: Date?
 
     // MARK: - Text search
 
-    /// Text search query.
+    /// Free-text search query matched against card content.
     public let query: String?
-    /// Comma-separated fields to search in.
+    /// Comma-separated list of fields to search in (e.g. `"title,description"`).
+    ///
+    /// When omitted, the API searches all default text fields.
     public let searchFields: String?
 
     // MARK: - Tags
 
-    /// Filter by tag name.
+    /// Filter by exact tag name.
     public let tag: String?
-    /// Comma-separated tag IDs.
+    /// Comma-separated tag IDs (e.g. `"1,2,3"`).
     public let tagIds: String?
 
-    // MARK: - ID filters
+    // MARK: - People & entity filters
 
-    /// Filter by card type ID.
+    /// Filter by a single card type ID.
     public let typeId: Int?
-    /// Comma-separated card type IDs.
+    /// Comma-separated card type IDs (e.g. `"1,4"`).
     public let typeIds: String?
-    /// Comma-separated member user IDs.
+    /// Comma-separated IDs of card **members** (participants added to the card).
     public let memberIds: String?
-    /// Filter by owner user ID.
+    /// Filter by a single **owner** ID — the user who created the card.
     public let ownerId: Int?
-    /// Comma-separated owner user IDs.
+    /// Comma-separated **owner** IDs (card creators).
     public let ownerIds: String?
-    /// Filter by responsible user ID.
+    /// Filter by a single **responsible** user ID — the person accountable for the card.
     public let responsibleId: Int?
-    /// Comma-separated responsible user IDs.
+    /// Comma-separated **responsible** user IDs.
     public let responsibleIds: String?
-    /// Comma-separated column IDs.
+    /// Comma-separated column IDs to restrict results to specific board columns.
     public let columnIds: String?
-    /// Filter by space ID.
+    /// Filter cards belonging to a specific space.
     public let spaceId: Int?
-    /// Filter by external ID.
+    /// Filter by an external integration ID (e.g. a Jira or GitLab reference).
     public let externalId: String?
     /// Comma-separated organization IDs.
     public let organizationsIds: String?
 
     // MARK: - Exclude filters
 
-    /// Comma-separated board IDs to exclude.
+    /// Comma-separated board IDs whose cards should be excluded from results.
     public let excludeBoardIds: String?
-    /// Comma-separated lane IDs to exclude.
+    /// Comma-separated lane IDs whose cards should be excluded.
     public let excludeLaneIds: String?
-    /// Comma-separated column IDs to exclude.
+    /// Comma-separated column IDs whose cards should be excluded.
     public let excludeColumnIds: String?
-    /// Comma-separated owner IDs to exclude.
+    /// Comma-separated owner IDs whose cards should be excluded.
     public let excludeOwnerIds: String?
-    /// Comma-separated card IDs to exclude.
+    /// Comma-separated card IDs to exclude from results.
     public let excludeCardIds: String?
 
     // MARK: - State filters
 
-    /// Card condition filter.
+    /// Card condition on the board.
+    ///
+    /// Use `.onBoard` to find active cards or `.archived` for archived ones.
+    /// - SeeAlso: ``CardCondition``
     public let condition: CardCondition?
-    /// Card workflow states to include.
+    /// Card workflow states to include (e.g. `[.queued, .inProgress, .done]`).
+    ///
+    /// When multiple states are provided, cards matching **any** of them are returned.
+    /// - SeeAlso: ``CardState``
     public let states: [CardState]?
-    /// Filter by archived status.
+    /// Filter by archived status (`true` = only archived, `false` = only non-archived).
     public let archived: Bool?
-    /// Filter ASAP cards.
+    /// When `true`, return only cards marked as ASAP (high urgency).
     public let asap: Bool?
-    /// Filter overdue cards.
+    /// When `true`, return only cards that are past their due date.
     public let overdue: Bool?
-    /// Filter cards done on time.
+    /// When `true`, return only cards that were completed before their due date.
     public let doneOnTime: Bool?
-    /// Filter cards that have a due date.
+    /// When `true`, return only cards that have a due date set.
     public let withDueDate: Bool?
-    /// Filter service desk request cards.
+    /// When `true`, return only cards created via service desk requests.
     public let isRequest: Bool?
 
     // MARK: - Sorting
 
-    /// Field to order by.
+    /// Field name to order results by (e.g. `"created_at"`, `"updated_at"`, `"due_date"`).
     public let orderBy: String?
-    /// Order direction: asc or desc.
+    /// Sort direction: `"asc"` for ascending or `"desc"` for descending.
     public let orderDirection: String?
-    /// Space ID for ordering context.
+    /// Space ID that provides the ordering context (required for some space-specific sort fields).
     public let orderSpaceId: Int?
 
     // MARK: - Extra
 
-    /// Comma-separated additional fields to include.
+    /// Comma-separated list of additional fields to include in the response (e.g. `"description,checklist"`).
     public let additionalCardFields: String?
 
     /// Creates a new card filter with all fields defaulting to `nil`.


### PR DESCRIPTION
## Summary

- Add struct-level doc comment with three usage examples for `CardFilter`
- Enhance per-property documentation for non-obvious fields (people roles, search fields, state filters, sorting options)
- Improve MARK group labels for better Xcode navigation
- Add `SeeAlso` links to Kaiten API docs and related enum types

Closes #352

## Test plan

- [ ] Verify build succeeds (documentation-only change, no logic changes)
- [ ] Confirm no properties were renamed or reordered

🤖 Generated with [Claude Code](https://claude.com/claude-code)