### PR TITLE
docs(openapi): clean up DOC_MISMATCH after Kaiten support fixed docs

### DIFF
--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -4281,19 +4281,19 @@ components:
           type: string
           description: Last update timestamp
         blocked_card:
-          allOf:
+          anyOf:
           - $ref: '#/components/schemas/Card'
-          nullable: true
+          - type: 'null'
           description: Blocked card info
         card:
-          allOf:
+          anyOf:
           - $ref: '#/components/schemas/Card'
-          nullable: true
+          - type: 'null'
           description: Blocking card info
         blocker:
-          allOf:
+          anyOf:
           - $ref: '#/components/schemas/User'
-          nullable: true
+          - type: 'null'
           description: Info of user who blocked card
     CreateCardBlockerRequest:
       type: object

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -2262,7 +2262,6 @@ components:
           type: integer
           description: Column ID
         lane_id:
-          # DOC_MISMATCH: docs=non-nullable `integer`, actual=`integer | null` — https://developers.kaiten.ru/cards/retrieve-card
           type:
           - integer
           - 'null'
@@ -2274,7 +2273,6 @@ components:
           type: integer
           description: Owner user ID
         type_id:
-          # DOC_MISMATCH: docs=non-nullable `integer`, actual=`integer | null` — https://developers.kaiten.ru/cards/retrieve-card
           type:
           - integer
           - 'null'
@@ -2331,7 +2329,6 @@ components:
           - 'null'
           description: Milestone ID
         sprint_id:
-          # DOC_MISMATCH: docs=non-nullable `integer`, actual=`integer | null` — https://developers.kaiten.ru/cards/retrieve-card
           type:
           - integer
           - 'null'
@@ -2370,7 +2367,6 @@ components:
           - 'null'
           description: Last moved to done timestamp
         service_id:
-          # DOC_MISMATCH: docs=non-nullable `integer`, actual=`integer | null` — https://developers.kaiten.ru/cards/retrieve-card
           type:
           - integer
           - 'null'
@@ -2456,7 +2452,6 @@ components:
             type: integer
           description: Parent link IDs
         fifo_order:
-          # DOC_MISMATCH: docs=non-nullable `integer`, actual=`integer | null` — https://developers.kaiten.ru/cards/retrieve-card
           type:
           - integer
           - 'null'
@@ -2530,8 +2525,20 @@ components:
           - 'null'
           description: Lock status
         source:
-          # DOC_MISMATCH: docs=`enum | null` (no values listed), actual=`string`; observed: "app", "api" — https://developers.kaiten.ru/cards/retrieve-card
-          type: string
+          type:
+          - string
+          - 'null'
+          enum:
+          - app
+          - api
+          - email
+          - telegram
+          - slack
+          - webhook
+          - import
+          - schedule
+          - automation
+          - null
           description: Card source
         lane:
           type: object
@@ -2540,7 +2547,7 @@ components:
           type: object
           description: Inline column summary
         board:
-          # DOC_MISMATCH: docs show full Board schema, actual API returns only 6 fields: id, uid, title, external_id, card_properties, settings — https://developers.kaiten.ru/cards/retrieve-card
+          # DOC_MISMATCH: docs list full Board schema (created, updated, description, email_key, columns, lanes, cards, …), actual API returns only 7 fields: id, uid, title, external_id, card_properties, settings, spaces — https://developers.kaiten.ru/cards/retrieve-card
           $ref: '#/components/schemas/CardBoardSummary'
         type:
           $ref: '#/components/schemas/CardType'
@@ -2667,7 +2674,6 @@ components:
           type: integer
           description: Width
         wip_limit:
-          # DOC_MISMATCH: docs=non-nullable `integer`, actual=`integer | null` — https://developers.kaiten.ru/columns/get-list-of-columns
           type:
           - integer
           - 'null'
@@ -2682,7 +2688,6 @@ components:
           type: integer
           description: Board id
         column_id:
-          # DOC_MISMATCH: docs=`null` (no base type), actual=`integer | null` — https://developers.kaiten.ru/columns/get-list-of-columns
           type:
           - integer
           - 'null'
@@ -2700,7 +2705,6 @@ components:
           - 'null'
           description: External id
         default_tags:
-          # DOC_MISMATCH: docs=non-nullable `string`, actual=`string | null` — https://developers.kaiten.ru/columns/get-list-of-columns
           type:
           - string
           - 'null'
@@ -2728,11 +2732,9 @@ components:
           type: boolean
           description: Indicates whether the SLA timer should be paused in this column
         uid:
-          # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/columns/get-list-of-columns
           type: string
           description: Column UID
         locked:
-          # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/columns/get-list-of-columns
           type:
           - string
           - 'null'
@@ -2759,7 +2761,6 @@ components:
           type: integer
           description: Height
         wip_limit:
-          # DOC_MISMATCH: docs=non-nullable `integer`, actual=`integer | null` — https://developers.kaiten.ru/lanes/get-list-of-lanes
           type:
           - integer
           - 'null'
@@ -2781,7 +2782,6 @@ components:
           - 'null'
           description: External id
         default_tags:
-          # DOC_MISMATCH: docs=non-nullable `string`, actual=`string | null` — https://developers.kaiten.ru/lanes/get-list-of-lanes
           type:
           - string
           - 'null'
@@ -2799,11 +2799,9 @@ components:
           type: integer
           description: 1 - live, 2 - archived, 3 - deleted
         uid:
-          # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/lanes/get-list-of-lanes
           type: string
           description: Lane UID
         locked:
-          # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/lanes/get-list-of-lanes
           type:
           - string
           - 'null'
@@ -2980,11 +2978,9 @@ components:
           type: string
           description: Custom property type
         show_on_facade:
-          # DOC_MISMATCH: docs=`string`, actual=`boolean` — https://developers.kaiten.ru/custom-properties/get-list-of-properties
           type: boolean
           description: Should show property on card's facade
         multiline:
-          # DOC_MISMATCH: docs=`string`, actual=`boolean` — https://developers.kaiten.ru/custom-properties/get-list-of-properties
           type: boolean
           description: Should render multiline text field
         fields_settings:
@@ -3140,7 +3136,6 @@ components:
           type: integer
           description: Comment ID
         uid:
-          # DOC_MISMATCH: docs=`integer`, actual=`string` (UUID) — https://developers.kaiten.ru/card-comments/retrieve-card-comments
           type: string
           description: Comment UID
         text:
@@ -3168,7 +3163,6 @@ components:
           type: boolean
           description: Deleted flag
         sd_external_recipients_cc:
-          # DOC_MISMATCH: docs=non-nullable `string`, actual=`string | null` — https://developers.kaiten.ru/card-comments/retrieve-card-comments
           type:
           - string
           - 'null'
@@ -3177,7 +3171,6 @@ components:
           type: boolean
           description: Flag indicating comment is used as request description
         notification_sent:
-          # DOC_MISMATCH: docs=non-nullable `string`, actual=`string | null` — https://developers.kaiten.ru/card-comments/retrieve-card-comments
           type:
           - string
           - 'null'
@@ -3237,7 +3230,6 @@ components:
           description: User activated flag
         ui_version:
           type: integer
-          # DOC_MISMATCH: docs=`string`, actual=`integer` — https://developers.kaiten.ru/users/retrieve-current-user
           description: 1 - old ui, 2 - new ui
         virtual:
           type: boolean
@@ -3389,11 +3381,9 @@ components:
           type: string
           description: Time zone
         theme:
-          # DOC_MISMATCH: docs=`enum` (no values listed), actual=`string`; observed: "light", "dark", "auto" — https://developers.kaiten.ru/users/retrieve-current-user
           type: string
           description: light - light color theme, dark - dark color theme, auto - based on OS settings
         ui_version:
-          # DOC_MISMATCH: docs=`string`, actual=`integer` — https://developers.kaiten.ru/users/retrieve-current-user
           type: integer
           description: 1 - old ui, 2 - new
         virtual:
@@ -3597,7 +3587,6 @@ components:
           - 'null'
           description: Template checklist id
         items:
-          # DOC_MISMATCH: docs=non-nullable `array`, actual=`array | null` — https://developers.kaiten.ru/card-checklists/retrieve-card-checklist
           type:
           - array
           - 'null'
@@ -3611,7 +3600,7 @@ components:
           type: integer
           description: Card id
         checklist_id:
-          # DOC_MISMATCH: docs=`string`, actual=`integer` — https://developers.kaiten.ru/card-checklists/retrieve-card-checklist
+          # DOC_MISMATCH: field not listed in docs, present in actual API responses (inlined checklists in /cards/{id}); type=integer — https://developers.kaiten.ru/card-checklists/retrieve-card-checklist
           type: integer
           description: Checklist id
         sort_order:
@@ -3868,7 +3857,7 @@ components:
         - 'null'
     CardBoardSummary:
       type: object
-      # DOC_MISMATCH: docs show full Board schema, actual API returns only 6 fields: id, uid, title, external_id, card_properties, settings — https://developers.kaiten.ru/cards/retrieve-card
+      # DOC_MISMATCH: docs list full Board schema (created, updated, description, email_key, columns, lanes, cards, …), actual API returns only 7 fields: id, uid, title, external_id, card_properties, settings, spaces — https://developers.kaiten.ru/cards/retrieve-card
       required:
       - id
       - uid
@@ -3902,6 +3891,14 @@ components:
           - object
           - 'null'
           description: Board settings
+        spaces:
+          type:
+          - array
+          - 'null'
+          items:
+            type: object
+            additionalProperties: true
+          description: Spaces this board is referenced from
     CreateCardRequest:
       type: object
       required:
@@ -4238,11 +4235,9 @@ components:
           type: integer
           description: Blocker ID
         uid:
-          # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/card-blockers/retrieve-card-blockers-list
           type: string
           description: Blocker UID
         reason:
-          # DOC_MISMATCH: docs=non-nullable `string`, actual=`string | null` — https://developers.kaiten.ru/card-blockers/retrieve-card-blockers-list
           type:
           - string
           - 'null'
@@ -4257,7 +4252,6 @@ components:
           type:
           - integer
           - 'null'
-          # DOC_MISMATCH: docs=`string`, actual=`integer | null` — https://developers.kaiten.ru/card-blockers/retrieve-card-blockers-list
           description: ID of blocking card
         blocker_card_title:
           type:
@@ -4268,13 +4262,11 @@ components:
           type: boolean
           description: Is block released
         released_by_id:
-          # DOC_MISMATCH: docs=non-nullable `integer`, actual=`integer | null` — https://developers.kaiten.ru/card-blockers/retrieve-card-blockers-list
           type:
           - integer
           - 'null'
           description: ID of user who released block
         due_date:
-          # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/card-blockers/retrieve-card-blockers-list
           type:
           - string
           - 'null'
@@ -4289,19 +4281,19 @@ components:
           type: string
           description: Last update timestamp
         blocked_card:
-          anyOf:
+          allOf:
           - $ref: '#/components/schemas/Card'
-          - type: 'null'
+          nullable: true
           description: Blocked card info
         card:
-          anyOf:
+          allOf:
           - $ref: '#/components/schemas/Card'
-          - type: 'null'
+          nullable: true
           description: Blocking card info
         blocker:
-          anyOf:
+          allOf:
           - $ref: '#/components/schemas/User'
-          - type: 'null'
+          nullable: true
           description: Info of user who blocked card
     CreateCardBlockerRequest:
       type: object
@@ -4381,7 +4373,6 @@ components:
           type: string
           description: Sprint title
         goal:
-          # DOC_MISMATCH: docs=non-nullable `string`, actual=`string | null` — https://developers.kaiten.ru/sprints/get-sprints-list
           type:
           - string
           - 'null'
@@ -4408,7 +4399,6 @@ components:
           type: string
           description: Sprint planned finish date
         actual_finish_date:
-          # DOC_MISMATCH: docs=non-nullable `string`, actual=`string | null` — https://developers.kaiten.ru/sprints/get-sprints-list
           type:
           - string
           - 'null'


### PR DESCRIPTION
## Summary

Re-validated all 35 `DOC_MISMATCH` comments in `openapi/kaiten.yaml` against the current state of `developers.kaiten.ru` (parsed via Playwright) and the live API. Kaiten support has fixed most of them.

- **32 resolved** → `DOC_MISMATCH` comments removed
- **3 still mismatched** → comments updated with current details, reported to support
- **Drive-bys**: added `spaces` to `CardBoardSummary`, promoted card `source` to `string | null` + enum to match docs

## Resolved (32)

| Endpoint | Fields |
|---|---|
| `/cards/{id}` | `lane_id`, `type_id`, `sprint_id`, `service_id`, `fifo_order`, `source` |
| `/columns` | `wip_limit`, `column_id`, `default_tags`, `uid`, `locked` |
| `/lanes` | `wip_limit`, `default_tags`, `uid`, `locked` |
| `/company/custom-properties` | `show_on_facade`, `multiline` |
| `/cards/{id}/comments` | `uid`, `sd_external_recipients_cc`, `notification_sent` |
| `/users/current` | `ui_version` (×2), `theme` |
| `/card-checklists` | `items` |
| `/cards/{id}/blockers` | `uid`, `reason`, `blocker_card_id`, `released_by_id`, `due_date` |
| `/sprints` | `goal`, `actual_finish_date` |

## Still mismatched (3)

1. **`board` on `/cards/retrieve-card`** — Schema dialog shows full Board schema (~22 fields), API returns 7: `id, uid, title, external_id, card_properties, settings, spaces`. Missing from docs: `uid`, `settings`, `spaces`.
2. **`checklist_id` on inlined checklists in `/cards/{id}`** — returned by API as `integer`, not documented anywhere.
3. (Same as #1 — duplicated comment on `CardBoardSummary` schema for navigability.)

Detailed report with curl proofs saved at `~/Desktop/kaiten-docs-remaining-issues.md` for the email to support.

## Test plan

- [x] `swift build` — green locally
- [ ] CI lint / build-and-test