### PR TITLE
feat(cli): collapse unexpanded collections to their ids, and keep data whole

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Agent skill for the kaiten CLI — the Kaiten project management API from the terminal",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "plugins": [
     {
       "name": "kaiten",
       "source": "./agent",
       "description": "Teaches the agent when and how to reach for the kaiten CLI. Its subcommands are a large flat list whose names cannot be guessed, so the skill makes the agent read `kaiten --help` and `kaiten <subcommand> --help` first, then adds what the help does not cover: config file location, the ID discovery chain (spaces → boards → cards), the two JSON output shapes, pagination, and built-in 429 handling.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": {
         "name": "Aleksey Berezka"
       },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,29 @@ Rules:
 
 This prevents future contributors from re-introducing the same bugs.
 
+## Help Text and Comments
+
+This repository is public. Two rules follow from that and from what help text is for.
+
+**Never write real entity IDs.** Not cards, boards, spaces, users, tags — nothing. An ID from a
+company's live Kaiten leaks its internal structure into an open repository, and once it is in a
+commit message or a PR description it cannot be taken back. State the observation without it —
+"a card can have more children than either field admits" carries the finding, while naming the
+card adds nothing a reader can use. Examples in the README use obviously invented short IDs.
+
+**Help documents API behaviour, and only that.** A subcommand's help says how its own endpoint
+behaves, including where it misreports. It does not point the reader at other subcommands —
+`kaiten --help` already lists them, and cross-references rot first: `list-cards` went on claiming
+`get-card` "verifies those two fields" long after that verification was deleted. It does not
+explain the shell, or `jq`, or how to write a loop — that is not this CLI's behaviour to document.
+Keep it short: the observation, not the investigation behind it, and no worked examples.
+
+A fact about the CLI belongs in `--help`, not in `agent/skills/kaiten/SKILL.md`. The skill ships
+separately from the binary and lags behind it; the help is what every consumer reads. It follows
+that anything already stated in the help is deleted from the skill rather than restated there —
+what the skill is for is the judgement the help cannot enforce, such as not reading a fact out of
+a field that was omitted.
+
 ## Code Formatting
 
 This project uses [swift-format](https://github.com/swiftlang/swift-format) (bundled with the Swift toolchain) with default configuration.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,36 @@ Expansion is one level deep: an expanded value is itself stripped of its own
 nested fields, so `--expand children` returns the children of a card without
 *their* children. Ask for a deeper level with a second command.
 
+A collection that is not expanded collapses to its ids, keeping its own key, so
+the response never goes silent about a relation it holds:
+
+```bash
+kaiten get-card --id 123
+# {"members":[821,904],"external_links":[5512,5513],"tags":[],"owner_id":821,...}
+
+kaiten get-card --id 123 --expand members
+# {"members":[{"id":821,"full_name":"…",…}],…}
+```
+
+The field therefore holds ids by default and entities when expanded. Keeping
+the key is what makes a card with members and a card without report the same
+field — `members: [821]` and `members: []` are both answers.
+
+Only entities are trimmed, and an `id` is what marks one. A nested value
+without an `id` is data, not a reference — a card's `properties` holds the
+custom field values, `{"id_714":[1088]}` — so it is passed through whole. There
+is no `properties_id` to stand in for it, and dropping it would lose the values
+rather than a pointer to them.
+
+Id arrays Kaiten sends itself (`tag_ids`, `parents_ids`) are passed through
+untouched, and nothing is ever invented.
+
+> **`children_ids` and `children_count` undercount.** They come straight from
+> Kaiten and can report fewer children than a card has — both have been seen
+> reporting eight for a card that has eleven, and expanding `children` returns
+> the same short list. Use `list-card-children` when the children of a card
+> have to be accurate.
+
 To discover what a command offers, pass a name it does not have:
 
 ```bash

--- a/Sources/kaiten/Cards/CardCommands.swift
+++ b/Sources/kaiten/Cards/CardCommands.swift
@@ -41,7 +41,11 @@ func parseCardCondition(_ rawValue: Int?) throws -> CardCondition? {
 struct ListCards: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "list-cards",
-    abstract: "List cards on a board (paginated)"
+    abstract: "List cards on a board (paginated)",
+    discussion: """
+      `children_ids` and `children_count` on each row come straight from Kaiten and undercount: a \
+      card can have more children than either field admits.
+      """
   )
 
   @OptionGroup var global: GlobalOptions
@@ -345,7 +349,11 @@ struct CreateCard: AsyncParsableCommand {
 struct GetCard: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "get-card",
-    abstract: "Get a card by ID"
+    abstract: "Get a card by ID",
+    discussion: """
+      `children_ids` and `children_count` come straight from Kaiten and undercount: a card can \
+      have more children than either field admits.
+      """
   )
 
   @OptionGroup var global: GlobalOptions

--- a/Sources/kaiten/Cards/ChildCommands.swift
+++ b/Sources/kaiten/Cards/ChildCommands.swift
@@ -7,7 +7,11 @@ import KaitenSDK
 struct ListCardChildren: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "list-card-children",
-    abstract: "List children of a card"
+    abstract: "List children of a card",
+    discussion: """
+      Enumerates every child of a card, including the ones the card's own `children_ids` and \
+      `children_count` omit.
+      """
   )
 
   @OptionGroup var global: GlobalOptions

--- a/Sources/kaiten/JSONOutput.swift
+++ b/Sources/kaiten/JSONOutput.swift
@@ -6,8 +6,13 @@ import Foundation
 /// Kaiten responses embed whole related entities alongside the references to them: a card carries
 /// `owner_id` *and* the entire owner, plus its board, type, lane, column, members, tags, checklists,
 /// children and files. Those thirteen-odd fields dwarf the seventy scalars callers usually read, so
-/// by default they are dropped and only scalars and `*_id` references survive. `--expand` names the
-/// ones to keep.
+/// by default they are cut back to the reference alone and `--expand` names the ones to restore.
+///
+/// Only entities are cut, and an `id` is what marks one. A single entity is dropped outright — its
+/// `*_id` is already alongside it — while a collection becomes the ids of its members, under its own
+/// key. Anything without an `id` is data rather than a reference, has no `*_id` standing in for it,
+/// and is passed through whole: dropping a card's `properties` would lose the custom field values
+/// themselves, which is the silent loss this trimming exists to avoid.
 ///
 /// Expansion is one level deep. An expanded value is itself stripped of its own nested fields, so
 /// `--expand children` on an epic returns its children without *their* children. The bound is not a
@@ -68,42 +73,72 @@ enum JSONOutput {
     }
     return Set(
       objects(in: json).flatMap { object in
-        object.filter { isNested($1) || ($1 as? [Any])?.isEmpty == true }.keys
+        object.filter { isEntityReference($1) || ($1 as? [Any])?.isEmpty == true }.keys
       }
     )
   }
 
   // MARK: - Trimming
 
-  /// Drops nested fields other than `keep`, and flattens the ones kept.
+  /// Drops nested fields other than `keep`, flattens the ones kept, and leaves an id array behind
+  /// where a dropped collection would otherwise vanish without trace.
   private static func keeping(_ keep: Set<String>, in object: [String: Any]) -> [String: Any] {
     var result: [String: Any] = [:]
     for (key, value) in object {
-      guard isNested(value) else {
+      guard isEntityReference(value) else {
         result[key] = value
         continue
       }
       if keep.contains(key) {
         result[key] = flattened(value)
+      } else if let ids = identifiers(of: value) {
+        result[key] = ids
       }
     }
     return result
   }
 
-  /// Strips an expanded value of its own nested fields — the one level of depth.
-  private static func flattened(_ value: Any) -> Any {
-    apply(value) { object in object.filter { _, nested in !isNested(nested) } }
+  /// The ids of a collection's entities, which take the collection's place when it is dropped.
+  ///
+  /// A dropped single relation leaves its reference behind — `owner` goes, `owner_id` stays — but a
+  /// collection had no such fallback, so a card with members was indistinguishable from a card with
+  /// none. Keeping the ids under the collection's own key closes that without renaming anything: an
+  /// empty collection and a full one report the same field, and `--expand` swaps the ids back for
+  /// the entities in place.
+  ///
+  /// The field's element type therefore depends on `--expand` — ids by default, objects when
+  /// expanded. That is what `--expand` is for, and it beats the alternative of two different field
+  /// names for the same relation.
+  ///
+  /// Returns nil for a single object, which needs no help — its `*_id` is already alongside it.
+  /// Every element is known to carry an `id` by the time this runs; ``isEntityReference(_:)`` is
+  /// what established that, and a collection failing it is kept whole rather than arriving here.
+  private static func identifiers(of value: Any) -> [Any]? {
+    guard let elements = value as? [Any] else { return nil }
+    return elements.compactMap { ($0 as? [String: Any])?["id"] }
   }
 
-  /// Whether a value carries a whole entity rather than a scalar.
+  /// Strips an expanded value of its own nested fields — the one level of depth.
+  private static func flattened(_ value: Any) -> Any {
+    apply(value) { object in object.filter { _, nested in !isEntityReference(nested) } }
+  }
+
+  /// Whether a value holds entities the response can point at by id, rather than data that exists
+  /// only here.
   ///
-  /// An empty array is treated as scalar: it is indistinguishable from an empty list of IDs and
-  /// costs nothing to keep, whereas dropping it would make a card with no tags differ in shape from
-  /// one whose tags were merely not expanded.
-  private static func isNested(_ value: Any) -> Bool {
-    if value is [String: Any] { return true }
-    if let array = value as? [Any] { return array.contains { $0 is [String: Any] } }
-    return false
+  /// The `id` is the whole signal, and it is what makes dropping safe. `owner` carries one, so
+  /// removing it costs nothing: `owner_id` says the same thing. A card's `properties` — the custom
+  /// field values, shaped `{"id_714": [1088]}` — carries none, and no `properties_id` exists
+  /// either, so dropping it would silently lose the values themselves. That is the failure this
+  /// trimming exists to prevent, not to cause, so data is kept whole.
+  ///
+  /// An empty array is data by this test, which is also the right answer: it is indistinguishable
+  /// from an empty list of ids and costs nothing to keep.
+  private static func isEntityReference(_ value: Any) -> Bool {
+    if let object = value as? [String: Any] { return object["id"] != nil }
+    guard let array = value as? [Any], !array.isEmpty else { return false }
+    let objects = array.compactMap { $0 as? [String: Any] }
+    return objects.count == array.count && objects.allSatisfy { $0["id"] != nil }
   }
 
   // MARK: - Pagination

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -9,6 +9,7 @@ struct Kaiten: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "kaiten",
     abstract: "CLI for Kaiten API",
+    discussion: "Every subcommand prints compact JSON to stdout.",
     subcommands: [
       ListSpaces.self,
       ListBoards.self,
@@ -89,10 +90,19 @@ struct GlobalOptions: ParsableArguments {
     help: ArgumentHelp(
       "Comma-separated nested fields to include in the output, or 'all'.",
       discussion: """
-        Responses omit nested entities by default: a card keeps owner_id but drops the embedded \
-        owner object. Naming a field brings it back one level deep — expanded values are \
-        themselves stripped of their nested fields. Pass an unknown name to list what a command \
-        offers.
+        Responses omit nested entities by default. A single one is dropped, its `*_id` staying \
+        behind: a card keeps owner_id and loses the embedded owner object. A collection collapses \
+        to an array of its members' ids under its own key, so `members` holds user ids, and an \
+        empty `members` means nobody rather than something withheld.
+
+        Naming a field brings the entities back, one level deep — an expanded value is itself \
+        stripped of its nested fields.
+
+        A nested value carrying no id is data, not a reference, and nothing else in the response \
+        stands in for it, so it is always present and cannot be expanded: a card's custom field \
+        values are never omitted.
+
+        Pass an unknown name to list what a command offers.
         """,
       valueName: "fields"
     )

--- a/Tests/KaitenSDKTests/JSONOutputTests.swift
+++ b/Tests/KaitenSDKTests/JSONOutputTests.swift
@@ -38,9 +38,9 @@ struct JSONOutputTests {
       (trimmed["files"] as? [Any])?.isEmpty == true,
       "an empty array is indistinguishable from scalars, so it is kept"
     )
-    #expect(trimmed["owner"] == nil)
-    #expect(trimmed["tags"] == nil)
-    #expect(trimmed["children"] == nil)
+    #expect(trimmed["owner"] == nil, "a single relation goes; owner_id already carries the fact")
+    #expect(trimmed["tags"] as? [Int] == [4], "a collection is replaced by its ids")
+    #expect(trimmed["children"] as? [Int] == [43])
   }
 
   @Test("Named fields are expanded, others still dropped")
@@ -48,7 +48,7 @@ struct JSONOutputTests {
     let trimmed = try object(JSONOutput.trim(card, expand: ["owner"]))
 
     #expect(try object(#require(trimmed["owner"]))["full_name"] as? String == "Aleksey Berezka")
-    #expect(trimmed["tags"] == nil)
+    #expect(trimmed["tags"] as? [Int] == [4], "unexpanded collections stay as ids")
     #expect(trimmed["owner_id"] as? Int == 7, "expanding adds, it does not replace the reference")
   }
 
@@ -79,8 +79,87 @@ struct JSONOutputTests {
     for element in trimmed {
       let card = try object(element)
       #expect(card["owner"] != nil)
-      #expect(card["tags"] == nil)
+      #expect(card["tags"] as? [Int] == [4])
     }
+  }
+
+  // MARK: - Identifiers left behind by dropped collections
+
+  @Test("A dropped collection becomes its ids, under the same key")
+  func droppedCollectionBecomesIdentifiers() throws {
+    let card: [String: Any] = [
+      "id": 42,
+      "members": [["id": 7, "full_name": "A"], ["id": 12, "full_name": "B"]],
+    ]
+
+    let trimmed = try object(JSONOutput.trim(card, expand: []))
+
+    #expect(trimmed["members"] as? [Int] == [7, 12], "the payload goes, the fact stays")
+  }
+
+  @Test("A card with members and one without report the same field")
+  func fullAndEmptyCollectionsAgreeOnTheKey() throws {
+    let staffed = try object(JSONOutput.trim(["members": [["id": 7]]], expand: []))
+    let empty = try object(JSONOutput.trim(["members": []], expand: []))
+
+    #expect(staffed["members"] as? [Int] == [7])
+    #expect((empty["members"] as? [Any])?.isEmpty == true)
+  }
+
+  @Test("Expanding puts the entities back in the same key")
+  func expandingRestoresEntitiesInPlace() throws {
+    let card: [String: Any] = ["id": 42, "members": [["id": 7, "full_name": "A"]]]
+
+    let trimmed = try object(JSONOutput.trim(card, expand: ["members"]))
+    let members = try #require(trimmed["members"] as? [Any])
+
+    #expect(try object(#require(members.first))["full_name"] as? String == "A")
+  }
+
+  @Test("Id arrays Kaiten already sends are left alone")
+  func leavesKaitensOwnIdentifierArraysAlone() throws {
+    let card: [String: Any] = ["tags": [["id": 4]], "tag_ids": [4], "parents_ids": [9]]
+
+    let trimmed = try object(JSONOutput.trim(card, expand: []))
+
+    #expect(trimmed["tags"] as? [Int] == [4])
+    #expect(trimmed["tag_ids"] as? [Int] == [4], "untouched")
+    #expect(trimmed["parents_ids"] as? [Int] == [9], "untouched")
+  }
+
+  // MARK: - Data is not a reference
+
+  @Test("An object with no id is data, and survives whole")
+  func keepsDataObjects() throws {
+    // A card's custom field values. There is no `properties_id` standing in for them, so dropping
+    // them would lose the values outright.
+    let card: [String: Any] = [
+      "id": 42,
+      "owner": ["id": 7, "full_name": "A"],
+      "properties": ["id_714": [1088], "id_369988": 100],
+    ]
+
+    let trimmed = try object(JSONOutput.trim(card, expand: []))
+
+    #expect(trimmed["owner"] == nil, "an entity goes; owner_id already carries the fact")
+    #expect(try object(#require(trimmed["properties"]))["id_369988"] as? Int == 100)
+  }
+
+  @Test("A collection whose elements have no id is data too, and survives whole")
+  func keepsCollectionsOfData() throws {
+    let card: [String: Any] = ["id": 42, "notes": [["text": "no id here"]]]
+
+    let trimmed = try object(JSONOutput.trim(card, expand: []))
+    let notes = try #require(trimmed["notes"] as? [Any])
+
+    #expect(try object(#require(notes.first))["text"] as? String == "no id here")
+  }
+
+  @Test("Data is not offered to --expand, having never been collapsed")
+  func dataIsNotExpandable() {
+    let card: [String: Any] = ["id": 42, "properties": ["id_714": [1088]]]
+
+    #expect(!JSONOutput.expandableFields(in: card).contains("properties"))
   }
 
   // MARK: - Pagination
@@ -96,7 +175,7 @@ struct JSONOutputTests {
     #expect(trimmed["hasMore"] as? Bool == true, "page metadata survives")
     #expect(row["id"] as? Int == 42, "rows survive rather than being dropped with the envelope")
     #expect(row["owner"] != nil)
-    #expect(row["tags"] == nil)
+    #expect(row["tags"] as? [Int] == [4], "unexpanded collections stay as ids")
   }
 
   @Test("Expandable fields of a page are its rows', not the envelope's")
@@ -112,7 +191,10 @@ struct JSONOutputTests {
 
     let trimmed = try object(JSONOutput.trim(checklist, expand: []))
 
-    #expect(trimmed["items"] == nil, "checklist items are a nested entity, not a page payload")
+    #expect(
+      trimmed["items"] as? [Int] == [9],
+      "checklist items are a nested entity, so they collapse to ids rather than being the payload"
+    )
     #expect(JSONOutput.expandableFields(in: checklist) == ["items"])
   }
 

--- a/agent/.claude-plugin/plugin.json
+++ b/agent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kaiten",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Teaches the agent when and how to reach for the kaiten CLI (cards, boards, spaces, sprints, checklists, comments, members, custom properties) — read the help first, then work from it",
   "author": {
     "name": "Aleksey Berezka"

--- a/agent/.cursor-plugin/plugin.json
+++ b/agent/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kaiten",
   "displayName": "Kaiten",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Teaches the agent when and how to reach for the kaiten CLI (cards, boards, spaces, sprints, checklists, comments, members, custom properties) — read the help first, then work from it",
   "author": {
     "name": "Aleksey Berezka"

--- a/agent/gemini-extension.json
+++ b/agent/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "kaiten",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Drive the kaiten CLI for the Kaiten project management API — read its --help first, then compose commands from it"
 }

--- a/agent/skills/kaiten/SKILL.md
+++ b/agent/skills/kaiten/SKILL.md
@@ -104,7 +104,6 @@ Same idea elsewhere: resolve a person with `kaiten list-users --query <name>` be
 
 ## Output: always JSON, in one of two shapes
 
-Every subcommand prints compact JSON to stdout — a single line, keys sorted — so pipe it to `jq`.
 There are two shapes and mixing them up is the most common way these pipelines break:
 
 - Subcommands whose abstract in `kaiten --help` ends in **`(paginated)`** return a page envelope:
@@ -116,52 +115,26 @@ because accepting `--offset` / `--limit` is not the same thing. Several subcomma
 and still return a bare array with no `hasMore` — to page one of those, keep going until a response
 comes back shorter than the `--limit` you asked for.
 
-## Related entities are omitted until you ask for them
+## Never read a fact out of an omitted field
 
-A response carries that entity's own scalars plus `*_id` references to its neighbours. The entities
-behind those references — the person behind `owner_id`, the board behind `board_id`, and collections
-such as members, tags, children or files — are left out unless you name them:
+`--help` explains what `--expand` omits and how to get it back. The part it cannot make you do is
+resist concluding anything from what is missing, and that is where these responses go wrong: they
+produce confident false answers rather than errors.
 
-```bash
-kaiten get-card --id 7                       # scalars and *_id references only
-kaiten get-card --id 7 --expand owner,tags   # those two come back as full objects
-kaiten get-card --id 7 --expand all          # every related entity in this response
-```
+A card whose output has no `owner` key still has an owner. "This card is unassigned" read off a
+default response is a fabrication, not a finding. Whenever the fact you need is about a neighbouring
+entity rather than the one you fetched, expand it or fetch it — never infer it from silence.
 
-**A missing key says nothing about the tracker.** This is the trap worth internalising, because it
-produces confident false answers rather than errors: a card whose output has no `owner` key still
-has an owner, and "this card is unassigned" read off a default response is a fabrication. Whenever
-the fact you need is about a neighbouring entity rather than the one you fetched, expand it or fetch
-it — never infer it from silence. The same goes for counting: `members` being absent is not zero
-members, though a `*_count` or `*_total` scalar, when the response has one, is a real answer.
+Read the same way when a subcommand's `--help` warns that a field misreports. It means the number in
+front of you is a floor, not an answer, and a claim built on it needs the endpoint that enumerates
+the things instead.
 
 **Ask for the fields you need rather than reaching for `all`.** These payloads are large — a single
 expanded owner is a whole user record — and `all` on a list of cards multiplies that by every row.
 Naming two or three fields keeps a board-sized response readable instead of burying the answer.
 
-**To find out what a subcommand offers, ask it for a field that does not exist:**
-
-```bash
-kaiten get-card --id 7 --expand '?'
-# Error: Unknown --expand field: '?'. Available: board, column, lane, members, owner, …
-```
-
-Quote the `?` — unquoted it is a shell glob and never reaches the CLI. Any other name that
-cannot be a field does the same job: `--expand nope`.
-
-That list is computed from the response in front of you, so it is accurate for that call in a way no
-document can be — including this one, which is why no list of expandable fields appears here.
-
-**Expansion goes exactly one level deep.** `--expand children` returns a card's children as objects,
-but each child is trimmed by the same rule, so the children's own children are not there. This is
-deliberate: cards nest into cards, and unbounded expansion would return the shape of the graph
-rather than the answer. To go deeper, run the next command against the ID you just got back.
-
-**A name absent from that `Available:` list means the response does not contain it** — which is not
-the same as the data not existing. Relations frequently have a subcommand of their own, so check
-`kaiten --help` for one before concluding anything; a few subcommands also take a flag that asks the
-server to include extra fields, and their `--help` says so. Guessing again with a different spelling
-is the one thing that will not help.
+**Quote the probe name.** `--expand '?'` makes the CLI list what it offers; unquoted, `?` is a shell
+glob and never reaches the CLI. Any impossible name does the same job: `--expand nope`.
 
 ## Paging a full board
 
@@ -173,8 +146,8 @@ limit=100   # confirm the max in `kaiten list-cards --help`
 offset=0
 while :; do
   page=$(kaiten list-cards --board-id 42 --limit "$limit" --offset "$offset")
-  echo "$page" | jq -c '.items[]'
-  [ "$(echo "$page" | jq -r '.hasMore')" = "true" ] || break
+  printf '%s' "$page" | jq -c '.items[]'
+  [ "$(printf '%s' "$page" | jq -r '.hasMore')" = "true" ] || break
   offset=$((offset + limit))
 done
 ```

--- a/specs/002-kaiten-cli/spec.md
+++ b/specs/002-kaiten-cli/spec.md
@@ -174,6 +174,43 @@ stdout confirms it works.
   remove that cost and is the intended long-term fix.
 - **FR-020**: JSON output MUST be compact rather than pretty-printed, with
   keys sorted so that output is stable across runs.
+- **FR-021**: Where a collection of entities is omitted, the CLI MUST replace
+  it with an array of their ids **under the same key**, so the response still
+  states that the relation exists. A single relation needs no such treatment —
+  dropping `owner` leaves `owner_id` behind — but a collection had no
+  fallback, and a card with members was indistinguishable from a card with
+  none. Keeping the key means an empty collection and a populated one report
+  the same field, which renaming to `member_ids` would not achieve.
+  A consequence is that the element type depends on `--expand`: ids by
+  default, entities when expanded. That is accepted; it is what `--expand`
+  means, and it beats two field names for one relation.
+  The CLI MUST NOT invent ids, and id arrays Kaiten sends itself (`tag_ids`,
+  `parents_ids`) MUST be passed through untouched.
+- **FR-021a**: Only entities may be trimmed, and the presence of an `id` is
+  what identifies one. A nested value carrying no `id` is data rather than a
+  reference — a card's `properties` holds custom field values shaped
+  `{"id_714": [1088]}` — and MUST be passed through whole, whether it is an
+  object or a collection. No `properties_id` exists to stand in for it, so
+  dropping it would lose the values themselves rather than a reference to
+  them, which is precisely the silent loss this trimming exists to prevent.
+  Such fields MUST NOT be offered to `--expand`: never having been collapsed,
+  there is nothing to restore.
+- **FR-022**: Where the CLI knowingly passes through a field that
+  misreports, the help of the affected subcommand MUST say so.
+  `children_ids` and `children_count` undercount — both have been observed
+  reporting eight children for a card that has eleven, and expanding
+  `children` returns the same short list — so `get-card`, `list-cards` and
+  `list-card-children` each state it. The CLI MUST NOT issue extra requests
+  to repair such a field: the cost is per row, and documenting the limit
+  keeps one command one request.
+- **FR-023**: A subcommand's help MUST describe the behaviour of its own
+  endpoint and nothing else. It MUST NOT direct the reader to other
+  subcommands: `kaiten --help` already lists them, cross-references are the
+  first thing to rot, and a subcommand's help is not a guide to the CLI.
+  Help MUST NOT explain the shell, `jq`, or how to consume the output, and
+  MUST NOT carry worked examples or the evidence behind a stated limit —
+  none of that is this CLI's behaviour to document. Properties shared by
+  every response belong once in the root command's discussion.
 
 ### Non-Functional Requirements
 


### PR DESCRIPTION
Closes #409.

## The rule, in one line

A nested value is trimmed only if it is an **entity**, and an `id` is what marks one. Field names are never changed.

| kind of value | what happens |
|---|---|
| single entity (`owner`) | dropped — `owner_id` already says it |
| collection of entities (`members`) | becomes an array of their ids, **same key** |
| data, no `id` (a card's custom field values) | passed through whole |

```bash
kaiten get-card --id 123
# {"members":[821,904],"external_links":[5512,5513],"tags":[],"owner_id":821,…}

kaiten get-card --id 123 --expand members
# {"members":[{"id":821,"full_name":"…",…}],…}
```

## Why the key is kept rather than renamed

Renaming a dropped `members` to `member_ids` was tried and rejected. It moved the asymmetry instead of removing it: a card **with** members reported `member_ids`, a card **without** still reported `members: []` — one fact under two names depending on the data. It also dragged in singular/plural guessing (`parents` → `parent_ids` against Kaiten's own `parents_ids`), a check for pre-existing id arrays, and at one point a collection-name list generated from the OpenAPI schema.

Keeping the key removes all of it. `members: [821]` and `members: []` are both answers under one name, and the code is one six-line function. The consequence is that the field holds ids by default and entities when expanded — which is what `--expand` means, and better than two names for one relation.

Kaiten's own id arrays (`tag_ids`, `parents_ids`) are passed through untouched. Nothing is invented.

## Data was being lost, not just references

Looking for the same silence elsewhere found it somewhere worse. A card's custom field values — story points included — were dropped like any other nested object. But nothing stands in for them the way `owner_id` stands in for `owner`, so a card with custom fields read exactly like a card without. Trimming was discarding the values themselves, which is the failure it was written to prevent.

The `id` test settles it: values carrying no `id` are data, survive whole, and are not offered to `--expand` since they were never collapsed.

**Cost:** default output grows 14% on a company-sized space, still 6.2× smaller than `--expand all`.

## The children undercount is documented, not repaired

`children_ids` and `children_count` report fewer children than a card has, and the embedded `children` collection is equally short, so no flag recovers the difference.

The rule behind it was not established. Across 189 children of 25 parents, done children are always counted, in-progress never, queued usually not — but one parent counts its unfinished children, so state correlates without explaining. Board is ruled out (cross-board children are counted), archived is ruled out (counted and missing children are archived alike), counter staleness is ruled out (recalculation postdates the last change to the missing children).

So the affected subcommands say in their help that the fields undercount. An earlier revision had `get-card` re-read children to fix them; it was dropped deliberately — repairing a per-row field costs a request per row, and one command should stay one request.

## Documentation rules, now written down

Working on this surfaced how the help had drifted into being a manual. AGENTS.md now records what belongs where:

- help documents API behaviour only — no shell, no `jq`, no worked examples, no evidence behind a stated limit
- **never real entity IDs**, anywhere in help or comments: this repository is public
- a subcommand's help describes its own endpoint and does not point at other subcommands
- anything the help states is deleted from the skill rather than restated there

The skill kept only what help cannot enforce: do not read a fact out of an omitted field, and treat a field the help calls unreliable as a floor rather than an answer.

## Verification

- 284 tests pass, 9 new ones covering the entity/data distinction, the same-key rule for full and empty collections, and expansion restoring entities in place
- All 25 read-only commands checked against the invariant that the only keys absent by default are single entities carrying an `id` — no violations; id arrays verified element-by-element against the expanded entities
- Spec updated with FR-021/021a/022/023; README documents the output rules
- Agent skill updated, plugin **1.2.0** across all four manifests, both `claude plugin validate` runs clean