### PR TITLE
refactor: use option structs for card create/update

### DIFF
--- a/Sources/KaitenSDK/CardOptions.swift
+++ b/Sources/KaitenSDK/CardOptions.swift
@@ -1,0 +1,133 @@
+import OpenAPIRuntime
+
+/// Options for creating a new card.
+///
+/// Only ``title`` and ``boardId`` are required; all other properties default to `nil`
+/// and are omitted from the request when not set.
+///
+/// ```swift
+/// var opts = CardCreateOptions(title: "Bug fix", boardId: 1)
+/// opts.columnId = 42
+/// opts.description = "Fix the login crash"
+/// let card = try await client.createCard(opts)
+/// ```
+public struct CardCreateOptions: Sendable {
+  /// Card title (required).
+  public var title: String
+  /// Board ID (required).
+  public var boardId: Int
+  /// Target column ID.
+  public var columnId: Int?
+  /// Target lane ID.
+  public var laneId: Int?
+  /// Card description.
+  public var description: String?
+  /// ASAP marker.
+  public var asap: Bool?
+  /// Deadline in ISO 8601 format.
+  public var dueDate: String?
+  /// Whether deadline includes hours and minutes.
+  public var dueDateTimePresent: Bool?
+  /// Position in the cell (numeric sort order).
+  public var sortOrder: Double?
+  /// Fixed deadline flag.
+  public var expiresLater: Bool?
+  /// Size text (e.g. "1", "S", "XL").
+  public var sizeText: String?
+  /// Owner user ID.
+  public var ownerId: Int?
+  /// Responsible user ID.
+  public var responsibleId: Int?
+  /// Owner email address.
+  public var ownerEmail: String?
+  /// Card position in cell (first or last). Overrides ``sortOrder``.
+  public var position: CardPosition?
+  /// Card type ID.
+  public var typeId: Int?
+  /// External identifier.
+  public var externalId: String?
+  /// Text format for card description.
+  public var textFormatTypeId: TextFormatType?
+  /// Custom properties object.
+  public var properties: Components.Schemas.CreateCardRequest.propertiesPayload?
+
+  /// Creates card creation options.
+  ///
+  /// - Parameters:
+  ///   - title: Card title.
+  ///   - boardId: Board ID.
+  public init(title: String, boardId: Int) {
+    self.title = title
+    self.boardId = boardId
+  }
+}
+
+/// Options for updating an existing card.
+///
+/// All properties default to `nil` — only set values are sent to the server.
+///
+/// ```swift
+/// var opts = CardUpdateOptions()
+/// opts.title = "New Title"
+/// opts.columnId = 42
+/// let card = try await client.updateCard(id: 123, opts)
+/// ```
+public struct CardUpdateOptions: Sendable {
+  /// New card title.
+  public var title: String?
+  /// New description.
+  public var description: String?
+  /// ASAP marker.
+  public var asap: Bool?
+  /// Deadline in ISO 8601 format.
+  public var dueDate: String?
+  /// Whether deadline includes hours and minutes.
+  public var dueDateTimePresent: Bool?
+  /// Position in the cell.
+  public var sortOrder: Double?
+  /// Fixed deadline flag.
+  public var expiresLater: Bool?
+  /// Size text (e.g. "1", "S", "XL").
+  public var sizeText: String?
+  /// Target board ID.
+  public var boardId: Int?
+  /// Target column ID.
+  public var columnId: Int?
+  /// Target lane ID.
+  public var laneId: Int?
+  /// Owner user ID.
+  public var ownerId: Int?
+  /// Card type ID.
+  public var typeId: Int?
+  /// Service ID.
+  public var serviceId: Int?
+  /// Send `false` to release all blocks.
+  public var blocked: Bool?
+  /// Card condition (on board or archived).
+  public var condition: CardCondition?
+  /// External identifier.
+  public var externalId: String?
+  /// Text format for card description.
+  public var textFormatTypeId: TextFormatType?
+  /// Service Desk new comment flag.
+  public var sdNewComment: Bool?
+  /// Owner email address.
+  public var ownerEmail: String?
+  /// Previous card ID for repositioning.
+  public var prevCardId: Int?
+  /// Estimated workload.
+  public var estimateWorkload: Double?
+  /// Planned start date. Supports three states via `String??`:
+  ///
+  /// - `nil` (default): field omitted — server leaves value unchanged.
+  /// - `.some(nil)`: field sent as JSON `null` — server clears the value.
+  /// - `.some("2026-03-10")`: field sent as ISO 8601 string — server sets the value.
+  public var plannedStart: String??
+  /// Planned end date. Same three-state semantics as ``plannedStart``.
+  public var plannedEnd: String??
+  /// Custom properties object.
+  public var properties: Components.Schemas.UpdateCardRequest.propertiesPayload?
+
+  /// Creates empty card update options.
+  public init() {}
+}

--- a/Sources/KaitenSDK/Enums.swift
+++ b/Sources/KaitenSDK/Enums.swift
@@ -6,7 +6,7 @@
 
 /// Card condition on a board.
 ///
-/// Used in ``KaitenClient/CardFilter``, ``KaitenClient/updateCard(id:...)``.
+/// Used in ``KaitenClient/CardFilter`` and ``CardUpdateOptions``.
 /// - SeeAlso: [Kaiten API – Cards](https://developers.kaiten.ru/cards/retrieve-card-list)
 public enum CardCondition: Int, Sendable, CaseIterable {
   /// Card is on the board (active).
@@ -55,7 +55,7 @@ public enum CardMemberRoleType: Int, Sendable, CaseIterable {
 
 /// Text format for card description.
 ///
-/// Used in ``KaitenClient/createCard(...)`` and ``KaitenClient/updateCard(id:...)``.
+/// Used in ``CardCreateOptions`` and ``CardUpdateOptions``.
 /// - SeeAlso: [Kaiten API – Create Card](https://developers.kaiten.ru/cards/create-card)
 public enum TextFormatType: Int, Sendable, CaseIterable {
   /// Markdown format (default).

--- a/Sources/KaitenSDK/KaitenClient.swift
+++ b/Sources/KaitenSDK/KaitenClient.swift
@@ -460,69 +460,32 @@ public struct KaitenClient: Sendable {
 
   /// Creates a new card on a board.
   ///
-  /// - Parameters:
-  ///   - title: Card title (required, max 1024 characters).
-  ///   - boardId: Board ID where the card will be created (required).
-  ///   - columnId: Column ID. If omitted the board's default column is used.
-  ///   - laneId: Lane ID. If omitted the board's default lane is used.
-  ///   - description: Card description (max 32768 characters).
-  ///   - asap: ASAP marker.
-  ///   - dueDate: Deadline in ISO 8601 format.
-  ///   - dueDateTimePresent: Whether deadline includes hours and minutes.
-  ///   - sortOrder: Position in the cell.
-  ///   - expiresLater: Fixed deadline flag.
-  ///   - sizeText: Size text (e.g. "1", "S", "XL").
-  ///   - ownerId: Owner user ID.
-  ///   - responsibleId: Responsible user ID.
-  ///   - ownerEmail: Owner email address (only works if email belongs to company user).
-  ///   - position: Card position in cell. Overrides sort_order if present.
-  ///   - typeId: Card type ID.
-  ///   - externalId: External identifier.
-  ///   - textFormatTypeId: Text format for card description.
-  ///   - properties: Custom properties object.
+  /// - Parameter options: Creation options. See ``CardCreateOptions``.
   /// - Returns: The created card.
   /// - Throws: ``KaitenError``
   public func createCard(
-    title: String,
-    boardId: Int,
-    columnId: Int? = nil,
-    laneId: Int? = nil,
-    description: String? = nil,
-    asap: Bool? = nil,
-    dueDate: String? = nil,
-    dueDateTimePresent: Bool? = nil,
-    sortOrder: Double? = nil,
-    expiresLater: Bool? = nil,
-    sizeText: String? = nil,
-    ownerId: Int? = nil,
-    responsibleId: Int? = nil,
-    ownerEmail: String? = nil,
-    position: CardPosition? = nil,
-    typeId: Int? = nil,
-    externalId: String? = nil,
-    textFormatTypeId: TextFormatType? = nil,
-    properties: Components.Schemas.CreateCardRequest.propertiesPayload? = nil
+    _ options: CardCreateOptions
   ) async throws(KaitenError) -> Components.Schemas.Card {
     let body = Components.Schemas.CreateCardRequest(
-      title: title,
-      board_id: boardId,
-      column_id: columnId,
-      lane_id: laneId,
-      description: description,
-      asap: asap,
-      due_date: dueDate,
-      due_date_time_present: dueDateTimePresent,
-      sort_order: sortOrder,
-      expires_later: expiresLater,
-      size_text: sizeText,
-      owner_id: ownerId,
-      responsible_id: responsibleId,
-      owner_email: ownerEmail,
-      position: position?.rawValue,
-      type_id: typeId,
-      external_id: externalId,
-      text_format_type_id: textFormatTypeId?.rawValue,
-      properties: properties
+      title: options.title,
+      board_id: options.boardId,
+      column_id: options.columnId,
+      lane_id: options.laneId,
+      description: options.description,
+      asap: options.asap,
+      due_date: options.dueDate,
+      due_date_time_present: options.dueDateTimePresent,
+      sort_order: options.sortOrder,
+      expires_later: options.expiresLater,
+      size_text: options.sizeText,
+      owner_id: options.ownerId,
+      responsible_id: options.responsibleId,
+      owner_email: options.ownerEmail,
+      position: options.position?.rawValue,
+      type_id: options.typeId,
+      external_id: options.externalId,
+      text_format_type_id: options.textFormatTypeId?.rawValue,
+      properties: options.properties
     )
     let response = try await call {
       try await client.create_card(body: .json(body))
@@ -532,99 +495,47 @@ public struct KaitenClient: Sendable {
 
   /// Updates a card by its identifier.
   ///
-  /// All fields in the request body are optional — only provided values are changed.
+  /// All fields in ``CardUpdateOptions`` are optional — only set values are changed.
   ///
   /// - Parameters:
   ///   - id: The card identifier.
-  ///   - title: New card title.
-  ///   - description: New description (pass `nil` wrapped in `.some(nil)` to clear).
-  ///   - asap: ASAP marker.
-  ///   - dueDate: Deadline in ISO 8601 format (pass `nil` wrapped in `.some(nil)` to clear).
-  ///   - dueDateTimePresent: Whether deadline includes hours and minutes.
-  ///   - sortOrder: Position in the cell.
-  ///   - expiresLater: Fixed deadline flag.
-  ///   - sizeText: Size text (e.g. "1", "S", "XL").
-  ///   - boardId: Target board ID.
-  ///   - columnId: Target column ID.
-  ///   - laneId: Target lane ID.
-  ///   - ownerId: Owner user ID.
-  ///   - typeId: Card type ID.
-  ///   - serviceId: Service ID.
-  ///   - blocked: Send `false` to release all blocks.
-  ///   - condition: Card condition (on board or archived).
-  ///   - externalId: External identifier.
-  ///   - textFormatTypeId: Text format for card description.
-  ///   - sdNewComment: Service Desk new comment flag.
-  ///   - ownerEmail: Owner email address.
-  ///   - prevCardId: Previous card ID for repositioning.
-  ///   - estimateWorkload: Estimated workload.
-  ///   - plannedStart: Planned start date. Supports three states via `String??`:
-  ///     - `nil` (default): field omitted — server leaves value unchanged.
-  ///     - `.some(nil)`: field sent as JSON `null` — server clears the value.
-  ///     - `.some("2026-03-10")`: field sent as ISO 8601 string — server sets the value.
-  ///     See ``ExplicitNullString`` for implementation details.
-  ///   - plannedEnd: Planned end date. Same three-state semantics as `plannedStart`.
-  ///   - properties: Custom properties object.
+  ///   - options: Update options. See ``CardUpdateOptions``.
   /// - Returns: The updated card.
   /// - Throws: ``KaitenError/notFound(resource:id:)`` if the card does not exist.
   public func updateCard(
     id: Int,
-    title: String? = nil,
-    description: String? = nil,
-    asap: Bool? = nil,
-    dueDate: String? = nil,
-    dueDateTimePresent: Bool? = nil,
-    sortOrder: Double? = nil,
-    expiresLater: Bool? = nil,
-    sizeText: String? = nil,
-    boardId: Int? = nil,
-    columnId: Int? = nil,
-    laneId: Int? = nil,
-    ownerId: Int? = nil,
-    typeId: Int? = nil,
-    serviceId: Int? = nil,
-    blocked: Bool? = nil,
-    condition: CardCondition? = nil,
-    externalId: String? = nil,
-    textFormatTypeId: TextFormatType? = nil,
-    sdNewComment: Bool? = nil,
-    ownerEmail: String? = nil,
-    prevCardId: Int? = nil,
-    estimateWorkload: Double? = nil,
-    plannedStart: String?? = nil,
-    plannedEnd: String?? = nil,
-    properties: Components.Schemas.UpdateCardRequest.propertiesPayload? = nil
+    _ options: CardUpdateOptions
   ) async throws(KaitenError) -> Components.Schemas.Card {
     let body = Components.Schemas.UpdateCardRequest(
-      title: title,
-      description: description,
-      asap: asap,
-      due_date: dueDate,
-      due_date_time_present: dueDateTimePresent,
-      sort_order: sortOrder,
-      expires_later: expiresLater,
-      size_text: sizeText,
-      board_id: boardId,
-      column_id: columnId,
-      lane_id: laneId,
-      owner_id: ownerId,
-      type_id: typeId,
-      service_id: serviceId,
-      blocked: blocked,
-      condition: condition?.rawValue,
-      external_id: externalId,
-      text_format_type_id: textFormatTypeId?.rawValue,
-      sd_new_comment: sdNewComment,
-      owner_email: ownerEmail,
-      prev_card_id: prevCardId,
-      estimate_workload: estimateWorkload,
+      title: options.title,
+      description: options.description,
+      asap: options.asap,
+      due_date: options.dueDate,
+      due_date_time_present: options.dueDateTimePresent,
+      sort_order: options.sortOrder,
+      expires_later: options.expiresLater,
+      size_text: options.sizeText,
+      board_id: options.boardId,
+      column_id: options.columnId,
+      lane_id: options.laneId,
+      owner_id: options.ownerId,
+      type_id: options.typeId,
+      service_id: options.serviceId,
+      blocked: options.blocked,
+      condition: options.condition?.rawValue,
+      external_id: options.externalId,
+      text_format_type_id: options.textFormatTypeId?.rawValue,
+      sd_new_comment: options.sdNewComment,
+      owner_email: options.ownerEmail,
+      prev_card_id: options.prevCardId,
+      estimate_workload: options.estimateWorkload,
       // Map String?? → ExplicitNullString?:
       //   nil          → nil          (field omitted from JSON, server leaves value unchanged)
       //   .some(nil)   → .some(.null) (field sent as JSON null, server clears the value)
       //   .some("x")   → .some(.value("x")) (field sent as string, server sets the value)
-      planned_start: plannedStart.map { $0.map(ExplicitNullString.value) ?? .null },
-      planned_end: plannedEnd.map { $0.map(ExplicitNullString.value) ?? .null },
-      properties: properties
+      planned_start: options.plannedStart.map { $0.map(ExplicitNullString.value) ?? .null },
+      planned_end: options.plannedEnd.map { $0.map(ExplicitNullString.value) ?? .null },
+      properties: options.properties
     )
     let response = try await call {
       try await client.update_card(

--- a/Sources/kaiten/Cards/CardCommands.swift
+++ b/Sources/kaiten/Cards/CardCommands.swift
@@ -306,26 +306,24 @@ struct CreateCard: AsyncParsableCommand {
 
   func run() async throws {
     let client = try await global.makeClient()
-    let card = try await client.createCard(
-      title: title,
-      boardId: boardId,
-      columnId: columnId,
-      laneId: laneId,
-      description: description,
-      asap: asap,
-      dueDate: dueDate,
-      dueDateTimePresent: dueDateTimePresent,
-      sortOrder: sortOrder,
-      expiresLater: expiresLater,
-      sizeText: sizeText,
-      ownerId: ownerId,
-      responsibleId: responsibleId,
-      ownerEmail: ownerEmail,
-      position: position.flatMap(CardPosition.init(rawValue:)),
-      typeId: typeId,
-      externalId: externalId,
-      textFormatTypeId: textFormatTypeId.flatMap(TextFormatType.init(rawValue:))
-    )
+    var opts = CardCreateOptions(title: title, boardId: boardId)
+    opts.columnId = columnId
+    opts.laneId = laneId
+    opts.description = description
+    opts.asap = asap
+    opts.dueDate = dueDate
+    opts.dueDateTimePresent = dueDateTimePresent
+    opts.sortOrder = sortOrder
+    opts.expiresLater = expiresLater
+    opts.sizeText = sizeText
+    opts.ownerId = ownerId
+    opts.responsibleId = responsibleId
+    opts.ownerEmail = ownerEmail
+    opts.position = position.flatMap(CardPosition.init(rawValue:))
+    opts.typeId = typeId
+    opts.externalId = externalId
+    opts.textFormatTypeId = textFormatTypeId.flatMap(TextFormatType.init(rawValue:))
+    let card = try await client.createCard(opts)
     try printJSON(card)
   }
 }
@@ -436,38 +434,35 @@ struct UpdateCard: AsyncParsableCommand {
 
   func run() async throws {
     let client = try await global.makeClient()
+    var opts = CardUpdateOptions()
+    opts.title = title
+    opts.description = description
+    opts.asap = asap
+    opts.dueDate = dueDate
+    opts.dueDateTimePresent = dueDateTimePresent
+    opts.sortOrder = sortOrder
+    opts.expiresLater = expiresLater
+    opts.sizeText = sizeText
+    opts.boardId = boardId
+    opts.columnId = columnId
+    opts.laneId = laneId
+    opts.ownerId = ownerId
+    opts.typeId = typeId
+    opts.serviceId = serviceId
+    opts.blocked = blocked
+    opts.condition = condition.flatMap(CardCondition.init(rawValue:))
+    opts.externalId = externalId
+    opts.textFormatTypeId = textFormatTypeId.flatMap(TextFormatType.init(rawValue:))
+    opts.ownerEmail = ownerEmail
+    opts.prevCardId = prevCardId
+    opts.estimateWorkload = estimateWorkload
     // Map String? → String??:
     //   nil (not passed)  → nil         (omit field, server leaves value unchanged)
     //   ""  (empty)       → .some(nil)  (send JSON null, server clears the value)
     //   "date"            → .some("date") (send string, server sets the value)
-    let plannedStartArg: String?? = plannedStart.map { $0.isEmpty ? nil : $0 }
-    let plannedEndArg: String?? = plannedEnd.map { $0.isEmpty ? nil : $0 }
-    let card = try await client.updateCard(
-      id: id,
-      title: title,
-      description: description,
-      asap: asap,
-      dueDate: dueDate,
-      dueDateTimePresent: dueDateTimePresent,
-      sortOrder: sortOrder,
-      expiresLater: expiresLater,
-      sizeText: sizeText,
-      boardId: boardId,
-      columnId: columnId,
-      laneId: laneId,
-      ownerId: ownerId,
-      typeId: typeId,
-      serviceId: serviceId,
-      blocked: blocked,
-      condition: condition.flatMap(CardCondition.init(rawValue:)),
-      externalId: externalId,
-      textFormatTypeId: textFormatTypeId.flatMap(TextFormatType.init(rawValue:)),
-      ownerEmail: ownerEmail,
-      prevCardId: prevCardId,
-      estimateWorkload: estimateWorkload,
-      plannedStart: plannedStartArg,
-      plannedEnd: plannedEndArg
-    )
+    opts.plannedStart = plannedStart.map { $0.isEmpty ? nil : $0 }
+    opts.plannedEnd = plannedEnd.map { $0.isEmpty ? nil : $0 }
+    let card = try await client.updateCard(id: id, opts)
     try printJSON(card)
   }
 }

--- a/Tests/KaitenSDKTests/CreateCardTests.swift
+++ b/Tests/KaitenSDKTests/CreateCardTests.swift
@@ -16,7 +16,7 @@ struct CreateCardTests {
     let client = try KaitenClient(
       baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    let card = try await client.createCard(title: "New card", boardId: 1)
+    let card = try await client.createCard(CardCreateOptions(title: "New card", boardId: 1))
     #expect(card.id == 123)
     #expect(card.title == "New card")
   }
@@ -28,7 +28,7 @@ struct CreateCardTests {
       baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
     await #expect(throws: KaitenError.self) {
-      _ = try await client.createCard(title: "Test", boardId: 1)
+      _ = try await client.createCard(CardCreateOptions(title: "Test", boardId: 1))
     }
   }
 
@@ -39,7 +39,7 @@ struct CreateCardTests {
       baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
     await #expect(throws: KaitenError.self) {
-      _ = try await client.createCard(title: "Test", boardId: 1)
+      _ = try await client.createCard(CardCreateOptions(title: "Test", boardId: 1))
     }
   }
 
@@ -50,7 +50,7 @@ struct CreateCardTests {
       baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
     await #expect(throws: KaitenError.self) {
-      _ = try await client.createCard(title: "Test", boardId: 1)
+      _ = try await client.createCard(CardCreateOptions(title: "Test", boardId: 1))
     }
   }
 }

--- a/Tests/KaitenSDKTests/UpdateCardTests.swift
+++ b/Tests/KaitenSDKTests/UpdateCardTests.swift
@@ -17,7 +17,10 @@ struct UpdateCardTests {
     let client = try KaitenClient(
       baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    let card = try await client.updateCard(id: 42, title: "Updated title", description: "New desc")
+    var opts = CardUpdateOptions()
+    opts.title = "Updated title"
+    opts.description = "New desc"
+    let card = try await client.updateCard(id: 42, opts)
     #expect(card.id == 42)
     #expect(card.title == "Updated title")
     #expect(card.description == "New desc")
@@ -30,7 +33,9 @@ struct UpdateCardTests {
       baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
     await #expect(throws: KaitenError.self) {
-      _ = try await client.updateCard(id: 999, title: "x")
+      var opts = CardUpdateOptions()
+      opts.title = "x"
+      _ = try await client.updateCard(id: 999, opts)
     }
   }
 
@@ -41,7 +46,9 @@ struct UpdateCardTests {
       baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
     await #expect(throws: KaitenError.self) {
-      _ = try await client.updateCard(id: 1, title: "x")
+      var opts = CardUpdateOptions()
+      opts.title = "x"
+      _ = try await client.updateCard(id: 1, opts)
     }
   }
 
@@ -62,7 +69,7 @@ struct UpdateCardTests {
     let client = try KaitenClient(
       baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    _ = try await client.updateCard(id: 42, plannedStart: nil)
+    _ = try await client.updateCard(id: 42, CardUpdateOptions())
 
     let body = try await requestBodyJSON(from: transport)
     #expect(body["planned_start"] == nil, "planned_start should be absent when nil")
@@ -74,7 +81,9 @@ struct UpdateCardTests {
     let client = try KaitenClient(
       baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    _ = try await client.updateCard(id: 42, plannedStart: .some(nil))
+    var opts = CardUpdateOptions()
+    opts.plannedStart = .some(nil)
+    _ = try await client.updateCard(id: 42, opts)
 
     let body = try await requestBodyJSON(from: transport)
     #expect(body["planned_start"] is NSNull, "planned_start should be JSON null when .some(nil)")
@@ -86,7 +95,9 @@ struct UpdateCardTests {
     let client = try KaitenClient(
       baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    _ = try await client.updateCard(id: 42, plannedStart: "2026-03-10")
+    var opts = CardUpdateOptions()
+    opts.plannedStart = "2026-03-10"
+    _ = try await client.updateCard(id: 42, opts)
 
     let body = try await requestBodyJSON(from: transport)
     #expect(body["planned_start"] as? String == "2026-03-10")
@@ -98,7 +109,7 @@ struct UpdateCardTests {
     let client = try KaitenClient(
       baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    _ = try await client.updateCard(id: 42, plannedEnd: nil)
+    _ = try await client.updateCard(id: 42, CardUpdateOptions())
 
     let body = try await requestBodyJSON(from: transport)
     #expect(body["planned_end"] == nil, "planned_end should be absent when nil")
@@ -110,7 +121,9 @@ struct UpdateCardTests {
     let client = try KaitenClient(
       baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    _ = try await client.updateCard(id: 42, plannedEnd: .some(nil))
+    var opts = CardUpdateOptions()
+    opts.plannedEnd = .some(nil)
+    _ = try await client.updateCard(id: 42, opts)
 
     let body = try await requestBodyJSON(from: transport)
     #expect(body["planned_end"] is NSNull, "planned_end should be JSON null when .some(nil)")
@@ -122,7 +135,9 @@ struct UpdateCardTests {
     let client = try KaitenClient(
       baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
 
-    _ = try await client.updateCard(id: 42, plannedEnd: "2026-12-31")
+    var opts = CardUpdateOptions()
+    opts.plannedEnd = "2026-12-31"
+    _ = try await client.updateCard(id: 42, opts)
 
     let body = try await requestBodyJSON(from: transport)
     #expect(body["planned_end"] as? String == "2026-12-31")


### PR DESCRIPTION
## Summary

- Add `CardCreateOptions` and `CardUpdateOptions` structs to replace long parameter lists in `createCard()` and `updateCard()`
- Update all call sites: CLI commands and tests
- All 247 tests pass

Closes #348

## Test plan

- [x] All existing tests pass (`swift test` — 247 tests)
- [x] Build succeeds (`swift build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)