### PR TITLE
fix: replace nullable+allOf with anyOf for CardBlocker fields

### DIFF
--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -4289,19 +4289,19 @@ components:
           type: string
           description: Last update timestamp
         blocked_card:
-          allOf:
+          anyOf:
           - $ref: '#/components/schemas/Card'
-          nullable: true
+          - type: 'null'
           description: Blocked card info
         card:
-          allOf:
+          anyOf:
           - $ref: '#/components/schemas/Card'
-          nullable: true
+          - type: 'null'
           description: Blocking card info
         blocker:
-          allOf:
+          anyOf:
           - $ref: '#/components/schemas/User'
-          nullable: true
+          - type: 'null'
           description: Info of user who blocked card
     CreateCardBlockerRequest:
       type: object


### PR DESCRIPTION
## Summary

- `Sources/KaitenSDK/openapi.yaml` declares `openapi: 3.1.0` but `CardBlocker.{blocked_card, card, blocker}` used the OpenAPI 3.0 `allOf + nullable: true` pattern, which has been removed in 3.1.
- Replaced with the 3.1-native `anyOf: [$ref, type: 'null']` form. No behavior change — the generator still emits an optional in Swift.
- Removes 9 lines of validation/schema warnings every dependent project saw on every build, and unblocks consumers that opt into `treatAllWarnings(as: .error)`.

Closes #389

## Test plan

- [ ] CI build (macOS arm64, Linux x86_64/arm64, Windows x86_64/arm64) green
- [ ] Lint green
- [ ] No more `'nullable' property` warnings in generator output for CardBlocker