### PR TITLE
feat(cli): forward SDK inputs the CLI never exposed

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,21 @@ opts.columnId = 42
 let card = try await client.updateCard(id: 123, opts)
 ```
 
+### Custom properties
+
+Both option types carry a `properties` payload for the workspace's custom fields. Keys are
+`id_<property-id>`; a value is an array of value IDs for select properties, a number for numeric
+ones, or `null` to clear the property. Resolve the IDs first with `listCustomProperties()` and
+`listCustomPropertySelectValues(propertyId:)` — they differ per workspace.
+
+From the CLI, `create-card` and `update-card` take the same payload as a JSON object:
+
+```bash
+kaiten update-card --id 123 --properties '{"id_299126": [106915]}'
+```
+
+The object is parsed and validated locally, so a malformed payload fails before any request is sent.
+
 ## Configuration
 
 The CLI and MCP server share the same config file at `~/.config/kaiten/config.json` (see [Configure Credentials](#2-configure-credentials) above).

--- a/README.md
+++ b/README.md
@@ -304,6 +304,15 @@ kaiten update-card --id 123 --properties '{"id_299126": [106915]}'
 
 The object is parsed and validated locally, so a malformed payload fails before any request is sent.
 
+### WIP limits
+
+Columns and lanes carry a work-in-progress limit. `--wip-limit` sets the value and `--wip-limit-type`
+selects what it counts — `1` for card count, `2` for card size:
+
+```bash
+kaiten update-column --board-id 42 --id 7 --wip-limit 5 --wip-limit-type 1
+```
+
 ## Configuration
 
 The CLI and MCP server share the same config file at `~/.config/kaiten/config.json` (see [Configure Credentials](#2-configure-credentials) above).

--- a/Sources/kaiten/Boards/BoardCRUDCommands.swift
+++ b/Sources/kaiten/Boards/BoardCRUDCommands.swift
@@ -21,13 +21,17 @@ struct CreateBoard: AsyncParsableCommand {
   @Option(name: .long, help: "Sort order")
   var sortOrder: Double?
 
+  @Option(name: .long, help: "External ID")
+  var externalId: String?
+
   func run() async throws {
     let client = try await global.makeClient()
     let board = try await client.createBoard(
       spaceId: spaceId,
       title: title,
       description: boardDescription,
-      sortOrder: sortOrder
+      sortOrder: sortOrder,
+      externalId: externalId
     )
     try printJSON(board)
   }
@@ -56,6 +60,9 @@ struct UpdateBoard: AsyncParsableCommand {
   @Option(name: .long, help: "Sort order")
   var sortOrder: Double?
 
+  @Option(name: .long, help: "External ID")
+  var externalId: String?
+
   func run() async throws {
     let client = try await global.makeClient()
     let board = try await client.updateBoard(
@@ -63,7 +70,8 @@ struct UpdateBoard: AsyncParsableCommand {
       id: id,
       title: title,
       description: boardDescription,
-      sortOrder: sortOrder
+      sortOrder: sortOrder,
+      externalId: externalId
     )
     try printJSON(board)
   }

--- a/Sources/kaiten/Boards/ColumnCommands.swift
+++ b/Sources/kaiten/Boards/ColumnCommands.swift
@@ -12,6 +12,17 @@ func parseColumnType(_ rawValue: Int?) throws -> ColumnType? {
   return type
 }
 
+func parseWipLimitType(_ rawValue: Int?) throws -> WipLimitType? {
+  guard let rawValue else { return nil }
+  let type = WipLimitType(rawValue: rawValue)
+  guard WipLimitType.allCases.contains(type) else {
+    throw ValidationError(
+      "Invalid WIP limit type: \(rawValue). Allowed values: 1 (card count), 2 (card size)"
+    )
+  }
+  return type
+}
+
 struct CreateColumn: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "create-column",
@@ -32,13 +43,25 @@ struct CreateColumn: AsyncParsableCommand {
   @Option(name: .long, help: "Column type: 1=queue, 2=in progress, 3=done")
   var columnType: Int?
 
+  @Option(name: .long, help: "WIP limit value")
+  var wipLimit: Int?
+
+  @Option(name: .long, help: "WIP limit type: 1=card count, 2=card size")
+  var wipLimitType: Int?
+
+  @Option(name: .long, help: "Number of columns to display side by side")
+  var colCount: Int?
+
   func run() async throws {
     let client = try await global.makeClient()
     let column = try await client.createColumn(
       boardId: boardId,
       title: title,
       sortOrder: sortOrder,
-      type: try parseColumnType(columnType)
+      type: try parseColumnType(columnType),
+      wipLimit: wipLimit,
+      wipLimitType: try parseWipLimitType(wipLimitType),
+      colCount: colCount
     )
     try printJSON(column)
   }
@@ -67,6 +90,15 @@ struct UpdateColumn: AsyncParsableCommand {
   @Option(name: .long, help: "Column type: 1=queue, 2=in progress, 3=done")
   var columnType: Int?
 
+  @Option(name: .long, help: "WIP limit value")
+  var wipLimit: Int?
+
+  @Option(name: .long, help: "WIP limit type: 1=card count, 2=card size")
+  var wipLimitType: Int?
+
+  @Option(name: .long, help: "Number of columns to display side by side")
+  var colCount: Int?
+
   func run() async throws {
     let client = try await global.makeClient()
     let column = try await client.updateColumn(
@@ -74,7 +106,10 @@ struct UpdateColumn: AsyncParsableCommand {
       id: id,
       title: title,
       sortOrder: sortOrder,
-      type: try parseColumnType(columnType)
+      type: try parseColumnType(columnType),
+      wipLimit: wipLimit,
+      wipLimitType: try parseWipLimitType(wipLimitType),
+      colCount: colCount
     )
     try printJSON(column)
   }
@@ -143,12 +178,16 @@ struct CreateSubcolumn: AsyncParsableCommand {
   @Option(name: .long, help: "Sort order")
   var sortOrder: Double?
 
+  @Option(name: .long, help: "Subcolumn type: 1=queue, 2=in progress, 3=done")
+  var columnType: Int?
+
   func run() async throws {
     let client = try await global.makeClient()
     let subcolumn = try await client.createSubcolumn(
       columnId: columnId,
       title: title,
-      sortOrder: sortOrder
+      sortOrder: sortOrder,
+      type: try parseColumnType(columnType)
     )
     try printJSON(subcolumn)
   }
@@ -174,13 +213,17 @@ struct UpdateSubcolumn: AsyncParsableCommand {
   @Option(name: .long, help: "Sort order")
   var sortOrder: Double?
 
+  @Option(name: .long, help: "Subcolumn type: 1=queue, 2=in progress, 3=done")
+  var columnType: Int?
+
   func run() async throws {
     let client = try await global.makeClient()
     let subcolumn = try await client.updateSubcolumn(
       columnId: columnId,
       id: id,
       title: title,
-      sortOrder: sortOrder
+      sortOrder: sortOrder,
+      type: try parseColumnType(columnType)
     )
     try printJSON(subcolumn)
   }

--- a/Sources/kaiten/Boards/LaneCommands.swift
+++ b/Sources/kaiten/Boards/LaneCommands.swift
@@ -28,6 +28,12 @@ struct CreateLane: AsyncParsableCommand {
   @Option(name: .long, help: "Sort order")
   var sortOrder: Double?
 
+  @Option(name: .long, help: "WIP limit value")
+  var wipLimit: Int?
+
+  @Option(name: .long, help: "WIP limit type: 1=card count, 2=card size")
+  var wipLimitType: Int?
+
   @Option(name: .long, help: "Row count (height)")
   var rowCount: Int?
 
@@ -37,6 +43,8 @@ struct CreateLane: AsyncParsableCommand {
       boardId: boardId,
       title: title,
       sortOrder: sortOrder,
+      wipLimit: wipLimit,
+      wipLimitType: try parseWipLimitType(wipLimitType),
       rowCount: rowCount
     )
     try printJSON(lane)
@@ -63,6 +71,12 @@ struct UpdateLane: AsyncParsableCommand {
   @Option(name: .long, help: "Sort order")
   var sortOrder: Double?
 
+  @Option(name: .long, help: "WIP limit value")
+  var wipLimit: Int?
+
+  @Option(name: .long, help: "WIP limit type: 1=card count, 2=card size")
+  var wipLimitType: Int?
+
   @Option(name: .long, help: "Row count (height)")
   var rowCount: Int?
 
@@ -76,6 +90,8 @@ struct UpdateLane: AsyncParsableCommand {
       id: id,
       title: title,
       sortOrder: sortOrder,
+      wipLimit: wipLimit,
+      wipLimitType: try parseWipLimitType(wipLimitType),
       rowCount: rowCount,
       condition: try parseLaneCondition(condition)
     )

--- a/Sources/kaiten/Cards/CardCommands.swift
+++ b/Sources/kaiten/Cards/CardCommands.swift
@@ -446,6 +446,9 @@ struct UpdateCard: AsyncParsableCommand {
   )
   var plannedEnd: String?
 
+  @Option(name: .long, help: "Service Desk unseen-comment flag")
+  var sdNewComment: Bool?
+
   @Option(
     name: .long,
     help:
@@ -483,6 +486,7 @@ struct UpdateCard: AsyncParsableCommand {
     //   "date"            → .some("date") (send string, server sets the value)
     opts.plannedStart = plannedStart.map { $0.isEmpty ? nil : $0 }
     opts.plannedEnd = plannedEnd.map { $0.isEmpty ? nil : $0 }
+    opts.sdNewComment = sdNewComment
     opts.properties = try parseCardProperties(properties, fieldName: "properties")
     let card = try await client.updateCard(id: id, opts)
     try printJSON(card)

--- a/Sources/kaiten/Cards/CardCommands.swift
+++ b/Sources/kaiten/Cards/CardCommands.swift
@@ -310,6 +310,13 @@ struct CreateCard: AsyncParsableCommand {
   @Option(name: .long, help: "Text format: 1 - markdown, 2 - html, 3 - jira wiki")
   var textFormatTypeId: Int?
 
+  @Option(
+    name: .long,
+    help:
+      "Custom properties as a JSON object. Keys are \"id_<property-id>\"; values are an array of value IDs for select properties, a number for numeric ones, or null to clear. Example: '{\"id_299126\": [106915]}'"
+  )
+  var properties: String?
+
   func run() async throws {
     let client = try await global.makeClient()
     var opts = CardCreateOptions(title: title, boardId: boardId)
@@ -329,6 +336,7 @@ struct CreateCard: AsyncParsableCommand {
     opts.typeId = typeId
     opts.externalId = externalId
     opts.textFormatTypeId = textFormatTypeId.map(TextFormatType.init(rawValue:))
+    opts.properties = try parseCardProperties(properties, fieldName: "properties")
     let card = try await client.createCard(opts)
     try printJSON(card)
   }
@@ -438,6 +446,13 @@ struct UpdateCard: AsyncParsableCommand {
   )
   var plannedEnd: String?
 
+  @Option(
+    name: .long,
+    help:
+      "Custom properties as a JSON object. Keys are \"id_<property-id>\"; values are an array of value IDs for select properties, a number for numeric ones, or null to clear. Example: '{\"id_299126\": [106915]}'"
+  )
+  var properties: String?
+
   func run() async throws {
     let client = try await global.makeClient()
     var opts = CardUpdateOptions()
@@ -468,6 +483,7 @@ struct UpdateCard: AsyncParsableCommand {
     //   "date"            → .some("date") (send string, server sets the value)
     opts.plannedStart = plannedStart.map { $0.isEmpty ? nil : $0 }
     opts.plannedEnd = plannedEnd.map { $0.isEmpty ? nil : $0 }
+    opts.properties = try parseCardProperties(properties, fieldName: "properties")
     let card = try await client.updateCard(id: id, opts)
     try printJSON(card)
   }

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -133,6 +133,33 @@ func printJSON(_ value: some Encodable) throws {
   print(String(decoding: data, as: UTF8.self))
 }
 
+/// Decodes a custom-properties JSON object into the generated request payload.
+///
+/// Custom property values are a free-form object rather than a flat scalar, so they cannot be
+/// expressed as ordinary options. Keys are `id_<property-id>`; values are an array of value IDs for
+/// select properties, a number for numeric ones, or `null` to clear the property.
+///
+/// Parsing happens locally so a malformed object fails before any request is sent.
+func parseCardProperties<Payload: Decodable>(
+  _ rawValue: String?,
+  fieldName: String
+) throws -> Payload? {
+  guard let rawValue else { return nil }
+  let data = Data(rawValue.utf8)
+  guard let object = try? JSONSerialization.jsonObject(with: data), object is [String: Any] else {
+    throw ValidationError(
+      "Invalid \(fieldName) value: expected a JSON object such as '{\"id_42\": [7]}'"
+    )
+  }
+  do {
+    return try JSONDecoder().decode(Payload.self, from: data)
+  } catch {
+    throw ValidationError(
+      "Invalid \(fieldName) value: \(error.localizedDescription)"
+    )
+  }
+}
+
 func parseIntegerCSV(_ rawValue: String?, fieldName: String) throws -> [Int]? {
   guard let rawValue else { return nil }
   var result: [Int] = []

--- a/Sources/kaiten/Spaces/SpaceCRUDCommands.swift
+++ b/Sources/kaiten/Spaces/SpaceCRUDCommands.swift
@@ -18,11 +18,15 @@ struct CreateSpace: AsyncParsableCommand {
   @Option(name: .long, help: "Sort order")
   var sortOrder: Double?
 
+  @Option(name: .long, help: "Parent entity UID for nesting the space")
+  var parentEntityUid: String?
+
   func run() async throws {
     let client = try await global.makeClient()
     let space = try await client.createSpace(
       title: title,
       externalId: externalId,
+      parentEntityUid: parentEntityUid,
       sortOrder: sortOrder
     )
     try printJSON(space)
@@ -67,13 +71,21 @@ struct UpdateSpace: AsyncParsableCommand {
   @Option(name: .long, help: "Sort order")
   var sortOrder: Double?
 
+  @Option(name: .long, help: "Access mode")
+  var access: String?
+
+  @Option(name: .long, help: "Parent entity UID for nesting the space")
+  var parentEntityUid: String?
+
   func run() async throws {
     let client = try await global.makeClient()
     let space = try await client.updateSpace(
       id: id,
       title: title,
       externalId: externalId,
-      sortOrder: sortOrder
+      sortOrder: sortOrder,
+      access: access,
+      parentEntityUid: parentEntityUid
     )
     try printJSON(space)
   }

--- a/Tests/KaitenSDKTests/CLIValidationTests.swift
+++ b/Tests/KaitenSDKTests/CLIValidationTests.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import KaitenSDK
 import Testing
 
 @testable import kaiten
@@ -66,5 +67,38 @@ struct CLIValidationTests {
 
     let `default` = try GlobalOptions.parse([])
     #expect(`default`.selectedConfigPath == GlobalOptions.defaultConfigPath)
+  }
+
+  @Test("Card properties parser returns nil when the option is absent")
+  func cardPropertiesReturnsNilWhenAbsent() throws {
+    let parsed: Components.Schemas.UpdateCardRequest.propertiesPayload? =
+      try parseCardProperties(nil, fieldName: "properties")
+    #expect(parsed == nil)
+  }
+
+  @Test("Card properties parser accepts select and numeric values")
+  func cardPropertiesAcceptsValues() throws {
+    let parsed: Components.Schemas.UpdateCardRequest.propertiesPayload? =
+      try parseCardProperties(
+        #"{"id_299126": [106915], "id_160": 7, "id_42": null}"#,
+        fieldName: "properties"
+      )
+    #expect(parsed != nil)
+  }
+
+  @Test("Card properties parser rejects malformed JSON")
+  func cardPropertiesRejectsMalformedJSON() {
+    #expect(throws: ValidationError.self) {
+      let _: Components.Schemas.UpdateCardRequest.propertiesPayload? =
+        try parseCardProperties("{oops", fieldName: "properties")
+    }
+  }
+
+  @Test("Card properties parser rejects a non-object payload")
+  func cardPropertiesRejectsNonObject() {
+    #expect(throws: ValidationError.self) {
+      let _: Components.Schemas.UpdateCardRequest.propertiesPayload? =
+        try parseCardProperties("[1, 2]", fieldName: "properties")
+    }
   }
 }

--- a/Tests/KaitenSDKTests/CLIValidationTests.swift
+++ b/Tests/KaitenSDKTests/CLIValidationTests.swift
@@ -69,6 +69,20 @@ struct CLIValidationTests {
     #expect(`default`.selectedConfigPath == GlobalOptions.defaultConfigPath)
   }
 
+  @Test("WIP limit type parser rejects unknown value")
+  func wipLimitTypeRejectsUnknown() {
+    #expect(throws: ValidationError.self) {
+      _ = try parseWipLimitType(999)
+    }
+  }
+
+  @Test("WIP limit type parser accepts documented values")
+  func wipLimitTypeAcceptsDocumented() throws {
+    #expect(try parseWipLimitType(1) == .cardCount)
+    #expect(try parseWipLimitType(2) == .cardSize)
+    #expect(try parseWipLimitType(nil) == nil)
+  }
+
   @Test("Card properties parser returns nil when the option is absent")
   func cardPropertiesReturnsNilWhenAbsent() throws {
     let parsed: Components.Schemas.UpdateCardRequest.propertiesPayload? =

--- a/specs/002-kaiten-cli/spec.md
+++ b/specs/002-kaiten-cli/spec.md
@@ -138,6 +138,12 @@ stdout confirms it works.
   across commands (including `list-users --ids`); malformed tokens MUST fail locally.
 - **FR-016**: The only supported connection argument is `--config`.
   URL and token input is allowed only via selected config file (`--config` path or default config path).
+- **FR-017**: SDK inputs that are free-form JSON objects rather than scalars
+  (card custom properties) MUST still be reachable from the CLI, as a single
+  option carrying a JSON object string. The CLI MUST parse and validate that
+  string locally before invoking the SDK method: input that is not a JSON
+  object, or that does not decode into the mapped payload, MUST produce a
+  validation error rather than being dropped or forwarded.
 
 ### Non-Functional Requirements
 


### PR DESCRIPTION
## What

Sixteen SDK inputs had no way to be set from the CLI. Each is the same defect: the SDK method or options struct accepts the value, no subcommand defined an option for it, so the call site silently passed the default.

| Command | Added |
|---|---|
| `create-card` / `update-card` | `--properties` |
| `update-card` | `--sd-new-comment` |
| `create-column` / `update-column` | `--wip-limit`, `--wip-limit-type`, `--col-count` |
| `create-lane` / `update-lane` | `--wip-limit`, `--wip-limit-type` |
| `create-subcolumn` / `update-subcolumn` | `--column-type` |
| `create-board` / `update-board` | `--external-id` |
| `create-space` | `--parent-entity-uid` |
| `update-space` | `--access`, `--parent-entity-uid` |

## Why

This is a gap against requirements already in the spec — **FR-002** (a subcommand argument for each SDK input) and **FR-012** (options defined for a command must be forwarded to the SDK call) — not new functionality.

It surfaced while migrating `dodobrands/dodo-mobile-ios` off the Kaiten MCP server. Several agent workflows there set epic category, quarter and platform through `kaiten_update_card_properties`, and there was nothing in the CLI to move them to — even though `CardUpdateOptions.properties` has existed all along and the MCP server does nothing more than decode the same JSON into it.

Auditing the rest of the surface for the same shape turned up the other fifteen. **WIP limits are the notable one**: a column or lane could be created from the CLI but never given the limit that makes it a kanban column.

## Custom properties

```bash
kaiten update-card --id 123 --properties '{"id_299126": [106915]}'
```

Keys are `id_<property-id>`; a value is an array of value IDs for select properties, a number for numeric ones, or `null` to clear. IDs differ per workspace — resolve them with `list-custom-properties` and `list-custom-property-select-values`.

## Validation

Both new input shapes fail locally rather than reaching the API:

```
$ kaiten update-card --id 1 --properties '{oops'
Error: Invalid properties value: expected a JSON object such as '{"id_42": [7]}'

$ kaiten update-card --id 1 --properties '[1, 2]'
Error: Invalid properties value: expected a JSON object such as '{"id_42": [7]}'

$ kaiten create-column --board-id 1 --title x --wip-limit-type 99
Error: Invalid WIP limit type: 99. Allowed values: 1 (card count), 2 (card size)
```

`--wip-limit-type` and the subcolumn `--column-type` map to SDK enums, so they go through validating parsers like the existing ones — an undocumented value fails instead of being coerced to `.unknown`, per FR-014.

FR-017 is added to the CLI spec to record the rule for free-form JSON inputs, since `--properties` is the first option of that shape.

## Verification

The audit that found these now reports nothing left: every parameter of every SDK method called from the CLI is passed, and every field of `CardCreateOptions` and `CardUpdateOptions` is assigned.

- `swift test` — 260 tests in 64 suites pass; six new cases cover the properties parser (absent, valid, malformed, non-object) and the WIP limit type parser (valid, unknown)
- `swift format lint --strict` — clean
- Every new flag verified against the built binary, not just the source

🤖 Generated with [Claude Code](https://claude.com/claude-code)