### PR TITLE
feat: add space automations to spec, SDK and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,43 @@ Quote the `?` — unquoted it is a shell glob and never reaches the CLI.
 | `listSprints()` | List sprints |
 | `getSprintSummary(...)` | Get sprint summary |
 
+### Automations
+
+| Method | Description |
+|--------|-------------|
+| `listAutomations(spaceId:)` | List automations in a space |
+| `createAutomation(spaceId:type:actions:name:trigger:conditions:)` | Create an automation |
+| `updateAutomation(spaceId:automationUid:name:trigger:conditions:actions:)` | Update an automation |
+| `deleteAutomation(spaceId:automationUid:)` | Delete an automation |
+
+Automations come in three types: `.onAction` (event), `.onDate` (due date) and
+`.onDemand` (button).
+
+Trigger, action, status and condition discriminators are exposed as Swift enums
+(`AutomationTriggerType`, `AutomationActionType`, `AutomationStatus`,
+`AutomationConditionClause`). Each has an `unknown(String)` case: Kaiten returns
+values its documentation does not list, so undocumented values are preserved
+rather than failing the whole response. Nested `data` payloads stay free-form
+JSON — the documentation does not describe their fields.
+
+```swift
+let automations = try await client.listAutomations(spaceId: 38155)
+for automation in automations {
+  switch automation.actions?.first?.actionType {
+  case .moveToPath: print("moves cards")
+  case .unknown(let raw): print("new action type: \(raw)")
+  default: break
+  }
+}
+
+let created = try await client.createAutomation(
+  spaceId: 38155,
+  type: .onDemand,
+  actions: [.init(actionType: .completeChecklists)],
+  name: "Complete all checklists"
+)
+```
+
 ## Pagination
 
 Most list endpoints accept `offset` and `limit` parameters and return a `Page<T>`:

--- a/Sources/KaitenSDK/Enums.swift
+++ b/Sources/KaitenSDK/Enums.swift
@@ -397,3 +397,446 @@ public enum CardHistoryCondition: Sendable, Equatable, CaseIterable, Codable {
     try container.encode(rawValue)
   }
 }
+
+// MARK: - Automations
+//
+// Automation discriminators are declared as plain strings in the OpenAPI spec
+// because Kaiten returns values that its documentation does not list (for
+// example the action type `change_type`). A generated closed enum would fail to
+// decode those responses outright, so the typed surface lives here instead —
+// with an `unknown(String)` case that preserves anything new the API adds.
+
+/// Automation type.
+///
+/// Used in ``KaitenClient/createAutomation(spaceId:type:actions:name:trigger:conditions:)``.
+/// - SeeAlso: [Kaiten API – Automations](https://developers.kaiten.ru/automations/create-automation)
+public enum AutomationType: Sendable, Equatable, CaseIterable, Codable {
+  /// Triggered by an event.
+  case onAction
+  /// Triggered by a due date.
+  case onDate
+  /// Triggered manually via the automation button on a card.
+  case onDemand
+  /// Unknown value returned by the API (forward compatibility).
+  case unknown(String)
+
+  public static var allCases: [AutomationType] {
+    [.onAction, .onDate, .onDemand]
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "on_action": self = .onAction
+    case "on_date": self = .onDate
+    case "on_demand": self = .onDemand
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: String {
+    switch self {
+    case .onAction: "on_action"
+    case .onDate: "on_date"
+    case .onDemand: "on_demand"
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(String.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}
+
+/// Automation status.
+/// - SeeAlso: [Kaiten API – Automations](https://developers.kaiten.ru/automations/get-list-of-automations)
+public enum AutomationStatus: Sendable, Equatable, CaseIterable, Codable {
+  /// Automation is enabled.
+  case active
+  /// Automation is switched off.
+  case disabled
+  /// Automation is deleted.
+  case removed
+  /// Automation references a missing entity and cannot run.
+  case broken
+  /// Unknown value returned by the API (forward compatibility).
+  case unknown(String)
+
+  public static var allCases: [AutomationStatus] {
+    [.active, .disabled, .removed, .broken]
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "active": self = .active
+    case "disabled": self = .disabled
+    case "removed": self = .removed
+    case "broken": self = .broken
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: String {
+    switch self {
+    case .active: "active"
+    case .disabled: "disabled"
+    case .removed: "removed"
+    case .broken: "broken"
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(String.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}
+
+/// Automation trigger type.
+/// - SeeAlso: [Kaiten API – Automations](https://developers.kaiten.ru/automations/get-list-of-automations)
+public enum AutomationTriggerType: Sendable, Equatable, CaseIterable, Codable {
+  /// Card moved.
+  case cardMovedInPath
+  /// Card created.
+  case cardCreated
+  /// Comment is posted to a card.
+  case commentPosted
+  /// Card member added.
+  case cardUserAdded
+  /// Card responsible member added.
+  case responsibleAdded
+  /// Card type is changed.
+  case cardTypeChanged
+  /// Card state is changed.
+  case cardStateChanged
+  /// Property is changed.
+  case customPropertyChanged
+  /// Due date is changed.
+  case dueDateChanged
+  /// Checklist item is checked.
+  case checklistItemChecked
+  /// All checklists in a card are completed.
+  case checklistsCompleted
+  /// Child cards state is changed.
+  case childCardsStateChanged
+  /// Tag added.
+  case tagAdded
+  /// Tag removed.
+  case tagRemoved
+  /// Card is blocked.
+  case blocked
+  /// Card is unblocked.
+  case unblocked
+  /// Blocker is added to a card.
+  case blockerAdded
+  /// Card has a due date.
+  case dueDateOnDate
+  /// Checklist item has a due date.
+  case checklistItemDueDateOnDate
+  /// A field with the Date type has a date.
+  case customPropertyDateOnDate
+  /// All automation conditions are met.
+  case allConditionsMet
+  /// Unknown value returned by the API (forward compatibility).
+  case unknown(String)
+
+  public static var allCases: [AutomationTriggerType] {
+    [
+      .cardMovedInPath,
+      .cardCreated,
+      .commentPosted,
+      .cardUserAdded,
+      .responsibleAdded,
+      .cardTypeChanged,
+      .cardStateChanged,
+      .customPropertyChanged,
+      .dueDateChanged,
+      .checklistItemChecked,
+      .checklistsCompleted,
+      .childCardsStateChanged,
+      .tagAdded,
+      .tagRemoved,
+      .blocked,
+      .unblocked,
+      .blockerAdded,
+      .dueDateOnDate,
+      .checklistItemDueDateOnDate,
+      .customPropertyDateOnDate,
+      .allConditionsMet,
+    ]
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "card_moved_in_path": self = .cardMovedInPath
+    case "card_created": self = .cardCreated
+    case "comment_posted": self = .commentPosted
+    case "card_user_added": self = .cardUserAdded
+    case "responsible_added": self = .responsibleAdded
+    case "card_type_changed": self = .cardTypeChanged
+    case "card_state_changed": self = .cardStateChanged
+    case "custom_property_changed": self = .customPropertyChanged
+    case "due_date_changed": self = .dueDateChanged
+    case "checklist_item_checked": self = .checklistItemChecked
+    case "checklists_completed": self = .checklistsCompleted
+    case "child_cards_state_changed": self = .childCardsStateChanged
+    case "tag_added": self = .tagAdded
+    case "tag_removed": self = .tagRemoved
+    case "blocked": self = .blocked
+    case "unblocked": self = .unblocked
+    case "blocker_added": self = .blockerAdded
+    case "due_date_on_date": self = .dueDateOnDate
+    case "checklist_item_due_date_on_date": self = .checklistItemDueDateOnDate
+    case "custom_property_date_on_date": self = .customPropertyDateOnDate
+    case "all_conditions_met": self = .allConditionsMet
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: String {
+    switch self {
+    case .cardMovedInPath: "card_moved_in_path"
+    case .cardCreated: "card_created"
+    case .commentPosted: "comment_posted"
+    case .cardUserAdded: "card_user_added"
+    case .responsibleAdded: "responsible_added"
+    case .cardTypeChanged: "card_type_changed"
+    case .cardStateChanged: "card_state_changed"
+    case .customPropertyChanged: "custom_property_changed"
+    case .dueDateChanged: "due_date_changed"
+    case .checklistItemChecked: "checklist_item_checked"
+    case .checklistsCompleted: "checklists_completed"
+    case .childCardsStateChanged: "child_cards_state_changed"
+    case .tagAdded: "tag_added"
+    case .tagRemoved: "tag_removed"
+    case .blocked: "blocked"
+    case .unblocked: "unblocked"
+    case .blockerAdded: "blocker_added"
+    case .dueDateOnDate: "due_date_on_date"
+    case .checklistItemDueDateOnDate: "checklist_item_due_date_on_date"
+    case .customPropertyDateOnDate: "custom_property_date_on_date"
+    case .allConditionsMet: "all_conditions_met"
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(String.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}
+
+/// Automation action type.
+/// - SeeAlso: [Kaiten API – Automations](https://developers.kaiten.ru/automations/get-list-of-automations)
+public enum AutomationActionType: Sendable, Equatable, CaseIterable, Codable {
+  /// Make responsible.
+  case addAssignee
+  /// Remove responsible.
+  case removeAssignee
+  /// Add card members.
+  case addCardUsers
+  /// Remove card members.
+  case removeCardUsers
+  /// Add user groups to a card.
+  case addUserGroups
+  /// Add tags.
+  case addTag
+  /// Remove tags.
+  case removeTags
+  /// Add property.
+  case addProperty
+  /// Add property to child cards.
+  case propertyAddToChildCard
+  /// Add size.
+  case addSize
+  /// Add timeline.
+  case addTimeline
+  /// Change ASAP.
+  case changeAsap
+  /// Set due date.
+  case addDueDate
+  /// Remove due date.
+  case removeDueDate
+  /// Move card to.
+  case moveToPath
+  /// Move a card within the board.
+  case moveOnBoard
+  /// Archive card.
+  case archive
+  /// Create child card.
+  case addChildCard
+  /// Create parent card.
+  case addParentCard
+  /// Add parent card.
+  case connectParentCard
+  /// Complete all checklists in card.
+  case completeChecklists
+  /// Sort cards.
+  case sortCards
+  /// Add comment.
+  case addComment
+  /// Add SLA.
+  case cardAddSla
+  /// Remove SLA.
+  case cardRemoveSla
+  /// Unknown value returned by the API (forward compatibility).
+  case unknown(String)
+
+  public static var allCases: [AutomationActionType] {
+    [
+      .addAssignee,
+      .removeAssignee,
+      .addCardUsers,
+      .removeCardUsers,
+      .addUserGroups,
+      .addTag,
+      .removeTags,
+      .addProperty,
+      .propertyAddToChildCard,
+      .addSize,
+      .addTimeline,
+      .changeAsap,
+      .addDueDate,
+      .removeDueDate,
+      .moveToPath,
+      .moveOnBoard,
+      .archive,
+      .addChildCard,
+      .addParentCard,
+      .connectParentCard,
+      .completeChecklists,
+      .sortCards,
+      .addComment,
+      .cardAddSla,
+      .cardRemoveSla,
+    ]
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "add_assignee": self = .addAssignee
+    case "remove_assignee": self = .removeAssignee
+    case "add_card_users": self = .addCardUsers
+    case "remove_card_users": self = .removeCardUsers
+    case "add_user_groups": self = .addUserGroups
+    case "add_tag": self = .addTag
+    case "remove_tags": self = .removeTags
+    case "add_property": self = .addProperty
+    case "property_add_to_child_card": self = .propertyAddToChildCard
+    case "add_size": self = .addSize
+    case "add_timeline": self = .addTimeline
+    case "change_asap": self = .changeAsap
+    case "add_due_date": self = .addDueDate
+    case "remove_due_date": self = .removeDueDate
+    case "move_to_path": self = .moveToPath
+    case "move_on_board": self = .moveOnBoard
+    case "archive": self = .archive
+    case "add_child_card": self = .addChildCard
+    case "add_parent_card": self = .addParentCard
+    case "connect_parent_card": self = .connectParentCard
+    case "complete_checklists": self = .completeChecklists
+    case "sort_cards": self = .sortCards
+    case "add_comment": self = .addComment
+    case "card_add_sla": self = .cardAddSla
+    case "card_remove_sla": self = .cardRemoveSla
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: String {
+    switch self {
+    case .addAssignee: "add_assignee"
+    case .removeAssignee: "remove_assignee"
+    case .addCardUsers: "add_card_users"
+    case .removeCardUsers: "remove_card_users"
+    case .addUserGroups: "add_user_groups"
+    case .addTag: "add_tag"
+    case .removeTags: "remove_tags"
+    case .addProperty: "add_property"
+    case .propertyAddToChildCard: "property_add_to_child_card"
+    case .addSize: "add_size"
+    case .addTimeline: "add_timeline"
+    case .changeAsap: "change_asap"
+    case .addDueDate: "add_due_date"
+    case .removeDueDate: "remove_due_date"
+    case .moveToPath: "move_to_path"
+    case .moveOnBoard: "move_on_board"
+    case .archive: "archive"
+    case .addChildCard: "add_child_card"
+    case .addParentCard: "add_parent_card"
+    case .connectParentCard: "connect_parent_card"
+    case .completeChecklists: "complete_checklists"
+    case .sortCards: "sort_cards"
+    case .addComment: "add_comment"
+    case .cardAddSla: "card_add_sla"
+    case .cardRemoveSla: "card_remove_sla"
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(String.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}
+
+/// Boolean clause joining automation conditions within a group.
+/// - SeeAlso: [Kaiten API – Automations](https://developers.kaiten.ru/automations/get-list-of-automations)
+public enum AutomationConditionClause: Sendable, Equatable, CaseIterable, Codable {
+  /// All nested conditions must match.
+  case and
+  /// Any nested condition must match.
+  case or
+  /// Unknown value returned by the API (forward compatibility).
+  case unknown(String)
+
+  public static var allCases: [AutomationConditionClause] {
+    [.and, .or]
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "and": self = .and
+    case "or": self = .or
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: String {
+    switch self {
+    case .and: "and"
+    case .or: "or"
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(String.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}

--- a/Sources/KaitenSDK/KaitenClient+Automations.swift
+++ b/Sources/KaitenSDK/KaitenClient+Automations.swift
@@ -1,0 +1,210 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - Typed Discriminators
+
+// Automation discriminators travel as plain strings (see the comment above the
+// automation enums in `Enums.swift`). These accessors and initializers give the
+// generated payloads a typed surface without losing undocumented values.
+
+extension Components.Schemas.Automation {
+  /// The automation type, or `nil` if the API omitted the field.
+  public var automationType: AutomationType? {
+    _type.map(AutomationType.init(rawValue:))
+  }
+
+  /// The automation status, or `nil` if the API omitted the field.
+  public var automationStatus: AutomationStatus? {
+    status.map(AutomationStatus.init(rawValue:))
+  }
+}
+
+extension Components.Schemas.AutomationTrigger {
+  /// The trigger type, or `nil` if the API omitted the field.
+  public var triggerType: AutomationTriggerType? {
+    _type.map(AutomationTriggerType.init(rawValue:))
+  }
+
+  /// Creates a trigger from a typed trigger type.
+  ///
+  /// - Parameters:
+  ///   - triggerType: The trigger type.
+  ///   - hasToFireOnCardCreation: Whether the trigger fires on card creation.
+  ///   - data: Trigger payload. Its shape depends on the trigger type and is not
+  ///     described in the Kaiten documentation.
+  public init(
+    triggerType: AutomationTriggerType,
+    hasToFireOnCardCreation: Bool? = nil,
+    data: Components.Schemas.AutomationTrigger.dataPayload? = nil
+  ) {
+    self.init(
+      _type: triggerType.rawValue, hasToFireOnCardCreation: hasToFireOnCardCreation, data: data)
+  }
+}
+
+extension Components.Schemas.AutomationAction {
+  /// The action type, or `nil` if the API omitted the field.
+  public var actionType: AutomationActionType? {
+    _type.map(AutomationActionType.init(rawValue:))
+  }
+
+  /// Creates an action from a typed action type.
+  ///
+  /// - Parameters:
+  ///   - actionType: The action type.
+  ///   - created: Action creation timestamp.
+  ///   - data: Action payload. Its shape depends on the action type and is not
+  ///     described in the Kaiten documentation.
+  public init(
+    actionType: AutomationActionType,
+    created: String? = nil,
+    data: Components.Schemas.AutomationAction.dataPayload? = nil
+  ) {
+    self.init(_type: actionType.rawValue, created: created, data: data)
+  }
+}
+
+extension Components.Schemas.AutomationConditionGroup {
+  /// The clause joining the nested conditions, or `nil` if the API omitted the field.
+  public var conditionClause: AutomationConditionClause? {
+    clause.map(AutomationConditionClause.init(rawValue:))
+  }
+}
+
+// MARK: - Automations
+
+extension KaitenClient {
+  /// Lists all automations in a space.
+  ///
+  /// - Parameter spaceId: The space identifier.
+  /// - Returns: An array of automations. Returns an empty array if the space has no automations.
+  /// - Throws:
+  ///   - ``KaitenError/notFound(resource:id:)`` if the space does not exist.
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for forbidden (403) or other undocumented HTTP status codes.
+  public func listAutomations(spaceId: Int) async throws(KaitenError) -> [Components.Schemas
+    .Automation]
+  {
+    guard
+      let response = try await callList({
+        try await client.list_automations(path: .init(space_id: spaceId))
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("space", spaceId)) {
+      try $0.json
+    }
+  }
+
+  /// Creates an automation in a space.
+  ///
+  /// - Parameters:
+  ///   - spaceId: The space identifier.
+  ///   - type: The automation type. `on_action` and `on_date` automations require a `trigger`;
+  ///     `on_demand` (button) automations require a `name`.
+  ///   - actions: The actions the automation performs. Kaiten accepts 1 to 10 actions.
+  ///   - name: The automation name.
+  ///   - trigger: The automation trigger.
+  ///   - conditions: The automation conditions.
+  /// - Returns: The created automation.
+  /// - Throws:
+  ///   - ``KaitenError/notFound(resource:id:)`` if the space does not exist.
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for bad request (400), unsupported
+  ///     tariff (402), forbidden (403) or other undocumented HTTP status codes.
+  public func createAutomation(
+    spaceId: Int,
+    type: AutomationType,
+    actions: [Components.Schemas.AutomationAction],
+    name: String? = nil,
+    trigger: Components.Schemas.AutomationTrigger? = nil,
+    conditions: Components.Schemas.AutomationConditionGroup? = nil
+  ) async throws(KaitenError) -> Components.Schemas.Automation {
+    let response = try await call {
+      try await client.create_automation(
+        path: .init(space_id: spaceId),
+        body: .json(
+          .init(
+            name: name,
+            _type: type.rawValue,
+            trigger: trigger,
+            conditions: conditions,
+            actions: actions
+          ))
+      )
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("space", spaceId)) {
+      try $0.json
+    }
+  }
+
+  /// Updates an automation.
+  ///
+  /// - Parameters:
+  ///   - spaceId: The space identifier.
+  ///   - automationUid: The automation UID.
+  ///   - name: The updated automation name.
+  ///   - trigger: The updated automation trigger.
+  ///   - conditions: The updated automation conditions.
+  ///   - actions: The updated automation actions. Kaiten accepts 1 to 10 actions.
+  /// - Returns: The updated automation.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for bad request (400), unsupported
+  ///     tariff (402), forbidden (403), not found (404) or other undocumented HTTP status codes.
+  ///     A 404 is reported as `unexpectedResponse` rather than
+  ///     ``KaitenError/notFound(resource:id:)`` because automations are addressed by string UID and
+  ///     the response does not say whether the space or the automation is missing.
+  public func updateAutomation(
+    spaceId: Int,
+    automationUid: String,
+    name: String? = nil,
+    trigger: Components.Schemas.AutomationTrigger? = nil,
+    conditions: Components.Schemas.AutomationConditionGroup? = nil,
+    actions: [Components.Schemas.AutomationAction]? = nil
+  ) async throws(KaitenError) -> Components.Schemas.Automation {
+    let response = try await call {
+      try await client.update_automation(
+        path: .init(space_id: spaceId, automation_uid: automationUid),
+        body: .json(
+          .init(
+            name: name,
+            trigger: trigger,
+            conditions: conditions,
+            actions: actions
+          ))
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Deletes an automation.
+  ///
+  /// The endpoint returns HTTP 200 with no response body.
+  ///
+  /// - Parameters:
+  ///   - spaceId: The space identifier.
+  ///   - automationUid: The automation UID.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for forbidden (403), not found (404)
+  ///     or other undocumented HTTP status codes. A 404 is reported as `unexpectedResponse` rather
+  ///     than ``KaitenError/notFound(resource:id:)`` because automations are addressed by string
+  ///     UID and the response does not say whether the space or the automation is missing.
+  public func deleteAutomation(spaceId: Int, automationUid: String) async throws(KaitenError) {
+    let response = try await call {
+      try await client.delete_automation(
+        path: .init(space_id: spaceId, automation_uid: automationUid)
+      )
+    }
+    try decodeResponse(response.toCase()) { _ in () }
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -283,9 +283,7 @@ extension Operations.get_property.Output {
 }
 
 extension Operations.get_list_of_select_values.Output {
-  func toCase()
-    -> KaitenClient.ResponseCase<Operations.get_list_of_select_values.Output.Ok.Body>
-  {
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_list_of_select_values.Output.Ok.Body> {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
@@ -545,9 +543,7 @@ extension Operations.list_sprints.Output {
 // MARK: - External Links
 
 extension Operations.list_card_external_links.Output {
-  func toCase()
-    -> KaitenClient.ResponseCase<Operations.list_card_external_links.Output.Ok.Body>
-  {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_card_external_links.Output.Ok.Body> {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
@@ -559,9 +555,7 @@ extension Operations.list_card_external_links.Output {
 }
 
 extension Operations.create_card_external_link.Output {
-  func toCase()
-    -> KaitenClient.ResponseCase<Operations.create_card_external_link.Output.Ok.Body>
-  {
+  func toCase() -> KaitenClient.ResponseCase<Operations.create_card_external_link.Output.Ok.Body> {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
@@ -573,9 +567,7 @@ extension Operations.create_card_external_link.Output {
 }
 
 extension Operations.update_card_external_link.Output {
-  func toCase()
-    -> KaitenClient.ResponseCase<Operations.update_card_external_link.Output.Ok.Body>
-  {
+  func toCase() -> KaitenClient.ResponseCase<Operations.update_card_external_link.Output.Ok.Body> {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
@@ -587,9 +579,7 @@ extension Operations.update_card_external_link.Output {
 }
 
 extension Operations.remove_card_external_link.Output {
-  func toCase()
-    -> KaitenClient.ResponseCase<Operations.remove_card_external_link.Output.Ok.Body>
-  {
+  func toCase() -> KaitenClient.ResponseCase<Operations.remove_card_external_link.Output.Ok.Body> {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
@@ -603,9 +593,7 @@ extension Operations.remove_card_external_link.Output {
 // MARK: - Card Location History
 
 extension Operations.get_card_location_history.Output {
-  func toCase()
-    -> KaitenClient.ResponseCase<Operations.get_card_location_history.Output.Ok.Body>
-  {
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_card_location_history.Output.Ok.Body> {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
@@ -827,6 +815,60 @@ extension Operations.get_card_baselines.Output {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
     case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+// MARK: - Automations
+
+extension Operations.list_automations.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_automations.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.create_automation.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.create_automation.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.update_automation.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.update_automation.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.delete_automation.Output {
+  func toCase() -> KaitenClient.ResponseCase<Void> {
+    switch self {
+    case .ok: .ok(())
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
     case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
     }
   }

--- a/Sources/kaiten/Automations/AutomationCommands.swift
+++ b/Sources/kaiten/Automations/AutomationCommands.swift
@@ -1,0 +1,177 @@
+import ArgumentParser
+import Foundation
+import KaitenSDK
+
+// MARK: - Automations
+
+func parseAutomationType(_ rawValue: String) throws -> AutomationType {
+  let type = AutomationType(rawValue: rawValue)
+  guard AutomationType.allCases.contains(type) else {
+    let allowed = AutomationType.allCases.map(\.rawValue).joined(separator: ", ")
+    throw ValidationError("Invalid automation type: '\(rawValue)'. Allowed values: \(allowed)")
+  }
+  return type
+}
+
+/// Decodes a JSON command-line argument into a generated OpenAPI type.
+///
+/// Malformed JSON fails locally with a validation error — the value is never
+/// silently dropped or forwarded to the SDK.
+func parseAutomationJSON<T: Decodable>(
+  _ rawValue: String?, as type: T.Type, fieldName: String
+) throws -> T? {
+  guard let rawValue else { return nil }
+  guard let data = rawValue.data(using: .utf8) else {
+    throw ValidationError("Invalid \(fieldName): value is not valid UTF-8")
+  }
+  do {
+    return try JSONDecoder().decode(T.self, from: data)
+  } catch {
+    throw ValidationError("Invalid \(fieldName) JSON: \(error.localizedDescription)")
+  }
+}
+
+// MARK: - List Automations
+
+struct ListAutomations: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-automations",
+    abstract: "List automations in a space"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Space ID")
+  var spaceId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let automations = try await client.listAutomations(spaceId: spaceId)
+    try printJSON(automations)
+  }
+}
+
+// MARK: - Create Automation
+
+struct CreateAutomation: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "create-automation",
+    abstract: "Create an automation in a space"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Space ID")
+  var spaceId: Int
+
+  @Option(name: .long, help: "Automation type: on_action, on_date, on_demand")
+  var type: String
+
+  @Option(name: .long, help: "Actions as a JSON array, e.g. '[{\"type\":\"add_assignee\"}]'")
+  var actions: String
+
+  @Option(name: .long, help: "Automation name")
+  var name: String?
+
+  @Option(name: .long, help: "Trigger as a JSON object, e.g. '{\"type\":\"card_created\"}'")
+  var trigger: String?
+
+  @Option(name: .long, help: "Conditions as a JSON object")
+  var conditions: String?
+
+  func run() async throws {
+    let automationType = try parseAutomationType(type)
+    guard
+      let parsedActions = try parseAutomationJSON(
+        actions, as: [Components.Schemas.AutomationAction].self, fieldName: "actions")
+    else {
+      throw ValidationError("Invalid actions: value is required")
+    }
+    let parsedTrigger = try parseAutomationJSON(
+      trigger, as: Components.Schemas.AutomationTrigger.self, fieldName: "trigger")
+    let parsedConditions = try parseAutomationJSON(
+      conditions, as: Components.Schemas.AutomationConditionGroup.self, fieldName: "conditions")
+
+    let client = try await global.makeClient()
+    let automation = try await client.createAutomation(
+      spaceId: spaceId,
+      type: automationType,
+      actions: parsedActions,
+      name: name,
+      trigger: parsedTrigger,
+      conditions: parsedConditions
+    )
+    try printJSON(automation)
+  }
+}
+
+// MARK: - Update Automation
+
+struct UpdateAutomation: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "update-automation",
+    abstract: "Update an automation"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Space ID")
+  var spaceId: Int
+
+  @Option(name: .long, help: "Automation UID")
+  var automationUid: String
+
+  @Option(name: .long, help: "Automation name")
+  var name: String?
+
+  @Option(name: .long, help: "Trigger as a JSON object")
+  var trigger: String?
+
+  @Option(name: .long, help: "Conditions as a JSON object")
+  var conditions: String?
+
+  @Option(name: .long, help: "Actions as a JSON array")
+  var actions: String?
+
+  func run() async throws {
+    let parsedTrigger = try parseAutomationJSON(
+      trigger, as: Components.Schemas.AutomationTrigger.self, fieldName: "trigger")
+    let parsedConditions = try parseAutomationJSON(
+      conditions, as: Components.Schemas.AutomationConditionGroup.self, fieldName: "conditions")
+    let parsedActions = try parseAutomationJSON(
+      actions, as: [Components.Schemas.AutomationAction].self, fieldName: "actions")
+
+    let client = try await global.makeClient()
+    let automation = try await client.updateAutomation(
+      spaceId: spaceId,
+      automationUid: automationUid,
+      name: name,
+      trigger: parsedTrigger,
+      conditions: parsedConditions,
+      actions: parsedActions
+    )
+    try printJSON(automation)
+  }
+}
+
+// MARK: - Delete Automation
+
+struct DeleteAutomation: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "delete-automation",
+    abstract: "Delete an automation"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Space ID")
+  var spaceId: Int
+
+  @Option(name: .long, help: "Automation UID")
+  var automationUid: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    try await client.deleteAutomation(spaceId: spaceId, automationUid: automationUid)
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -75,6 +75,10 @@ struct Kaiten: AsyncParsableCommand {
       CreateLane.self,
       UpdateLane.self,
       GetCardBaselines.self,
+      ListAutomations.self,
+      CreateAutomation.self,
+      UpdateAutomation.self,
+      DeleteAutomation.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/AutomationsTests.swift
+++ b/Tests/KaitenSDKTests/AutomationsTests.swift
@@ -1,0 +1,237 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Automations")
+struct AutomationsTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// `KaitenError` is not `Equatable`, so the status code is matched by pattern.
+  private func expectUnexpectedResponse(
+    statusCode: Int,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      Issue.record(
+        "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), no error thrown",
+        sourceLocation: sourceLocation)
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == statusCode else {
+        Issue.record(
+          "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), got \(error)",
+          sourceLocation: sourceLocation)
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)", sourceLocation: sourceLocation)
+    }
+  }
+
+  // MARK: - List
+
+  @Test("200 returns array of Automation")
+  func listSuccess() async throws {
+    let json = """
+      [{
+        "id": "5355bdb2-3b52-4d2e-9162-beee750c1f47",
+        "name": "Assign on create",
+        "sort_order": 1.5,
+        "space_uid": "space-uid",
+        "updater_id": 42,
+        "status": "active",
+        "type": "on_action",
+        "trigger": {"type": "card_created", "hasToFireOnCardCreation": true, "data": {}},
+        "actions": [{"type": "add_assignee", "created": "2023-09-19T07:34:34.112Z", "data": {}}],
+        "conditions": null
+      }]
+      """
+    let client = try makeClient(.returning(statusCode: 200, body: json))
+
+    let automations = try await client.listAutomations(spaceId: 38155)
+    #expect(automations.count == 1)
+    #expect(automations[0].id == "5355bdb2-3b52-4d2e-9162-beee750c1f47")
+    #expect(automations[0].automationStatus == .active)
+    #expect(automations[0].automationType == .onAction)
+    #expect(automations[0].trigger?.triggerType == .cardCreated)
+    #expect(automations[0].actions?.first?.actionType == .addAssignee)
+  }
+
+  @Test("200 with empty body returns empty array")
+  func listEmptyBody() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: ""))
+    let automations = try await client.listAutomations(spaceId: 38155)
+    #expect(automations.isEmpty)
+  }
+
+  /// Button (`on_demand`) automations come back with `trigger` and `conditions` set to JSON null,
+  /// which the Kaiten documentation declares as non-nullable objects.
+  @Test("null trigger and conditions decode to nil")
+  func listNullTrigger() async throws {
+    let json = """
+      [{
+        "id": "uid-1",
+        "name": "Button automation",
+        "type": "on_demand",
+        "status": "broken",
+        "trigger": null,
+        "conditions": null,
+        "actions": [{"type": "complete_checklists", "data": {}}],
+        "tags": [{"id": 44771, "name": "iOS", "color": 3}],
+        "brokenLogs": [{"id": "log-1", "status": "broken"}]
+      }]
+      """
+    let client = try makeClient(.returning(statusCode: 200, body: json))
+
+    let automations = try await client.listAutomations(spaceId: 38155)
+    #expect(automations[0].trigger == nil)
+    #expect(automations[0].conditions == nil)
+    #expect(automations[0].automationType == .onDemand)
+    #expect(automations[0].tags?.first?.name == "iOS")
+    #expect(automations[0].brokenLogs?.count == 1)
+  }
+
+  /// Kaiten returns action types its documentation does not list (`change_type` is a live
+  /// example). A closed enum would fail the whole response, so undocumented values must survive
+  /// as `.unknown`.
+  @Test("undocumented discriminators decode as unknown")
+  func listUndocumentedDiscriminators() async throws {
+    let json = """
+      [{
+        "id": "uid-1",
+        "type": "on_action",
+        "status": "some_new_status",
+        "trigger": {"type": "some_new_trigger"},
+        "actions": [{"type": "change_type"}],
+        "conditions": {"clause": "xor", "conditions": []}
+      }]
+      """
+    let client = try makeClient(.returning(statusCode: 200, body: json))
+
+    let automations = try await client.listAutomations(spaceId: 38155)
+    #expect(automations[0].actions?.first?.actionType == .unknown("change_type"))
+    #expect(automations[0].trigger?.triggerType == .unknown("some_new_trigger"))
+    #expect(automations[0].automationStatus == .unknown("some_new_status"))
+    #expect(automations[0].conditions?.conditionClause == .unknown("xor"))
+    #expect(automations[0].automationType == .onAction)
+  }
+
+  @Test("404 throws notFound")
+  func listNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listAutomations(spaceId: 999)
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func listUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listAutomations(spaceId: 1)
+    }
+  }
+
+  // MARK: - Create
+
+  @Test("create sends type and actions in the body")
+  func createSendsBody() async throws {
+    let json = """
+      {"id": "new-uid", "type": "on_demand", "status": "active", "actions": []}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let automation = try await client.createAutomation(
+      spaceId: 38155,
+      type: .onDemand,
+      actions: [.init(actionType: .completeChecklists)],
+      name: "Button automation"
+    )
+
+    #expect(automation.id == "new-uid")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .post)
+    #expect(recorded.request.path == "/spaces/38155/automations")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["type"] as? String == "on_demand")
+    #expect(sent["name"] as? String == "Button automation")
+    let sentActions = try #require(sent["actions"] as? [[String: Any]])
+    #expect(sentActions.first?["type"] as? String == "complete_checklists")
+  }
+
+  @Test("402 unsupported tariff throws unexpectedResponse")
+  func createPaymentRequired() async throws {
+    let client = try makeClient(.returning(statusCode: 402))
+    await expectUnexpectedResponse(statusCode: 402) {
+      _ = try await client.createAutomation(
+        spaceId: 1, type: .onAction, actions: [.init(actionType: .addTag)])
+    }
+  }
+
+  // MARK: - Update
+
+  @Test("update targets the automation UID")
+  func updateSuccess() async throws {
+    let json = """
+      {"id": "uid-1", "name": "Renamed", "type": "on_action", "status": "disabled"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let automation = try await client.updateAutomation(
+      spaceId: 38155, automationUid: "uid-1", name: "Renamed")
+
+    #expect(automation.name == "Renamed")
+    #expect(automation.automationStatus == .disabled)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .patch)
+    #expect(recorded.request.path == "/spaces/38155/automations/uid-1")
+  }
+
+  /// Automations are addressed by string UID, which ``KaitenError/notFound(resource:id:)``
+  /// cannot represent, so a 404 surfaces as `unexpectedResponse`.
+  @Test("404 throws unexpectedResponse")
+  func updateNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await expectUnexpectedResponse(statusCode: 404) {
+      _ = try await client.updateAutomation(spaceId: 1, automationUid: "missing")
+    }
+  }
+
+  // MARK: - Delete
+
+  @Test("delete succeeds on 200 with no body")
+  func deleteSuccess() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200)
+    let client = try makeClient(transport)
+
+    try await client.deleteAutomation(spaceId: 38155, automationUid: "uid-1")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .delete)
+    #expect(recorded.request.path == "/spaces/38155/automations/uid-1")
+  }
+
+  @Test("delete 403 throws unexpectedResponse")
+  func deleteForbidden() async throws {
+    let client = try makeClient(.returning(statusCode: 403))
+    await expectUnexpectedResponse(statusCode: 403) {
+      try await client.deleteAutomation(spaceId: 1, automationUid: "uid-1")
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/OpenAPISpecIntegrityTests.swift
+++ b/Tests/KaitenSDKTests/OpenAPISpecIntegrityTests.swift
@@ -1,0 +1,184 @@
+import Foundation
+import Testing
+
+@testable import KaitenSDK
+
+/// Guards against schema patterns that `swift-openapi-generator` drops silently.
+///
+/// When a property's schema is `anyOf: [$ref, 'null']`, the generator emits no
+/// stored property for it at all. Nothing fails: the spec still declares the
+/// field, the package still builds, and every existing test still passes — the
+/// data simply never reaches callers. These tests make that failure loud.
+@Suite("OpenAPI spec integrity")
+struct OpenAPISpecIntegrityTests {
+
+  private static var specURL: URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()  // KaitenSDKTests
+      .deletingLastPathComponent()  // Tests
+      .deletingLastPathComponent()  // repository root
+      .appendingPathComponent("openapi/kaiten.yaml")
+  }
+
+  // MARK: - Structural guard
+
+  /// A property declared as `anyOf: [$ref, 'null']` anywhere in the spec.
+  private struct NullableRefProperty: CustomStringConvertible {
+    let schema: String
+    let property: String
+    let line: Int
+
+    var description: String { "\(schema).\(property) (kaiten.yaml:\(line))" }
+  }
+
+  /// Scans `components/schemas` for the pattern.
+  ///
+  /// The spec is machine-formatted with fixed indentation, so a line scan is
+  /// enough and keeps the test free of a YAML dependency:
+  ///   - `    SchemaName:`        (4 spaces)
+  ///   - `        property_name:` (8 spaces)
+  ///   - `          anyOf:`       (10 spaces)
+  private static func findNullableRefProperties() throws -> [NullableRefProperty] {
+    let source = try String(contentsOf: specURL, encoding: .utf8)
+    let lines = source.components(separatedBy: .newlines)
+
+    guard let schemasIndex = lines.firstIndex(of: "  schemas:") else {
+      Issue.record("openapi/kaiten.yaml has no components/schemas section")
+      return []
+    }
+
+    var found: [NullableRefProperty] = []
+    var currentSchema = "?"
+    var currentProperty = "?"
+
+    for index in schemasIndex..<lines.count {
+      let line = lines[index]
+
+      if line.hasPrefix("    ") && !line.hasPrefix("     ") && line.hasSuffix(":") {
+        currentSchema = line.trimmingCharacters(in: .whitespaces).dropLast().description
+        continue
+      }
+      if line.hasPrefix("        ") && !line.hasPrefix("         ") && line.hasSuffix(":") {
+        currentProperty = line.trimmingCharacters(in: .whitespaces).dropLast().description
+        continue
+      }
+      guard line.trimmingCharacters(in: .whitespaces) == "anyOf:" else { continue }
+
+      // Collect the anyOf members: subsequent lines more indented than `anyOf:`.
+      let anyOfIndent = line.prefix { $0 == " " }.count
+      var hasRef = false
+      var hasNull = false
+      var cursor = index + 1
+      while cursor < lines.count {
+        let member = lines[cursor]
+        let trimmed = member.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty {
+          cursor += 1
+          continue
+        }
+        guard member.prefix(while: { $0 == " " }).count >= anyOfIndent else { break }
+        if trimmed.hasPrefix("- $ref:") || trimmed.hasPrefix("$ref:") { hasRef = true }
+        if trimmed == "- type: 'null'" || trimmed == "type: 'null'" { hasNull = true }
+        cursor += 1
+      }
+
+      if hasRef && hasNull {
+        found.append(
+          NullableRefProperty(
+            schema: currentSchema, property: currentProperty, line: index + 1))
+      }
+    }
+    return found
+  }
+
+  @Test("no property uses anyOf: [$ref, 'null'] — the generator drops those silently")
+  func noNullableRefProperties() throws {
+    let offenders = try Self.findNullableRefProperties()
+    #expect(
+      offenders.isEmpty,
+      """
+      These properties are declared in openapi/kaiten.yaml but will NOT exist on the \
+      generated Swift types — swift-openapi-generator drops `anyOf: [$ref, 'null']` \
+      without any diagnostic:
+
+      \(offenders.map { "  - \($0)" }.joined(separator: "\n"))
+
+      Use a plain `$ref` instead. The property is optional, so the synthesized decoder \
+      already maps an explicit JSON `null` to `nil`.
+      """)
+  }
+
+  // MARK: - Behavioural guard
+
+  /// Every property the spec declares must survive a decode/encode round trip.
+  ///
+  /// If the generator dropped a property, the decoder ignores that key on the way in
+  /// and the encoder omits it on the way out — so a round trip is enough to catch it
+  /// without referencing a member that may not compile.
+  private func assertRoundTrips<T: Codable & Sendable>(
+    _ json: String,
+    as type: T.Type,
+    expecting keys: [String],
+    sourceLocation: SourceLocation = #_sourceLocation
+  ) throws {
+    let decoded = try JSONDecoder().decode(T.self, from: Data(json.utf8))
+    let reencoded = try JSONEncoder().encode(decoded)
+    let object =
+      try JSONSerialization.jsonObject(with: reencoded) as? [String: Any] ?? [:]
+
+    let missing = keys.filter { object[$0] == nil }
+    #expect(
+      missing.isEmpty,
+      """
+      \(T.self) lost \(missing.count) property/properties declared in openapi/kaiten.yaml: \
+      \(missing.joined(separator: ", ")). They are almost certainly declared as \
+      `anyOf: [$ref, 'null']`, which swift-openapi-generator drops silently.
+      """,
+      sourceLocation: sourceLocation)
+  }
+
+  @Test("CardBlocker keeps its nested card and user objects")
+  func cardBlockerKeepsNestedObjects() throws {
+    let json = """
+      {
+        "id": 1,
+        "reason": "Waiting for design",
+        "card_id": 42,
+        "released": false,
+        "blocked_card": {"id": 7, "title": "Blocked card"},
+        "card": {"id": 8, "title": "Blocking card"},
+        "blocker": {"id": 9, "full_name": "Ann"}
+      }
+      """
+    try assertRoundTrips(
+      json,
+      as: Components.Schemas.CardBlocker.self,
+      expecting: ["blocked_card", "card", "blocker"])
+
+    // Referencing the properties directly turns a regression into a compile error,
+    // which is louder than a failing assertion.
+    let blocker = try JSONDecoder().decode(
+      Components.Schemas.CardBlocker.self, from: Data(json.utf8))
+    #expect(blocker.blocked_card?.title == "Blocked card")
+    #expect(blocker.card?.title == "Blocking card")
+    #expect(blocker.blocker?.full_name == "Ann")
+  }
+
+  @Test("Automation keeps its trigger and conditions objects")
+  func automationKeepsNestedObjects() throws {
+    let json = """
+      {
+        "id": "uid-1",
+        "type": "on_action",
+        "status": "active",
+        "trigger": {"type": "card_created", "hasToFireOnCardCreation": true},
+        "conditions": {"clause": "and", "conditions": []},
+        "actions": [{"type": "add_tag"}]
+      }
+      """
+    try assertRoundTrips(
+      json,
+      as: Components.Schemas.Automation.self,
+      expecting: ["trigger", "conditions", "actions"])
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -4528,20 +4528,19 @@ components:
         updated:
           type: string
           description: Last update timestamp
+        # NOTE: these three are nullable, but expressed as plain $refs rather than
+        # `anyOf: [$ref, 'null']` — swift-openapi-generator silently drops properties using
+        # that pattern, so the fields never reached callers at all. The properties are
+        # optional, and the synthesized decoder maps an explicit JSON `null` to `nil`.
+        # Guarded by Tests/KaitenSDKTests/OpenAPISpecIntegrityTests.swift.
         blocked_card:
-          anyOf:
-          - $ref: '#/components/schemas/Card'
-          - type: 'null'
+          $ref: '#/components/schemas/Card'
           description: Blocked card info
         card:
-          anyOf:
-          - $ref: '#/components/schemas/Card'
-          - type: 'null'
+          $ref: '#/components/schemas/Card'
           description: Blocking card info
         blocker:
-          anyOf:
-          - $ref: '#/components/schemas/User'
-          - type: 'null'
+          $ref: '#/components/schemas/User'
           description: Info of user who blocked card
     CreateCardBlockerRequest:
       type: object
@@ -5091,7 +5090,7 @@ components:
     AutomationAction:
       type: object
       properties:
-        # DOC_MISMATCH: docs=`enum` (25 values), actual=`string`; observed undocumented value: "change_type" — https://developers.kaiten.ru/automations/get-list-of-automations
+        # DOC_MISMATCH: docs=`enum` (25 values), actual=`string`; observed undocumented values: "change_type", "add_template_checklists" — https://developers.kaiten.ru/automations/get-list-of-automations
         type:
           type: string
           description: 'Action type. Documented values: add_assignee, remove_assignee, add_card_users, remove_card_users, add_user_groups, add_tag, remove_tags, add_property, property_add_to_child_card, add_size, add_timeline, change_asap, add_due_date, remove_due_date, move_to_path, move_on_board, archive, add_child_card, add_parent_card, connect_parent_card, complete_checklists, sort_cards, add_comment, card_add_sla, card_remove_sla. Map to the AutomationActionType Swift enum, which preserves unknown values.'

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -2215,6 +2215,130 @@ paths:
           description: Invalid token
         '403':
           description: Forbidden
+  /spaces/{space_id}/automations:
+    get:
+      summary: Get list of automations
+      operationId: list_automations
+      parameters:
+      - name: space_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Space ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Automation'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    post:
+      summary: Create automation
+      operationId: create_automation
+      parameters:
+      - name: space_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Space ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAutomationRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Automation'
+        '400':
+          description: Bad request
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+  /spaces/{space_id}/automations/{automation_uid}:
+    patch:
+      summary: Update automation
+      operationId: update_automation
+      parameters:
+      - name: space_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Space ID
+      - name: automation_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Automation UID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateAutomationRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Automation'
+        '400':
+          description: Bad request
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    delete:
+      summary: Delete automation
+      operationId: delete_automation
+      parameters:
+      - name: space_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Space ID
+      - name: automation_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Automation UID
+      responses:
+        '200':
+          description: success
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
 components:
   securitySchemes:
     bearerAuth:
@@ -4879,3 +5003,163 @@ components:
           - string
           - 'null'
           description: Baseline end time
+    Automation:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Automation uid
+        name:
+          type:
+          - string
+          - 'null'
+          description: Automation name
+        sort_order:
+          type: number
+          description: Automation sort order
+        space_uid:
+          type: string
+          description: Space uid
+        updater_id:
+          type: integer
+          description: User id, who created automation
+        # DOC_MISMATCH: docs=`enum` without `on_demand`, actual includes `on_demand` (button automations) — https://developers.kaiten.ru/automations/get-list-of-automations
+        # DOC_MISMATCH: docs=`enum` (active, disabled, removed, broken), actual=`string` — Kaiten returns undocumented values, so a closed enum breaks decoding — https://developers.kaiten.ru/automations/get-list-of-automations
+        status:
+          type: string
+          description: 'Automation status. Documented values: active, disabled, removed, broken. Map to the AutomationStatus Swift enum, which preserves unknown values.'
+        # DOC_MISMATCH: docs=`enum` without `on_demand`, actual=`string` including `on_demand` (button automations) — https://developers.kaiten.ru/automations/get-list-of-automations
+        type:
+          type: string
+          description: 'Automation type. Documented values: on_action (event), on_date (due date), on_demand (button). Map to the AutomationType Swift enum, which preserves unknown values.'
+        # DOC_MISMATCH: docs=non-nullable `object`, actual=`object | null` (button automations have no trigger) — https://developers.kaiten.ru/automations/get-list-of-automations
+        # NOTE: expressed as a plain $ref rather than `anyOf: [$ref, 'null']` — swift-openapi-generator
+        # silently drops properties using that pattern. The property is optional, and the synthesized
+        # decoder maps an explicit JSON `null` to `nil`.
+        trigger:
+          $ref: '#/components/schemas/AutomationTrigger'
+          description: Automation trigger data
+        actions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AutomationAction'
+          description: Automation actions
+        # DOC_MISMATCH: docs=non-nullable `object`, actual=`object | null` — https://developers.kaiten.ru/automations/get-list-of-automations
+        # NOTE: see the comment on `trigger` above for why this is a plain $ref.
+        conditions:
+          $ref: '#/components/schemas/AutomationConditionGroup'
+          description: Automation conditions
+        # DOC_MISMATCH: docs=`integer`, absent from actual API responses — https://developers.kaiten.ru/automations/get-list-of-automations
+        company_id:
+          type: integer
+          description: Company id
+        # DOC_MISMATCH: docs=`string`, absent from actual API responses — https://developers.kaiten.ru/automations/get-list-of-automations
+        created:
+          type: string
+          description: Created timestamp
+        # DOC_MISMATCH: docs=`string`, absent from actual API responses — https://developers.kaiten.ru/automations/get-list-of-automations
+        updated:
+          type: string
+          description: Updated timestamp
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/automations/get-list-of-automations
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/Tag'
+          description: Tags referenced by the automation
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/automations/get-list-of-automations
+        brokenLogs:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+          description: Diagnostic entries for automations in the `broken` status
+    AutomationTrigger:
+      type: object
+      properties:
+        # DOC_MISMATCH: docs=`enum` (21 values), actual=`string` — Kaiten returns undocumented trigger types, so a closed enum breaks decoding — https://developers.kaiten.ru/automations/get-list-of-automations
+        type:
+          type: string
+          description: 'Trigger type. Documented values: card_moved_in_path, card_created, comment_posted, card_user_added, responsible_added, card_type_changed, card_state_changed, custom_property_changed, due_date_changed, checklist_item_checked, checklists_completed, child_cards_state_changed, tag_added, tag_removed, blocked, unblocked, blocker_added, due_date_on_date, checklist_item_due_date_on_date, custom_property_date_on_date, all_conditions_met. Map to the AutomationTriggerType Swift enum, which preserves unknown values.'
+        hasToFireOnCardCreation:
+          type: boolean
+          description: Should it fire on card creation
+        data:
+          type: object
+          additionalProperties: true
+          description: Trigger data. Shape depends on the trigger type and is not described in the Kaiten documentation
+    AutomationAction:
+      type: object
+      properties:
+        # DOC_MISMATCH: docs=`enum` (25 values), actual=`string`; observed undocumented value: "change_type" — https://developers.kaiten.ru/automations/get-list-of-automations
+        type:
+          type: string
+          description: 'Action type. Documented values: add_assignee, remove_assignee, add_card_users, remove_card_users, add_user_groups, add_tag, remove_tags, add_property, property_add_to_child_card, add_size, add_timeline, change_asap, add_due_date, remove_due_date, move_to_path, move_on_board, archive, add_child_card, add_parent_card, connect_parent_card, complete_checklists, sort_cards, add_comment, card_add_sla, card_remove_sla. Map to the AutomationActionType Swift enum, which preserves unknown values.'
+        created:
+          type: string
+          description: Action create timestamp
+        data:
+          type: object
+          additionalProperties: true
+          description: Action data. Shape depends on the action type and is not described in the Kaiten documentation
+    AutomationConditionGroup:
+      type: object
+      properties:
+        clause:
+          type: string
+          description: 'Condition clause. Documented values: and, or. Map to the AutomationConditionClause Swift enum, which preserves unknown values.'
+        created:
+          type: string
+          description: Condition created timestamp. ISO 8601 format
+        conditions:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+          description: Array of condition groups. Shape depends on the trigger type and is not described in the Kaiten documentation
+    CreateAutomationRequest:
+      type: object
+      required:
+      - type
+      - actions
+      properties:
+        name:
+          type: string
+          maxLength: 256
+          description: Automation name. Required for `on_demand` automations
+        type:
+          type: string
+          description: 'Automation type. Documented values: on_action, on_date, on_demand.'
+        trigger:
+          $ref: '#/components/schemas/AutomationTrigger'
+          description: Automation trigger. Required for `on_action` and `on_date` automations
+        conditions:
+          $ref: '#/components/schemas/AutomationConditionGroup'
+          description: Automation conditions
+        actions:
+          type: array
+          minItems: 1
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/AutomationAction'
+          description: Automation actions
+    UpdateAutomationRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 256
+          description: Automation name
+        trigger:
+          $ref: '#/components/schemas/AutomationTrigger'
+          description: Automation trigger
+        conditions:
+          $ref: '#/components/schemas/AutomationConditionGroup'
+          description: Automation conditions
+        actions:
+          type: array
+          minItems: 1
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/AutomationAction'
+          description: Automation actions

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -17,6 +17,7 @@
 enum ErrorCase: String {
   case badRequest
   case unauthorized
+  case paymentRequired
   case forbidden
   case notFound
 }
@@ -24,6 +25,15 @@ enum ErrorCase: String {
 struct Operation {
   let name: String
   let errors: [ErrorCase]
+  /// Whether the `200` response carries a body. Operations documented as
+  /// returning no content map to `ResponseCase<Void>`.
+  let hasBody: Bool
+
+  init(name: String, errors: [ErrorCase], hasBody: Bool = true) {
+    self.name = name
+    self.errors = errors
+    self.hasBody = hasBody
+  }
 }
 
 struct Section {
@@ -138,17 +148,28 @@ let sections: [Section] = [
   Section(mark: "Card Baselines", operations: [
     Operation(name: "get_card_baselines", errors: [.unauthorized, .forbidden]),
   ]),
+  Section(mark: "Automations", operations: [
+    Operation(name: "list_automations", errors: [.unauthorized, .forbidden, .notFound]),
+    Operation(
+      name: "create_automation",
+      errors: [.badRequest, .unauthorized, .paymentRequired, .forbidden, .notFound]),
+    Operation(
+      name: "update_automation",
+      errors: [.badRequest, .unauthorized, .paymentRequired, .forbidden, .notFound]),
+    Operation(
+      name: "delete_automation", errors: [.unauthorized, .forbidden, .notFound], hasBody: false),
+  ]),
 ]
 
 // MARK: - Generator
 
 func generateExtension(_ op: Operation) -> String {
   let typeName = "Operations.\(op.name).Output"
-  let returnType = "KaitenClient.ResponseCase<\(typeName).Ok.Body>"
+  let returnType = "KaitenClient.ResponseCase<\(op.hasBody ? "\(typeName).Ok.Body" : "Void")>"
 
   // Build switch cases
   var cases: [String] = []
-  cases.append("    case .ok(let ok): .ok(ok.body)")
+  cases.append(op.hasBody ? "    case .ok(let ok): .ok(ok.body)" : "    case .ok: .ok(())")
 
   for error in op.errors {
     switch error {
@@ -156,6 +177,8 @@ func generateExtension(_ op: Operation) -> String {
       cases.append("    case .badRequest: .undocumented(statusCode: 400)")
     case .unauthorized:
       cases.append("    case .unauthorized: .unauthorized")
+    case .paymentRequired:
+      cases.append("    case .code402: .undocumented(statusCode: 402)")
     case .forbidden:
       cases.append("    case .forbidden: .forbidden")
     case .notFound:

--- a/scripts/kaiten-docs/parse-schemas.js
+++ b/scripts/kaiten-docs/parse-schemas.js
@@ -11,16 +11,22 @@ if (!url) {
   try {
     const schemas = await withPage(url, async page => {
       const results = [];
-      const buttons = await page.$$("button.MuiButton-root");
+      // Schema triggers render as either <button> or <a>, and their label is
+      // uppercased by CSS — match case-insensitively on both tags.
+      const buttons = await page.$$("button.MuiButton-root, a.MuiButton-root");
       const schemaButtons = [];
 
       for (const button of buttons) {
         const text = ((await button.textContent()) || "").trim();
-        if (text === "Schema") schemaButtons.push(button);
+        if (/^schema$/i.test(text)) schemaButtons.push(button);
       }
 
       for (const button of schemaButtons) {
-        const fieldContext = await button.evaluate(el => el.closest("tr")?.textContent || "unknown");
+        // The row's full textContent can contain serialized markup; the first
+        // cell holds the field name on its own.
+        const fieldContext = await button.evaluate(
+          el => el.closest("tr")?.querySelector("td")?.textContent || "unknown"
+        );
         try {
           await button.click({ timeout: 3000 });
           await page.waitForTimeout(700);

--- a/specs/001-kaiten-sdk-core/spec.md
+++ b/specs/001-kaiten-sdk-core/spec.md
@@ -130,6 +130,10 @@ A developer requests all spaces and boards — for navigation.
 - **FR-017**: SDK initialization MUST validate that `baseURL` is an absolute HTTPS URL with a non-empty host component.
 - **FR-018**: SDK response mapping MUST preserve documented client error classes. HTTP 400 responses MUST map to a dedicated typed error case and MUST NOT be downgraded to generic unexpected/undocumented errors.
 - **FR-019**: SDK methods exposing `limit`/`offset` for users, card types, and sprints MUST enforce documented endpoint caps locally with typed validation errors before network calls.
+- **FR-020**: SDK MUST expose space automations (list, create, update, delete). Nested `data` payloads of triggers and actions MUST stay free-form JSON objects — the documentation does not describe those fields, and reverse-engineering them from live responses is forbidden by FR-009.
+- **FR-020a**: Automation discriminators (`type`, `status`, `clause`) MUST be declared as plain `string` in the OpenAPI spec, not as closed enums. Kaiten returns values its documentation does not list (confirmed live: action type `change_type`), and a generated closed enum fails the entire response instead of the single field. The typed surface MUST instead be hand-written enums in `Enums.swift` with an `unknown(String)` case, per the forward-compatibility rule those enums already follow.
+- **FR-021**: For resources addressed by a string UID rather than an integer id (currently automations), a HTTP 404 MUST surface as `unexpectedResponse(statusCode: 404)`. `notFound(resource:id:)` carries an `Int` id and MUST NOT be populated with an unrelated identifier (for example the parent space id) to fake specificity.
+- **FR-022**: Endpoints documented as returning HTTP 200 with no response body (currently `delete_automation`) MUST map to a `Void`-returning SDK method. The SDK MUST NOT invent a response payload for them.
 
 ### Non-Functional Requirements
 
@@ -153,6 +157,7 @@ A developer requests all spaces and boards — for navigation.
 - **Member**: id, userId, fullName, role
 - **CustomProperty**: id, name, type, value (typed: string, number, select, multiselect, date, user)
 - **CustomPropertySelectValue**: id, customPropertyId, value, color, condition, sortOrder, externalId, updated, created, authorId, companyId
+- **Automation**: id (string UID), name, type (`on_action` / `on_date` / `on_demand`), status (`active` / `disabled` / `removed` / `broken`), spaceUid, sortOrder, updaterId, trigger, actions, conditions
 
 ### User Story 7a — List and Get Custom Property Select Values (Priority: P2)
 

--- a/specs/002-kaiten-cli/spec.md
+++ b/specs/002-kaiten-cli/spec.md
@@ -211,6 +211,10 @@ stdout confirms it works.
   MUST NOT carry worked examples or the evidence behind a stated limit —
   none of that is this CLI's behaviour to document. Properties shared by
   every response belong once in the root command's discussion.
+- **FR-024**: Options carrying structured JSON (currently automation `--trigger`,
+  `--conditions` and `--actions`) MUST be decoded and validated locally before the
+  SDK call. Malformed JSON MUST produce a validation error naming the offending
+  option; silently forwarding or dropping the value is forbidden.
 
 ### Non-Functional Requirements
 


### PR DESCRIPTION
Adds space automations support end to end, plus a generator-integrity guard.

- `openapi/kaiten.yaml`: automations paths and schemas
- `KaitenClient+Automations.swift`: SDK surface with DocC comments
- CLI: `AutomationCommands.swift`, registered in `Kaiten.swift`
- `OpenAPISpecIntegrityTests`: fails the build on `anyOf: [$ref, 'null']` (swift-openapi-generator silently drops such properties) and asserts every declared property survives a decode/encode round trip

This PR is a prerequisite for the endpoint-coverage issues #412–#456: they all rely on the integrity guard and the nullable-`$ref` fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)