### PR TITLE
fix: rename childId to childCardId in removeCardChild

### DIFF
--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -1340,16 +1340,16 @@ extension KaitenClient {
   ///
   /// - Parameters:
   ///   - cardId: The parent card identifier.
-  ///   - childId: The child card identifier.
+  ///   - childCardId: The child card identifier.
   /// - Returns: The deleted child ID.
   /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card or child does not exist.
-  public func removeCardChild(cardId: Int, childId: Int) async throws(KaitenError) -> Int {
+  public func removeCardChild(cardId: Int, childCardId: Int) async throws(KaitenError) -> Int {
     let response = try await call {
       try await client.remove_card_child(
-        path: .init(card_id: cardId, id: childId)
+        path: .init(card_id: cardId, id: childCardId)
       )
     }
-    let body = try decodeResponse(response.toCase(), notFoundResource: ("child", childId)) {
+    let body = try decodeResponse(response.toCase(), notFoundResource: ("child", childCardId)) {
       try $0.json
     }
     return body.id

--- a/Sources/kaiten/Cards/ChildCommands.swift
+++ b/Sources/kaiten/Cards/ChildCommands.swift
@@ -59,11 +59,11 @@ struct RemoveCardChild: AsyncParsableCommand {
   var cardId: Int
 
   @Option(name: .long, help: "Child Card ID")
-  var childId: Int
+  var childCardId: Int
 
   func run() async throws {
     let client = try await global.makeClient()
-    let deletedId = try await client.removeCardChild(cardId: cardId, childId: childId)
+    let deletedId = try await client.removeCardChild(cardId: cardId, childCardId: childCardId)
     try printJSON(["id": deletedId])
   }
 }

--- a/Tests/KaitenSDKTests/RemoveCardChildTests.swift
+++ b/Tests/KaitenSDKTests/RemoveCardChildTests.swift
@@ -16,7 +16,7 @@ struct RemoveCardChildTests {
     let client = try KaitenClient(
       baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    let deletedId = try await client.removeCardChild(cardId: 42, childId: 5)
+    let deletedId = try await client.removeCardChild(cardId: 42, childCardId: 5)
     #expect(deletedId == 5)
   }
 
@@ -27,7 +27,7 @@ struct RemoveCardChildTests {
       baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
     await #expect(throws: KaitenError.self) {
-      _ = try await client.removeCardChild(cardId: 42, childId: 999)
+      _ = try await client.removeCardChild(cardId: 42, childCardId: 999)
     }
   }
 
@@ -38,7 +38,7 @@ struct RemoveCardChildTests {
       baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
     await #expect(throws: KaitenError.self) {
-      _ = try await client.removeCardChild(cardId: 1, childId: 1)
+      _ = try await client.removeCardChild(cardId: 1, childCardId: 1)
     }
   }
 }


### PR DESCRIPTION
## Summary

- Rename `childId` parameter to `childCardId` in `removeCardChild` for consistency with `addCardChild`
- Update all call sites in Sources and Tests

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)