### PR TITLE
feat(card-service-desk-external-recipients): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,13 @@ Quote the `?` — unquoted it is a shell glob and never reaches the CLI.
 | `updateExternalLink(...)` | Update an external link |
 | `removeExternalLink(...)` | Remove an external link |
 
+### Service Desk External Recipients
+
+| Method | Description |
+|--------|-------------|
+| `addServiceDeskExternalRecipient(cardId:email:)` | Add an external recipient to a card's service desk request |
+| `removeServiceDeskExternalRecipient(cardId:email:)` | Remove an external recipient from a card's service desk request |
+
 ### Spaces
 
 | Method | Description |

--- a/Sources/KaitenSDK/KaitenClient+CardServiceDeskExternalRecipients.swift
+++ b/Sources/KaitenSDK/KaitenClient+CardServiceDeskExternalRecipients.swift
@@ -1,0 +1,55 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - Service Desk External Recipients
+
+extension KaitenClient {
+  /// Adds an external recipient to a card's service desk request.
+  ///
+  /// - Parameters:
+  ///   - cardId: The card identifier.
+  ///   - email: The recipient email. Kaiten accepts 1 to 128 characters.
+  /// - Returns: The added recipient.
+  /// - Throws:
+  ///   - ``KaitenError/notFound(resource:id:)`` if the card does not exist.
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for validation errors (400),
+  ///     unsupported tariff (402), forbidden (403) or other undocumented HTTP status codes.
+  public func addServiceDeskExternalRecipient(cardId: Int, email: String)
+    async throws(KaitenError) -> Components.Schemas.ServiceDeskExternalRecipient
+  {
+    let response = try await call {
+      try await client.add_sd_external_recipient(
+        path: .init(card_id: cardId),
+        body: .json(.init(email: email))
+      )
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) { try $0.json }
+  }
+
+  /// Removes an external recipient from a card's service desk request.
+  ///
+  /// - Parameters:
+  ///   - cardId: The card identifier.
+  ///   - email: The recipient email.
+  /// - Returns: The removed recipient.
+  /// - Throws:
+  ///   - ``KaitenError/notFound(resource:id:)`` if the card does not exist.
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for validation errors (400),
+  ///     forbidden (403) or other undocumented HTTP status codes.
+  public func removeServiceDeskExternalRecipient(cardId: Int, email: String)
+    async throws(KaitenError) -> Components.Schemas.ServiceDeskExternalRecipient
+  {
+    let response = try await call {
+      try await client.remove_sd_external_recipient(
+        path: .init(card_id: cardId, email: email)
+      )
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) { try $0.json }
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -886,3 +886,33 @@ extension Operations.delete_automation.Output {
     }
   }
 }
+
+// MARK: - Service Desk External Recipients
+
+extension Operations.add_sd_external_recipient.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.add_sd_external_recipient.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.remove_sd_external_recipient.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.remove_sd_external_recipient.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/CardServiceDeskExternalRecipients/CardServiceDeskExternalRecipientCommands.swift
+++ b/Sources/kaiten/CardServiceDeskExternalRecipients/CardServiceDeskExternalRecipientCommands.swift
@@ -1,0 +1,50 @@
+import ArgumentParser
+import Foundation
+import KaitenSDK
+
+// MARK: - Add Service Desk External Recipient
+
+struct AddServiceDeskExternalRecipient: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "add-sd-external-recipient",
+    abstract: "Add an external recipient to a card's service desk request"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Recipient email")
+  var email: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let recipient = try await client.addServiceDeskExternalRecipient(cardId: cardId, email: email)
+    try printJSON(recipient, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Remove Service Desk External Recipient
+
+struct RemoveServiceDeskExternalRecipient: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "remove-sd-external-recipient",
+    abstract: "Remove an external recipient from a card's service desk request"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Recipient email")
+  var email: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let recipient = try await client.removeServiceDeskExternalRecipient(
+      cardId: cardId, email: email)
+    try printJSON(recipient, expand: global.expandedFields)
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -80,6 +80,8 @@ struct Kaiten: AsyncParsableCommand {
       CreateAutomation.self,
       UpdateAutomation.self,
       DeleteAutomation.self,
+      AddServiceDeskExternalRecipient.self,
+      RemoveServiceDeskExternalRecipient.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/AddServiceDeskExternalRecipientTests.swift
+++ b/Tests/KaitenSDKTests/AddServiceDeskExternalRecipientTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("AddServiceDeskExternalRecipient")
+struct AddServiceDeskExternalRecipientTests {
+
+  @Test("200 returns ServiceDeskExternalRecipient")
+  func success() async throws {
+    // Based on the documentation example response for POST /cards/{card_id}/sd-external-recipients.
+    let json = """
+      {"created": "2023-01-23T13:56:24.078Z", "updated": "2023-01-23T13:56:24.078Z", "card_id": 42, "user_id": null, "email": "recipient@example.com", "unsubscribed": false, "updater_id": 7}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let recipient = try await client.addServiceDeskExternalRecipient(
+      cardId: 42, email: "recipient@example.com")
+    #expect(recipient.card_id == 42)
+    #expect(recipient.user_id == nil)
+    #expect(recipient.email == "recipient@example.com")
+    #expect(recipient.unsubscribed == false)
+    #expect(recipient.updater_id == 7)
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.addServiceDeskExternalRecipient(
+        cardId: 999, email: "recipient@example.com")
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.addServiceDeskExternalRecipient(
+        cardId: 1, email: "recipient@example.com")
+    }
+  }
+}

--- a/Tests/KaitenSDKTests/RemoveServiceDeskExternalRecipientTests.swift
+++ b/Tests/KaitenSDKTests/RemoveServiceDeskExternalRecipientTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("RemoveServiceDeskExternalRecipient")
+struct RemoveServiceDeskExternalRecipientTests {
+
+  @Test("200 returns ServiceDeskExternalRecipient")
+  func success() async throws {
+    // Based on the documentation example response for
+    // DELETE /cards/{card_id}/sd-external-recipients/{email}.
+    let json = """
+      {"created": "2023-01-23T16:16:08.643Z", "updated": "2023-01-23T16:16:08.643Z", "card_id": 42, "user_id": null, "email": "recipient@example.com", "unsubscribed": false, "updater_id": 7, "company_id": 3}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    let recipient = try await client.removeServiceDeskExternalRecipient(
+      cardId: 42, email: "recipient@example.com")
+    #expect(recipient.card_id == 42)
+    #expect(recipient.user_id == nil)
+    #expect(recipient.email == "recipient@example.com")
+    #expect(recipient.unsubscribed == false)
+    #expect(recipient.updater_id == 7)
+    #expect(recipient.company_id == 3)
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.removeServiceDeskExternalRecipient(
+        cardId: 999, email: "recipient@example.com")
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.removeServiceDeskExternalRecipient(
+        cardId: 1, email: "recipient@example.com")
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -1806,6 +1806,72 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /cards/{card_id}/sd-external-recipients:
+    post:
+      summary: Add new service desk external recipient
+      operationId: add_sd_external_recipient
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddServiceDeskExternalRecipientRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceDeskExternalRecipient'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+  /cards/{card_id}/sd-external-recipients/{email}:
+    delete:
+      summary: Remove service desk external recipient
+      operationId: remove_sd_external_recipient
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      - name: email
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Email
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceDeskExternalRecipient'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
   /card-types:
     get:
       summary: List card types
@@ -4526,6 +4592,45 @@ components:
         id:
           type: integer
           description: Deleted external link ID
+    ServiceDeskExternalRecipient:
+      type: object
+      properties:
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        card_id:
+          type: integer
+          description: Card id
+        user_id:
+          type:
+          - integer
+          - 'null'
+          description: Recipient id
+        email:
+          type: string
+          description: Recipient email
+        unsubscribed:
+          type: boolean
+          description: Is unsubscribed from service desk request
+        updater_id:
+          type: integer
+          description: Updater id
+        company_id:
+          type: integer
+          description: Company id. Documented only in the remove-recipient response.
+    AddServiceDeskExternalRecipientRequest:
+      type: object
+      required:
+      - email
+      properties:
+        email:
+          type: string
+          description: Recipient email
+          minLength: 1
+          maxLength: 128
     CardBlocker:
       type: object
       properties:

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -74,6 +74,8 @@ let sections: [Section] = [
     Operation(name: "get_list_of_properties", errors: [.unauthorized, .forbidden]),
     Operation(name: "get_property", errors: [.unauthorized, .forbidden, .notFound]),
     Operation(name: "get_list_of_select_values", errors: [.unauthorized, .forbidden, .notFound]),
+    Operation(
+      name: "create_select_value", errors: [.badRequest, .unauthorized, .forbidden, .notFound]),
     Operation(name: "get_select_value", errors: [.unauthorized, .forbidden, .notFound]),
   ]),
   Section(mark: "Boards", operations: [
@@ -158,6 +160,14 @@ let sections: [Section] = [
       errors: [.badRequest, .unauthorized, .paymentRequired, .forbidden, .notFound]),
     Operation(
       name: "delete_automation", errors: [.unauthorized, .forbidden, .notFound], hasBody: false),
+  ]),
+  Section(mark: "Service Desk External Recipients", operations: [
+    Operation(
+      name: "add_sd_external_recipient",
+      errors: [.badRequest, .unauthorized, .paymentRequired, .forbidden, .notFound]),
+    Operation(
+      name: "remove_sd_external_recipient",
+      errors: [.badRequest, .unauthorized, .forbidden, .notFound]),
   ]),
 ]
 


### PR DESCRIPTION
## Endpoints

- [x] `POST /cards/{card_id}/sd-external-recipients` — Add new recipient ([docs](https://developers.kaiten.ru/card-service-desk-external-recipients/add-new-recipient))
- [x] `DELETE /cards/{card_id}/sd-external-recipients/{email}` — Remove recipient ([docs](https://developers.kaiten.ru/card-service-desk-external-recipients/remove-recipient))

## What was verified how

Both endpoints are mutating (POST/DELETE), and this resource has no GET endpoint, so no live requests were made against the production instance. Schemas were built strictly from the official documentation (path parameters, body attributes with constraints, and response attributes including nullability), and test fixtures are based on the documented example responses.

The two documented 200 responses share the same shape except `company_id`, which the docs list only for the remove-recipient response; the shared `ServiceDeskExternalRecipient` schema keeps it optional and notes that.

## DOC_MISMATCH annotations

None — docs-only implementation, no live divergence observed.

## Also included

`scripts/generate-response-mapping.swift` was missing the `create_select_value` operation that the committed `ResponseMapping.swift` already contained, so any regeneration silently dropped it and broke the build. The generator config is re-synced in this PR.

## Checklist

- [x] `openapi/kaiten.yaml` paths and schemas
- [x] `Sources/KaitenSDK/KaitenClient+CardServiceDeskExternalRecipients.swift` with DocC comments
- [x] `Sources/kaiten/CardServiceDeskExternalRecipients/CardServiceDeskExternalRecipientCommands.swift`, registered in `Kaiten.swift`
- [x] README "API Reference" table updated
- [x] Tests: one 200 fixture test per endpoint plus 401/404 error paths
- [x] `swift format lint --strict` clean; `swift test` green (319 tests)

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)
