### PR TITLE
feat(cli): omit nested entities from output unless --expand asks for them

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Agent skill for the kaiten CLI — the Kaiten project management API from the terminal",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "plugins": [
     {
       "name": "kaiten",
       "source": "./agent",
       "description": "Teaches the agent when and how to reach for the kaiten CLI. Its subcommands are a large flat list whose names cannot be guessed, so the skill makes the agent read `kaiten --help` and `kaiten <subcommand> --help` first, then adds what the help does not cover: config file location, the ID discovery chain (spaces → boards → cards), the two JSON output shapes, pagination, and built-in 429 handling.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Aleksey Berezka"
       },

--- a/README.md
+++ b/README.md
@@ -111,10 +111,12 @@ nested fields, so `--expand children` returns the children of a card without
 To discover what a command offers, pass a name it does not have:
 
 ```bash
-kaiten get-card --id 123 --expand ?
+kaiten get-card --id 123 --expand '?'
 # Error: Unknown --expand field: '?'. Available: board, children, column,
 # external_links, files, lane, members, owner, parents, properties, tags, type, all
 ```
+
+Quote the `?` — unquoted it is a shell glob and never reaches the CLI.
 
 ## API Reference
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,37 @@ kaiten list-spaces
 kaiten get-card --id 123
 ```
 
+#### 3. Output Size
+
+Responses embed whole related entities next to the references to them — a card
+carries `owner_id` *and* the entire owner, plus its board, type, lane, members,
+tags and children. Commands drop those by default and keep only scalars and
+`*_id` references:
+
+```bash
+kaiten get-card --id 123
+# {"board_id":5,"column_id":3,"id":123,"owner_id":7,"title":"Fix login",...}
+```
+
+`--expand` brings back the ones you name, or `all` for every one of them:
+
+```bash
+kaiten get-card --id 123 --expand owner,tags
+kaiten get-card --id 123 --expand all
+```
+
+Expansion is one level deep: an expanded value is itself stripped of its own
+nested fields, so `--expand children` returns the children of a card without
+*their* children. Ask for a deeper level with a second command.
+
+To discover what a command offers, pass a name it does not have:
+
+```bash
+kaiten get-card --id 123 --expand ?
+# Error: Unknown --expand field: '?'. Available: board, children, column,
+# external_links, files, lane, members, owner, parents, properties, tags, type, all
+```
+
 ## API Reference
 
 ### Cards

--- a/Sources/kaiten/Boards/BoardCRUDCommands.swift
+++ b/Sources/kaiten/Boards/BoardCRUDCommands.swift
@@ -33,7 +33,7 @@ struct CreateBoard: AsyncParsableCommand {
       sortOrder: sortOrder,
       externalId: externalId
     )
-    try printJSON(board)
+    try printJSON(board, expand: global.expandedFields)
   }
 }
 
@@ -73,6 +73,6 @@ struct UpdateBoard: AsyncParsableCommand {
       sortOrder: sortOrder,
       externalId: externalId
     )
-    try printJSON(board)
+    try printJSON(board, expand: global.expandedFields)
   }
 }

--- a/Sources/kaiten/Boards/BoardCommands.swift
+++ b/Sources/kaiten/Boards/BoardCommands.swift
@@ -17,7 +17,7 @@ struct ListBoards: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let boards = try await client.listBoards(spaceId: spaceId)
-    try printJSON(boards)
+    try printJSON(boards, expand: global.expandedFields)
   }
 }
 
@@ -35,7 +35,7 @@ struct GetBoard: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let board = try await client.getBoard(id: id)
-    try printJSON(board)
+    try printJSON(board, expand: global.expandedFields)
   }
 }
 
@@ -53,7 +53,7 @@ struct GetBoardColumns: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let columns = try await client.getBoardColumns(boardId: boardId)
-    try printJSON(columns)
+    try printJSON(columns, expand: global.expandedFields)
   }
 }
 
@@ -77,6 +77,6 @@ struct GetBoardLanes: AsyncParsableCommand {
       boardId: boardId,
       condition: try parseLaneCondition(condition)
     )
-    try printJSON(lanes)
+    try printJSON(lanes, expand: global.expandedFields)
   }
 }

--- a/Sources/kaiten/Boards/ColumnCommands.swift
+++ b/Sources/kaiten/Boards/ColumnCommands.swift
@@ -63,7 +63,7 @@ struct CreateColumn: AsyncParsableCommand {
       wipLimitType: try parseWipLimitType(wipLimitType),
       colCount: colCount
     )
-    try printJSON(column)
+    try printJSON(column, expand: global.expandedFields)
   }
 }
 
@@ -111,7 +111,7 @@ struct UpdateColumn: AsyncParsableCommand {
       wipLimitType: try parseWipLimitType(wipLimitType),
       colCount: colCount
     )
-    try printJSON(column)
+    try printJSON(column, expand: global.expandedFields)
   }
 }
 
@@ -135,7 +135,7 @@ struct DeleteColumn: AsyncParsableCommand {
       boardId: boardId,
       id: id
     )
-    try printJSON(["id": deletedId])
+    try printJSON(["id": deletedId], expand: global.expandedFields)
   }
 }
 
@@ -157,7 +157,7 @@ struct ListSubcolumns: AsyncParsableCommand {
     let subcolumns = try await client.listSubcolumns(
       columnId: columnId
     )
-    try printJSON(subcolumns)
+    try printJSON(subcolumns, expand: global.expandedFields)
   }
 }
 
@@ -189,7 +189,7 @@ struct CreateSubcolumn: AsyncParsableCommand {
       sortOrder: sortOrder,
       type: try parseColumnType(columnType)
     )
-    try printJSON(subcolumn)
+    try printJSON(subcolumn, expand: global.expandedFields)
   }
 }
 
@@ -225,7 +225,7 @@ struct UpdateSubcolumn: AsyncParsableCommand {
       sortOrder: sortOrder,
       type: try parseColumnType(columnType)
     )
-    try printJSON(subcolumn)
+    try printJSON(subcolumn, expand: global.expandedFields)
   }
 }
 
@@ -249,6 +249,6 @@ struct DeleteSubcolumn: AsyncParsableCommand {
       columnId: columnId,
       id: id
     )
-    try printJSON(["id": deletedId])
+    try printJSON(["id": deletedId], expand: global.expandedFields)
   }
 }

--- a/Sources/kaiten/Boards/LaneCommands.swift
+++ b/Sources/kaiten/Boards/LaneCommands.swift
@@ -47,7 +47,7 @@ struct CreateLane: AsyncParsableCommand {
       wipLimitType: try parseWipLimitType(wipLimitType),
       rowCount: rowCount
     )
-    try printJSON(lane)
+    try printJSON(lane, expand: global.expandedFields)
   }
 }
 
@@ -95,6 +95,6 @@ struct UpdateLane: AsyncParsableCommand {
       rowCount: rowCount,
       condition: try parseLaneCondition(condition)
     )
-    try printJSON(lane)
+    try printJSON(lane, expand: global.expandedFields)
   }
 }

--- a/Sources/kaiten/CardTypes/CardTypeCommands.swift
+++ b/Sources/kaiten/CardTypes/CardTypeCommands.swift
@@ -18,6 +18,6 @@ struct ListCardTypes: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let types = try await client.listCardTypes(limit: limit, offset: offset)
-    try printJSON(types)
+    try printJSON(types, expand: global.expandedFields)
   }
 }

--- a/Sources/kaiten/Cards/BaselineCommands.swift
+++ b/Sources/kaiten/Cards/BaselineCommands.swift
@@ -15,6 +15,6 @@ struct GetCardBaselines: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let baselines = try await client.getCardBaselines(cardId: cardId)
-    try printJSON(baselines)
+    try printJSON(baselines, expand: global.expandedFields)
   }
 }

--- a/Sources/kaiten/Cards/BlockerCommands.swift
+++ b/Sources/kaiten/Cards/BlockerCommands.swift
@@ -18,7 +18,7 @@ struct ListCardBlockers: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let blockers = try await client.listCardBlockers(cardId: cardId)
-    try printJSON(blockers)
+    try printJSON(blockers, expand: global.expandedFields)
   }
 }
 
@@ -45,7 +45,7 @@ struct CreateCardBlocker: AsyncParsableCommand {
     let client = try await global.makeClient()
     let blocker = try await client.createCardBlocker(
       cardId: cardId, reason: reason, blockerCardId: blockerCardId)
-    try printJSON(blocker)
+    try printJSON(blocker, expand: global.expandedFields)
   }
 }
 
@@ -75,7 +75,7 @@ struct UpdateCardBlocker: AsyncParsableCommand {
     let client = try await global.makeClient()
     let blocker = try await client.updateCardBlocker(
       cardId: cardId, blockerId: blockerId, reason: reason, blockerCardId: blockerCardId)
-    try printJSON(blocker)
+    try printJSON(blocker, expand: global.expandedFields)
   }
 }
 
@@ -98,6 +98,6 @@ struct DeleteCardBlocker: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let blocker = try await client.deleteCardBlocker(cardId: cardId, blockerId: blockerId)
-    try printJSON(blocker)
+    try printJSON(blocker, expand: global.expandedFields)
   }
 }

--- a/Sources/kaiten/Cards/CardCommands.swift
+++ b/Sources/kaiten/Cards/CardCommands.swift
@@ -244,7 +244,7 @@ struct ListCards: AsyncParsableCommand {
     let page = try await client.listCards(
       boardId: boardId, columnId: columnId, laneId: laneId, offset: offset, limit: limit,
       filter: filter)
-    try printJSON(page)
+    try printJSON(page, expand: global.expandedFields)
   }
 }
 
@@ -338,7 +338,7 @@ struct CreateCard: AsyncParsableCommand {
     opts.textFormatTypeId = textFormatTypeId.map(TextFormatType.init(rawValue:))
     opts.properties = try parseCardProperties(properties, fieldName: "properties")
     let card = try await client.createCard(opts)
-    try printJSON(card)
+    try printJSON(card, expand: global.expandedFields)
   }
 }
 
@@ -356,7 +356,7 @@ struct GetCard: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let card = try await client.getCard(id: id)
-    try printJSON(card)
+    try printJSON(card, expand: global.expandedFields)
   }
 }
 
@@ -489,7 +489,7 @@ struct UpdateCard: AsyncParsableCommand {
     opts.sdNewComment = sdNewComment
     opts.properties = try parseCardProperties(properties, fieldName: "properties")
     let card = try await client.updateCard(id: id, opts)
-    try printJSON(card)
+    try printJSON(card, expand: global.expandedFields)
   }
 }
 
@@ -507,7 +507,7 @@ struct GetCardComments: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let comments = try await client.getCardComments(cardId: cardId)
-    try printJSON(comments)
+    try printJSON(comments, expand: global.expandedFields)
   }
 }
 
@@ -525,7 +525,7 @@ struct GetCardMembers: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let members = try await client.getCardMembers(cardId: cardId)
-    try printJSON(members)
+    try printJSON(members, expand: global.expandedFields)
   }
 }
 
@@ -550,7 +550,7 @@ struct UpdateComment: AsyncParsableCommand {
     let client = try await global.makeClient()
     let comment = try await client.updateComment(
       cardId: cardId, commentId: commentId, text: text)
-    try printJSON(comment)
+    try printJSON(comment, expand: global.expandedFields)
   }
 }
 
@@ -571,7 +571,7 @@ struct AddComment: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let comment = try await client.createComment(cardId: cardId, text: text)
-    try printJSON(comment)
+    try printJSON(comment, expand: global.expandedFields)
   }
 }
 
@@ -589,7 +589,7 @@ struct DeleteCard: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let card = try await client.deleteCard(id: cardId)
-    try printJSON(card)
+    try printJSON(card, expand: global.expandedFields)
   }
 }
 
@@ -610,6 +610,6 @@ struct DeleteComment: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let deletedId = try await client.deleteComment(cardId: cardId, commentId: commentId)
-    try printJSON(["id": deletedId])
+    try printJSON(["id": deletedId], expand: global.expandedFields)
   }
 }

--- a/Sources/kaiten/Cards/ChecklistCommands.swift
+++ b/Sources/kaiten/Cards/ChecklistCommands.swift
@@ -22,7 +22,7 @@ struct CreateChecklist: AsyncParsableCommand {
     let client = try await global.makeClient()
     let checklist = try await client.createChecklist(
       cardId: cardId, name: name, sortOrder: sortOrder)
-    try printJSON(checklist)
+    try printJSON(checklist, expand: global.expandedFields)
   }
 }
 
@@ -45,7 +45,7 @@ struct GetChecklist: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let checklist = try await client.getChecklist(cardId: cardId, checklistId: checklistId)
-    try printJSON(checklist)
+    try printJSON(checklist, expand: global.expandedFields)
   }
 }
 
@@ -66,7 +66,7 @@ struct RemoveChecklist: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let deletedId = try await client.removeChecklist(cardId: cardId, checklistId: checklistId)
-    try printJSON(["id": deletedId])
+    try printJSON(["id": deletedId], expand: global.expandedFields)
   }
 }
 
@@ -102,7 +102,7 @@ struct UpdateChecklist: AsyncParsableCommand {
       sortOrder: sortOrder,
       moveToCardId: moveToCardId
     )
-    try printJSON(checklist)
+    try printJSON(checklist, expand: global.expandedFields)
   }
 }
 
@@ -156,7 +156,7 @@ struct UpdateChecklistItem: AsyncParsableCommand {
       dueDate: dueDate,
       responsibleId: responsibleId
     )
-    try printJSON(item)
+    try printJSON(item, expand: global.expandedFields)
   }
 }
 
@@ -200,7 +200,7 @@ struct CreateChecklistItem: AsyncParsableCommand {
       dueDate: dueDate,
       responsibleId: responsibleId
     )
-    try printJSON(item)
+    try printJSON(item, expand: global.expandedFields)
   }
 }
 
@@ -228,6 +228,6 @@ struct RemoveChecklistItem: AsyncParsableCommand {
       checklistId: checklistId,
       itemId: itemId
     )
-    try printJSON(["id": deletedId])
+    try printJSON(["id": deletedId], expand: global.expandedFields)
   }
 }

--- a/Sources/kaiten/Cards/ChildCommands.swift
+++ b/Sources/kaiten/Cards/ChildCommands.swift
@@ -18,7 +18,7 @@ struct ListCardChildren: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let children = try await client.listCardChildren(cardId: cardId)
-    try printJSON(children)
+    try printJSON(children, expand: global.expandedFields)
   }
 }
 
@@ -41,7 +41,7 @@ struct AddCardChild: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let child = try await client.addCardChild(cardId: cardId, childCardId: childCardId)
-    try printJSON(child)
+    try printJSON(child, expand: global.expandedFields)
   }
 }
 
@@ -64,6 +64,6 @@ struct RemoveCardChild: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let deletedId = try await client.removeCardChild(cardId: cardId, childCardId: childCardId)
-    try printJSON(["id": deletedId])
+    try printJSON(["id": deletedId], expand: global.expandedFields)
   }
 }

--- a/Sources/kaiten/Cards/ExternalLinkCommands.swift
+++ b/Sources/kaiten/Cards/ExternalLinkCommands.swift
@@ -18,7 +18,7 @@ struct ListExternalLinks: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let links = try await client.listExternalLinks(cardId: cardId)
-    try printJSON(links)
+    try printJSON(links, expand: global.expandedFields)
   }
 }
 
@@ -45,7 +45,7 @@ struct CreateExternalLink: AsyncParsableCommand {
     let client = try await global.makeClient()
     let link = try await client.createExternalLink(
       cardId: cardId, url: url, description: description)
-    try printJSON(link)
+    try printJSON(link, expand: global.expandedFields)
   }
 }
 
@@ -75,7 +75,7 @@ struct UpdateExternalLink: AsyncParsableCommand {
     let client = try await global.makeClient()
     let link = try await client.updateExternalLink(
       cardId: cardId, linkId: linkId, url: url, description: description)
-    try printJSON(link)
+    try printJSON(link, expand: global.expandedFields)
   }
 }
 
@@ -98,6 +98,6 @@ struct RemoveExternalLink: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let deletedId = try await client.removeExternalLink(cardId: cardId, linkId: linkId)
-    try printJSON(["id": deletedId])
+    try printJSON(["id": deletedId], expand: global.expandedFields)
   }
 }

--- a/Sources/kaiten/Cards/HistoryCommands.swift
+++ b/Sources/kaiten/Cards/HistoryCommands.swift
@@ -15,6 +15,6 @@ struct GetCardHistory: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let history = try await client.getCardLocationHistory(cardId: cardId)
-    try printJSON(history)
+    try printJSON(history, expand: global.expandedFields)
   }
 }

--- a/Sources/kaiten/Cards/MemberCommands.swift
+++ b/Sources/kaiten/Cards/MemberCommands.swift
@@ -26,7 +26,7 @@ struct AddCardMember: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let member = try await client.addCardMember(cardId: cardId, userId: userId)
-    try printJSON(member)
+    try printJSON(member, expand: global.expandedFields)
   }
 }
 
@@ -51,7 +51,7 @@ struct UpdateCardMemberRole: AsyncParsableCommand {
     let client = try await global.makeClient()
     let roleType = try parseCardMemberRoleType(type)
     let role = try await client.updateCardMemberRole(cardId: cardId, userId: userId, type: roleType)
-    try printJSON(role)
+    try printJSON(role, expand: global.expandedFields)
   }
 }
 
@@ -72,6 +72,6 @@ struct RemoveCardMember: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let deletedId = try await client.removeCardMember(cardId: cardId, userId: userId)
-    try printJSON(["id": deletedId])
+    try printJSON(["id": deletedId], expand: global.expandedFields)
   }
 }

--- a/Sources/kaiten/Cards/TagCommands.swift
+++ b/Sources/kaiten/Cards/TagCommands.swift
@@ -18,7 +18,7 @@ struct ListCardTags: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let tags = try await client.listCardTags(cardId: cardId)
-    try printJSON(tags)
+    try printJSON(tags, expand: global.expandedFields)
   }
 }
 
@@ -41,7 +41,7 @@ struct AddCardTag: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let tag = try await client.addCardTag(cardId: cardId, name: name)
-    try printJSON(tag)
+    try printJSON(tag, expand: global.expandedFields)
   }
 }
 
@@ -64,6 +64,6 @@ struct RemoveCardTag: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let deletedId = try await client.removeCardTag(cardId: cardId, tagId: tagId)
-    try printJSON(["id": deletedId])
+    try printJSON(["id": deletedId], expand: global.expandedFields)
   }
 }

--- a/Sources/kaiten/CustomProperties/CustomPropertyCommands.swift
+++ b/Sources/kaiten/CustomProperties/CustomPropertyCommands.swift
@@ -56,7 +56,7 @@ struct ListCustomProperties: AsyncParsableCommand {
       orderBy: orderBy,
       orderDirection: orderDirection
     )
-    try printJSON(page)
+    try printJSON(page, expand: global.expandedFields)
   }
 }
 
@@ -74,7 +74,7 @@ struct GetCustomProperty: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let prop = try await client.getCustomProperty(id: id)
-    try printJSON(prop)
+    try printJSON(prop, expand: global.expandedFields)
   }
 }
 
@@ -126,7 +126,7 @@ struct ListCustomPropertySelectValues: AsyncParsableCommand {
       offset: offset ?? 0,
       limit: limit ?? 100
     )
-    try printJSON(values)
+    try printJSON(values, expand: global.expandedFields)
   }
 }
 
@@ -148,6 +148,6 @@ struct GetCustomPropertySelectValue: AsyncParsableCommand {
     let client = try await global.makeClient()
     let value = try await client.getCustomPropertySelectValue(
       propertyId: propertyId, id: id)
-    try printJSON(value)
+    try printJSON(value, expand: global.expandedFields)
   }
 }

--- a/Sources/kaiten/JSONOutput.swift
+++ b/Sources/kaiten/JSONOutput.swift
@@ -1,0 +1,171 @@
+import ArgumentParser
+import Foundation
+
+/// Trims nested entities out of command output.
+///
+/// Kaiten responses embed whole related entities alongside the references to them: a card carries
+/// `owner_id` *and* the entire owner, plus its board, type, lane, column, members, tags, checklists,
+/// children and files. Those thirteen-odd fields dwarf the seventy scalars callers usually read, so
+/// by default they are dropped and only scalars and `*_id` references survive. `--expand` names the
+/// ones to keep.
+///
+/// Expansion is one level deep. An expanded value is itself stripped of its own nested fields, so
+/// `--expand children` on an epic returns its children without *their* children. The bound is not a
+/// simplification but a correctness requirement: `Card.children` and `Card.parents` are arrays of
+/// cards, so unbounded expansion would make the response follow the shape of the card graph rather
+/// than the request, and a cycle in that graph would not terminate at all. Callers who need a
+/// deeper level ask for it with a second command.
+enum JSONOutput {
+  /// Expands every nested field rather than a named subset.
+  static let expandAllKeyword = "all"
+
+  /// Removes nested entities the caller did not ask for.
+  ///
+  /// - Parameters:
+  ///   - json: a decoded response — an object, or an array of objects.
+  ///   - expand: field names to keep, or `["all"]` for all of them.
+  /// - Returns: the response with unexpanded nested fields removed and expanded ones flattened.
+  /// - Throws: `ValidationError` if a requested name is not expandable in this response.
+  static func trim(_ json: Any, expand: Set<String>) throws -> Any {
+    if var envelope = json as? [String: Any], isPageEnvelope(envelope) {
+      envelope["items"] = try trim(envelope["items"] ?? [], expand: expand)
+      return envelope
+    }
+    // An empty result set has nothing to expand and nothing to validate a name against. Rejecting
+    // --expand here would fail a filter that legitimately matched no rows.
+    guard !objects(in: json).isEmpty else { return json }
+
+    let expandable = expandableFields(in: json)
+    let expandAll = expand.contains(expandAllKeyword)
+    if !expandAll {
+      let unknown = expand.subtracting(expandable).sorted()
+      guard unknown.isEmpty else {
+        let quoted = unknown.map { "'\($0)'" }.joined(separator: ", ")
+        let available =
+          expandable.isEmpty
+          ? "none, this command's response has no nested entities"
+          : (expandable.sorted() + [expandAllKeyword]).joined(separator: ", ")
+        throw ValidationError("Unknown --expand field: \(quoted). Available: \(available)")
+      }
+    }
+    let keep = expandAll ? expandable : expand
+    return apply(json) { keeping(keep, in: $0) }
+  }
+
+  /// Names of the fields `--expand` accepts for a given response.
+  ///
+  /// Derived from the response itself rather than from a hand-maintained per-schema list, so new
+  /// API fields become expandable without a code change and can never drift out of sync. The cost
+  /// is that a field the API did not return at all is indistinguishable from a typo.
+  ///
+  /// An empty array counts as expandable even though it is kept by default: the key is there and
+  /// simply has nothing in it. Judging by the value's type instead would make `--expand tags`
+  /// succeed on a card that has tags and fail on one that does not, so a script sweeping cards
+  /// would break on whichever row happened to be empty.
+  static func expandableFields(in json: Any) -> Set<String> {
+    if let envelope = json as? [String: Any], isPageEnvelope(envelope) {
+      return expandableFields(in: envelope["items"] ?? [])
+    }
+    return Set(
+      objects(in: json).flatMap { object in
+        object.filter { isNested($1) || ($1 as? [Any])?.isEmpty == true }.keys
+      }
+    )
+  }
+
+  // MARK: - Trimming
+
+  /// Drops nested fields other than `keep`, and flattens the ones kept.
+  private static func keeping(_ keep: Set<String>, in object: [String: Any]) -> [String: Any] {
+    var result: [String: Any] = [:]
+    for (key, value) in object {
+      guard isNested(value) else {
+        result[key] = value
+        continue
+      }
+      if keep.contains(key) {
+        result[key] = flattened(value)
+      }
+    }
+    return result
+  }
+
+  /// Strips an expanded value of its own nested fields — the one level of depth.
+  private static func flattened(_ value: Any) -> Any {
+    apply(value) { object in object.filter { _, nested in !isNested(nested) } }
+  }
+
+  /// Whether a value carries a whole entity rather than a scalar.
+  ///
+  /// An empty array is treated as scalar: it is indistinguishable from an empty list of IDs and
+  /// costs nothing to keep, whereas dropping it would make a card with no tags differ in shape from
+  /// one whose tags were merely not expanded.
+  private static func isNested(_ value: Any) -> Bool {
+    if value is [String: Any] { return true }
+    if let array = value as? [Any] { return array.contains { $0 is [String: Any] } }
+    return false
+  }
+
+  // MARK: - Pagination
+
+  /// Whether an object is a `KaitenSDK.Page` envelope rather than an entity.
+  ///
+  /// Its `items` array is the response payload, not a nested entity, so trimming has to reach
+  /// through it. Treating it like any other array of objects would leave a paginated command
+  /// returning its page metadata and none of the rows. `hasMore` is what tells the envelope apart
+  /// from an entity that merely has `items`, such as a checklist.
+  private static func isPageEnvelope(_ object: [String: Any]) -> Bool {
+    object["items"] is [Any] && object["hasMore"] != nil
+  }
+
+  // MARK: - Traversal
+
+  /// Applies `transform` to the response's objects: the top-level object, or every element of a
+  /// top-level array. Anything else passes through untouched.
+  private static func apply(
+    _ json: Any,
+    _ transform: ([String: Any]) -> [String: Any]
+  ) -> Any {
+    if let object = json as? [String: Any] { return transform(object) }
+    if let array = json as? [Any] {
+      return array.map { element in
+        (element as? [String: Any]).map(transform) ?? element
+      }
+    }
+    return json
+  }
+
+  /// The response's objects, whether it is one object or an array of them.
+  private static func objects(in json: Any) -> [[String: Any]] {
+    if let object = json as? [String: Any] { return [object] }
+    if let array = json as? [Any] { return array.compactMap { $0 as? [String: Any] } }
+    return []
+  }
+
+}
+
+// MARK: - Output
+
+/// Encodes `value`, keeping only the nested fields named in `expand`.
+///
+/// Output is compact rather than pretty-printed: every consumer either pipes it into a parser or
+/// reads it as an agent, and indentation is pure overhead for both. Keys are sorted so the field
+/// order stays stable across runs and output diffs stay readable.
+func renderJSON(_ value: some Encodable, expand: Set<String> = []) throws -> String {
+  let encoder = JSONEncoder()
+  encoder.outputFormatting = [.sortedKeys]
+  let encoded = try encoder.encode(value)
+
+  let json = try JSONSerialization.jsonObject(with: encoded, options: [.fragmentsAllowed])
+  let trimmed = try JSONOutput.trim(json, expand: expand)
+  let output = try JSONSerialization.data(
+    withJSONObject: trimmed,
+    options: [.sortedKeys, .fragmentsAllowed]
+  )
+  return String(decoding: output, as: UTF8.self)
+}
+
+/// Writes `value` to stdout as JSON, keeping only the nested fields named in `expand`.
+func printJSON(_ value: some Encodable, expand: Set<String> = []) throws {
+  print(try renderJSON(value, expand: expand))
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -84,6 +84,29 @@ struct GlobalOptions: ParsableArguments {
   @Option(name: .long, help: "Path to Kaiten config.json")
   var config: String?
 
+  @Option(
+    name: .long,
+    help: ArgumentHelp(
+      "Comma-separated nested fields to include in the output, or 'all'.",
+      discussion: """
+        Responses omit nested entities by default: a card keeps owner_id but drops the embedded \
+        owner object. Naming a field brings it back one level deep — expanded values are \
+        themselves stripped of their nested fields. Pass an unknown name to list what a command \
+        offers.
+        """,
+      valueName: "fields"
+    )
+  )
+  var expand: String?
+
+  /// `--expand` names, parsed with the same strict CSV rules as the other list-valued options: a
+  /// malformed token fails locally rather than being silently dropped.
+  var expandedFields: Set<String> {
+    get throws {
+      Set(try parseStringCSV(expand, fieldName: "--expand") ?? [])
+    }
+  }
+
   var selectedConfigPath: String {
     config ?? Self.defaultConfigPath
   }
@@ -125,13 +148,6 @@ struct GlobalOptions: ParsableArguments {
 }
 
 // MARK: - Helpers
-
-func printJSON(_ value: some Encodable) throws {
-  let encoder = JSONEncoder()
-  encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-  let data = try encoder.encode(value)
-  print(String(decoding: data, as: UTF8.self))
-}
 
 /// Decodes a custom-properties JSON object into the generated request payload.
 ///

--- a/Sources/kaiten/Spaces/SpaceCRUDCommands.swift
+++ b/Sources/kaiten/Spaces/SpaceCRUDCommands.swift
@@ -29,7 +29,7 @@ struct CreateSpace: AsyncParsableCommand {
       parentEntityUid: parentEntityUid,
       sortOrder: sortOrder
     )
-    try printJSON(space)
+    try printJSON(space, expand: global.expandedFields)
   }
 }
 
@@ -47,7 +47,7 @@ struct GetSpace: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let space = try await client.getSpace(id: id)
-    try printJSON(space)
+    try printJSON(space, expand: global.expandedFields)
   }
 }
 
@@ -87,6 +87,6 @@ struct UpdateSpace: AsyncParsableCommand {
       access: access,
       parentEntityUid: parentEntityUid
     )
-    try printJSON(space)
+    try printJSON(space, expand: global.expandedFields)
   }
 }

--- a/Sources/kaiten/Spaces/SpaceCommands.swift
+++ b/Sources/kaiten/Spaces/SpaceCommands.swift
@@ -14,6 +14,6 @@ struct ListSpaces: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let spaces = try await client.listSpaces()
-    try printJSON(spaces)
+    try printJSON(spaces, expand: global.expandedFields)
   }
 }

--- a/Sources/kaiten/Sprints/SprintCommands.swift
+++ b/Sources/kaiten/Sprints/SprintCommands.swift
@@ -22,6 +22,6 @@ struct ListSprints: AsyncParsableCommand {
     let client = try await global.makeClient()
     let sprints = try await client.listSprints(
       active: active ? true : nil, limit: limit, offset: offset)
-    try printJSON(sprints)
+    try printJSON(sprints, expand: global.expandedFields)
   }
 }

--- a/Sources/kaiten/Sprints/SprintSummaryCommand.swift
+++ b/Sources/kaiten/Sprints/SprintSummaryCommand.swift
@@ -19,6 +19,6 @@ struct GetSprintSummary: AsyncParsableCommand {
     let client = try await global.makeClient()
     let summary = try await client.getSprintSummary(
       id: id, excludeDeletedCards: excludeDeletedCards ? true : nil)
-    try printJSON(summary)
+    try printJSON(summary, expand: global.expandedFields)
   }
 }

--- a/Sources/kaiten/Users/UserCommands.swift
+++ b/Sources/kaiten/Users/UserCommands.swift
@@ -37,7 +37,7 @@ struct ListUsers: AsyncParsableCommand {
       offset: offset,
       includeInactive: includeInactive ? true : nil
     )
-    try printJSON(users)
+    try printJSON(users, expand: global.expandedFields)
   }
 }
 
@@ -52,6 +52,6 @@ struct GetCurrentUser: AsyncParsableCommand {
   func run() async throws {
     let client = try await global.makeClient()
     let user = try await client.getCurrentUser()
-    try printJSON(user)
+    try printJSON(user, expand: global.expandedFields)
   }
 }

--- a/Tests/KaitenSDKTests/JSONOutputTests.swift
+++ b/Tests/KaitenSDKTests/JSONOutputTests.swift
@@ -34,7 +34,10 @@ struct JSONOutputTests {
     #expect(trimmed["id"] as? Int == 42)
     #expect(trimmed["owner_id"] as? Int == 7)
     #expect(trimmed["tag_ids"] as? [Int] == [4, 9], "an array of IDs is scalar")
-    #expect(trimmed["files"] as? [Int] != nil, "an empty array is indistinguishable from scalars")
+    #expect(
+      (trimmed["files"] as? [Any])?.isEmpty == true,
+      "an empty array is indistinguishable from scalars, so it is kept"
+    )
     #expect(trimmed["owner"] == nil)
     #expect(trimmed["tags"] == nil)
     #expect(trimmed["children"] == nil)
@@ -149,7 +152,7 @@ struct JSONOutputTests {
 
     #expect(JSONOutput.expandableFields(in: untagged).contains("tags"))
     let trimmed = try object(JSONOutput.trim(untagged, expand: ["tags"]))
-    #expect(trimmed["tags"] as? [Int] != nil)
+    #expect((trimmed["tags"] as? [Any])?.isEmpty == true)
   }
 
   @Test("Expandable fields of an array response union its elements")

--- a/Tests/KaitenSDKTests/JSONOutputTests.swift
+++ b/Tests/KaitenSDKTests/JSONOutputTests.swift
@@ -1,0 +1,206 @@
+import ArgumentParser
+import Testing
+
+@testable import kaiten
+
+@Suite("JSON output trimming")
+struct JSONOutputTests {
+  /// A card shaped like the API returns it: scalars, ID references, and whole embedded entities.
+  private let card: [String: Any] = [
+    "id": 42,
+    "title": "Fix login redirect",
+    "owner_id": 7,
+    "tag_ids": [4, 9],
+    "files": [],
+    "owner": ["id": 7, "full_name": "Aleksey Berezka"],
+    "tags": [["id": 4, "name": "backend"]],
+    "children": [
+      [
+        "id": 43,
+        "title": "Child",
+        "children": [["id": 51, "title": "Grandchild"]],
+      ]
+    ],
+  ]
+
+  private func object(_ value: Any) throws -> [String: Any] {
+    try #require(value as? [String: Any])
+  }
+
+  @Test("By default scalars survive and nested entities are dropped")
+  func dropsNestedByDefault() throws {
+    let trimmed = try object(JSONOutput.trim(card, expand: []))
+
+    #expect(trimmed["id"] as? Int == 42)
+    #expect(trimmed["owner_id"] as? Int == 7)
+    #expect(trimmed["tag_ids"] as? [Int] == [4, 9], "an array of IDs is scalar")
+    #expect(trimmed["files"] as? [Int] != nil, "an empty array is indistinguishable from scalars")
+    #expect(trimmed["owner"] == nil)
+    #expect(trimmed["tags"] == nil)
+    #expect(trimmed["children"] == nil)
+  }
+
+  @Test("Named fields are expanded, others still dropped")
+  func expandsNamedField() throws {
+    let trimmed = try object(JSONOutput.trim(card, expand: ["owner"]))
+
+    #expect(try object(#require(trimmed["owner"]))["full_name"] as? String == "Aleksey Berezka")
+    #expect(trimmed["tags"] == nil)
+    #expect(trimmed["owner_id"] as? Int == 7, "expanding adds, it does not replace the reference")
+  }
+
+  @Test("Expansion stops after one level")
+  func expandsOneLevelOnly() throws {
+    let trimmed = try object(JSONOutput.trim(card, expand: ["children"]))
+    let children = try #require(trimmed["children"] as? [Any])
+    let child = try object(#require(children.first))
+
+    #expect(child["id"] as? Int == 43)
+    #expect(child["children"] == nil, "a child's own children are not expanded")
+  }
+
+  @Test("'all' expands every nested field")
+  func expandsAll() throws {
+    let trimmed = try object(JSONOutput.trim(card, expand: [JSONOutput.expandAllKeyword]))
+
+    #expect(trimmed["owner"] != nil)
+    #expect(trimmed["tags"] != nil)
+    #expect(trimmed["children"] != nil)
+  }
+
+  @Test("Array responses are trimmed element by element")
+  func trimsArrayResponses() throws {
+    let trimmed = try #require(JSONOutput.trim([card, card], expand: ["owner"]) as? [Any])
+
+    #expect(trimmed.count == 2)
+    for element in trimmed {
+      let card = try object(element)
+      #expect(card["owner"] != nil)
+      #expect(card["tags"] == nil)
+    }
+  }
+
+  // MARK: - Pagination
+
+  @Test("Paginated responses are trimmed through the envelope, not dropped as a nested field")
+  func trimsThroughPageEnvelope() throws {
+    let page: [String: Any] = ["items": [card], "offset": 0, "limit": 2, "hasMore": true]
+
+    let trimmed = try object(JSONOutput.trim(page, expand: ["owner"]))
+    let items = try #require(trimmed["items"] as? [Any])
+    let row = try object(#require(items.first))
+
+    #expect(trimmed["hasMore"] as? Bool == true, "page metadata survives")
+    #expect(row["id"] as? Int == 42, "rows survive rather than being dropped with the envelope")
+    #expect(row["owner"] != nil)
+    #expect(row["tags"] == nil)
+  }
+
+  @Test("Expandable fields of a page are its rows', not the envelope's")
+  func reportsRowFieldsForPage() {
+    let page: [String: Any] = ["items": [card], "offset": 0, "limit": 2, "hasMore": true]
+
+    #expect(JSONOutput.expandableFields(in: page) == ["owner", "tags", "children", "files"])
+  }
+
+  @Test("An entity that merely has items is not mistaken for a page")
+  func doesNotMistakeEntityForPage() throws {
+    let checklist: [String: Any] = ["id": 3, "items": [["id": 9, "text": "Step"]]]
+
+    let trimmed = try object(JSONOutput.trim(checklist, expand: []))
+
+    #expect(trimmed["items"] == nil, "checklist items are a nested entity, not a page payload")
+    #expect(JSONOutput.expandableFields(in: checklist) == ["items"])
+  }
+
+  @Test("Expanding an empty result set is allowed, not a validation error")
+  func allowsExpandOnEmptyResult() throws {
+    let trimmed = try #require(JSONOutput.trim([], expand: ["owner"]) as? [Any])
+
+    #expect(trimmed.isEmpty)
+  }
+
+  // MARK: - Diagnostics
+
+  @Test("Unknown expand field is rejected")
+  func rejectsUnknownField() {
+    #expect(throws: ValidationError.self) {
+      _ = try JSONOutput.trim(card, expand: ["ownr"])
+    }
+  }
+
+  @Test("Expanding a flat response is rejected")
+  func rejectsExpandOnFlatResponse() {
+    let user: [String: Any] = ["id": 7, "full_name": "Aleksey Berezka"]
+
+    #expect(throws: ValidationError.self) {
+      _ = try JSONOutput.trim(user, expand: ["manager"])
+    }
+  }
+
+  @Test("Expandable fields are derived from the response")
+  func reportsExpandableFields() {
+    #expect(JSONOutput.expandableFields(in: card) == ["owner", "tags", "children", "files"])
+  }
+
+  @Test("An empty collection stays expandable, so the same flag works on every row")
+  func acceptsExpandOfEmptyCollection() throws {
+    let untagged: [String: Any] = ["id": 42, "tags": []]
+
+    #expect(JSONOutput.expandableFields(in: untagged).contains("tags"))
+    let trimmed = try object(JSONOutput.trim(untagged, expand: ["tags"]))
+    #expect(trimmed["tags"] as? [Int] != nil)
+  }
+
+  @Test("Expandable fields of an array response union its elements")
+  func unionsExpandableFieldsAcrossElements() {
+    let first: [String: Any] = ["id": 1, "owner": ["id": 7]]
+    let second: [String: Any] = ["id": 2, "board": ["id": 5]]
+
+    #expect(JSONOutput.expandableFields(in: [first, second]) == ["owner", "board"])
+  }
+
+  // MARK: - Rendering
+
+  private struct Owner: Encodable {
+    var id: Int
+    var fullName: String
+  }
+
+  private struct Encoded: Encodable {
+    var id: Int
+    var archived: Bool
+    var size: Double
+    var ownerId: Int
+    var owner: Owner
+  }
+
+  private let encodable = Encoded(
+    id: 42,
+    archived: false,
+    size: 3,
+    ownerId: 7,
+    owner: Owner(id: 7, fullName: "Aleksey Berezka")
+  )
+
+  @Test("Rendered output is compact and trimmed")
+  func rendersCompactTrimmedJSON() throws {
+    let rendered = try renderJSON(encodable)
+
+    #expect(rendered == #"{"archived":false,"id":42,"ownerId":7,"size":3}"#)
+  }
+
+  @Test("Rendered output keeps expanded entities")
+  func rendersExpandedEntities() throws {
+    let rendered = try renderJSON(encodable, expand: ["owner"])
+
+    #expect(rendered.contains(#""owner":{"fullName":"Aleksey Berezka","id":7}"#))
+  }
+
+  @Test("Booleans survive the trimming round trip as booleans")
+  func preservesBooleans() throws {
+    let rendered = try renderJSON(encodable)
+
+    #expect(rendered.contains(#""archived":false"#), "a bool must not degrade into 0")
+  }
+}

--- a/agent/.claude-plugin/plugin.json
+++ b/agent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kaiten",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Teaches the agent when and how to reach for the kaiten CLI (cards, boards, spaces, sprints, checklists, comments, members, custom properties) — read the help first, then work from it",
   "author": {
     "name": "Aleksey Berezka"

--- a/agent/.cursor-plugin/plugin.json
+++ b/agent/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kaiten",
   "displayName": "Kaiten",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Teaches the agent when and how to reach for the kaiten CLI (cards, boards, spaces, sprints, checklists, comments, members, custom properties) — read the help first, then work from it",
   "author": {
     "name": "Aleksey Berezka"

--- a/agent/gemini-extension.json
+++ b/agent/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "kaiten",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Drive the kaiten CLI for the Kaiten project management API — read its --help first, then compose commands from it"
 }

--- a/agent/skills/kaiten/SKILL.md
+++ b/agent/skills/kaiten/SKILL.md
@@ -142,9 +142,12 @@ Naming two or three fields keeps a board-sized response readable instead of bury
 **To find out what a subcommand offers, ask it for a field that does not exist:**
 
 ```bash
-kaiten get-card --id 7 --expand ?
+kaiten get-card --id 7 --expand '?'
 # Error: Unknown --expand field: '?'. Available: board, column, lane, members, owner, …
 ```
+
+Quote the `?` — unquoted it is a shell glob and never reaches the CLI. Any other name that
+cannot be a field does the same job: `--expand nope`.
 
 That list is computed from the response in front of you, so it is accurate for that call in a way no
 document can be — including this one, which is why no list of expandable fields appears here.

--- a/agent/skills/kaiten/SKILL.md
+++ b/agent/skills/kaiten/SKILL.md
@@ -104,8 +104,8 @@ Same idea elsewhere: resolve a person with `kaiten list-users --query <name>` be
 
 ## Output: always JSON, in one of two shapes
 
-Every subcommand prints pretty-printed JSON to stdout, so pipe it to `jq`. There are two shapes and
-mixing them up is the most common way these pipelines break:
+Every subcommand prints compact JSON to stdout — a single line, keys sorted — so pipe it to `jq`.
+There are two shapes and mixing them up is the most common way these pipelines break:
 
 - Subcommands whose abstract in `kaiten --help` ends in **`(paginated)`** return a page envelope:
   `{"items": [...], "offset": …, "limit": …, "hasMore": …}`. Filter with `jq '.items[]'`.
@@ -115,6 +115,50 @@ That `(paginated)` marker is the reliable signal, and it is worth checking rathe
 because accepting `--offset` / `--limit` is not the same thing. Several subcommands take those flags
 and still return a bare array with no `hasMore` — to page one of those, keep going until a response
 comes back shorter than the `--limit` you asked for.
+
+## Related entities are omitted until you ask for them
+
+A response carries that entity's own scalars plus `*_id` references to its neighbours. The entities
+behind those references — the person behind `owner_id`, the board behind `board_id`, and collections
+such as members, tags, children or files — are left out unless you name them:
+
+```bash
+kaiten get-card --id 7                       # scalars and *_id references only
+kaiten get-card --id 7 --expand owner,tags   # those two come back as full objects
+kaiten get-card --id 7 --expand all          # every related entity in this response
+```
+
+**A missing key says nothing about the tracker.** This is the trap worth internalising, because it
+produces confident false answers rather than errors: a card whose output has no `owner` key still
+has an owner, and "this card is unassigned" read off a default response is a fabrication. Whenever
+the fact you need is about a neighbouring entity rather than the one you fetched, expand it or fetch
+it — never infer it from silence. The same goes for counting: `members` being absent is not zero
+members, though a `*_count` or `*_total` scalar, when the response has one, is a real answer.
+
+**Ask for the fields you need rather than reaching for `all`.** These payloads are large — a single
+expanded owner is a whole user record — and `all` on a list of cards multiplies that by every row.
+Naming two or three fields keeps a board-sized response readable instead of burying the answer.
+
+**To find out what a subcommand offers, ask it for a field that does not exist:**
+
+```bash
+kaiten get-card --id 7 --expand ?
+# Error: Unknown --expand field: '?'. Available: board, column, lane, members, owner, …
+```
+
+That list is computed from the response in front of you, so it is accurate for that call in a way no
+document can be — including this one, which is why no list of expandable fields appears here.
+
+**Expansion goes exactly one level deep.** `--expand children` returns a card's children as objects,
+but each child is trimmed by the same rule, so the children's own children are not there. This is
+deliberate: cards nest into cards, and unbounded expansion would return the shape of the graph
+rather than the answer. To go deeper, run the next command against the ID you just got back.
+
+**A name absent from that `Available:` list means the response does not contain it** — which is not
+the same as the data not existing. Relations frequently have a subcommand of their own, so check
+`kaiten --help` for one before concluding anything; a few subcommands also take a flag that asks the
+server to include extra fields, and their `--help` says so. Guessing again with a different spelling
+is the one thing that will not help.
 
 ## Paging a full board
 

--- a/specs/002-kaiten-cli/spec.md
+++ b/specs/002-kaiten-cli/spec.md
@@ -157,7 +157,21 @@ stdout confirms it works.
   response rather than from a per-command list, so it cannot drift out of
   sync with the API. An unknown name MUST produce a validation error listing
   the names the response does offer; silently ignoring it is forbidden.
-  A response with no nested fields MUST reject any `--expand` value.
+  A response that contains entities but no nested fields MUST reject any
+  `--expand` value.
+- **FR-019a**: An empty result set MUST accept `--expand` rather than reject
+  it. There is nothing to validate a name against, and failing here would
+  make a filter that legitimately matched no rows return an error instead of
+  an empty list.
+- **FR-019b**: A field whose value is an empty collection MUST be treated as
+  expandable even though it is kept by default. Judging expandability by the
+  value's type alone would make the same `--expand` name succeed on one row
+  and fail on the next depending on whether that row's collection happens to
+  be populated. The cost is that a scalar ID array (`tag_ids` and the like)
+  also appears expandable while empty, where expanding it is a no-op; a
+  response cannot distinguish an empty list of IDs from an empty list of
+  entities. Deriving the set from the OpenAPI schema at build time would
+  remove that cost and is the intended long-term fix.
 - **FR-020**: JSON output MUST be compact rather than pretty-printed, with
   keys sorted so that output is stable across runs.
 

--- a/specs/002-kaiten-cli/spec.md
+++ b/specs/002-kaiten-cli/spec.md
@@ -145,6 +145,22 @@ stdout confirms it works.
   object, or that does not decode into the mapped payload, MUST produce a
   validation error rather than being dropped or forwarded.
 
+- **FR-018**: Command output MUST omit nested entities by default, keeping
+  only scalar fields and `*_id` references. A `--expand` option MUST accept a
+  comma-separated list of nested field names, or `all`, to include them.
+  Expansion MUST stop after one level: an expanded value MUST itself be
+  stripped of its own nested fields, so that response size follows the
+  request rather than the shape of the entity graph. `Card.children` and
+  `Card.parents` are arrays of cards, so unbounded expansion would not
+  terminate on a cyclic graph.
+- **FR-019**: The set of names `--expand` accepts MUST be derived from the
+  response rather than from a per-command list, so it cannot drift out of
+  sync with the API. An unknown name MUST produce a validation error listing
+  the names the response does offer; silently ignoring it is forbidden.
+  A response with no nested fields MUST reject any `--expand` value.
+- **FR-020**: JSON output MUST be compact rather than pretty-printed, with
+  keys sorted so that output is stable across runs.
+
 ### Non-Functional Requirements
 
 - **NFR-001**: The CLI MUST compile and run on macOS (ARM) and


### PR DESCRIPTION
## What

Command output now keeps only scalars and `*_id` references. Nested entities — the embedded `owner`, `board`, `type`, `lane`, `column`, `members`, `tags`, `checklists`, `children`, `files` — are dropped unless `--expand` names them.

```bash
kaiten get-card --id 123                      # scalars and *_id only
kaiten get-card --id 123 --expand owner,tags  # named nested fields come back
kaiten get-card --id 123 --expand all         # all of them
kaiten get-card --id 123 --expand ?           # error lists what this command offers
```

Measured on this company's data: `list-spaces` goes from 1,144,986 bytes (`--expand all`) to 172,185 by default — 6.6x.

## Design

**One level deep.** An expanded value is itself stripped of its own nested fields, so `--expand children` returns a card's children without *their* children. This is a correctness requirement, not a simplification: `Card.children` and `Card.parents` are arrays of `Card`, so unbounded expansion would make response size follow the shape of the card graph rather than the request, and a cycle would not terminate.

**Expandable names come from the response, not a list.** A hand-maintained per-schema allow/denylist would drift out of sync with the API and would have to be updated for every new field. Deriving it from the payload means new API fields become expandable with no code change. The cost is that a field the API did not return at all is indistinguishable from a typo — [`cli/cli#5394`](https://github.com/cli/cli/issues/5394#issuecomment-1098285619) documents the same trade-off from the other side, and the mitigation here is the same one `gh` uses: reject the unknown name and list the alternatives.

## Two bugs found by running every read-only command against the live API

Both were invisible to unit tests written against a hand-made fixture, and both are now covered by regression tests.

1. **Paginated commands returned no rows.** `KaitenSDK.Page` is an envelope whose `items` array is the payload, not a nested entity — the first version dropped it, so `kaiten list-cards` returned `{"hasMore":true,"limit":2,"offset":0}`. Trimming now reaches through the envelope. `hasMore` is what tells a page apart from an entity that merely has `items`, such as a checklist.

2. **`--expand` failed depending on the data.** `--expand tags` worked on a card that had tags and errored on one that did not, because an empty array looked like a scalar. A script sweeping cards would break on whichever row happened to be empty. An empty collection is now expandable (a no-op) — the key's presence is the signal, not the value's type.

## Verification

- 277 tests pass, including 17 new ones for trimming, envelopes, depth, and the round trip.
- Every read-only command run against the live API. All behave as intended except `list-sprints`/`get-sprint-summary`, which return HTTP 403 for this token — a pre-existing permission issue unrelated to this change.
- The round-trip through `JSONSerialization` is asserted not to degrade `Bool` into `0` or `Double 3.0` into a different literal.

## Note for review

**Compact output is bundled in here and is separable.** Output switches from pretty-printed to compact (keys still sorted). Every consumer either pipes into a parser or reads as an agent, so indentation is overhead — but it touches every command's output and can be reverted on its own by restoring `.prettyPrinted` in `renderJSON`, if you would rather ship it separately.

Spec updated with FR-018/019/020 per the spec-first rule; README documents `--expand` in the CLI Quick Start.