### PR TITLE
feat(card-sla): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,15 @@ let created = try await client.createAutomation(
 CLI: `list-blocker-categories`, `add-blocker-category --blocker-id <id> --name <name>`,
 `remove-blocker-category --blocker-id <id> --category-uid <uid>`.
 
+### Card SLA
+
+| Method | Description |
+|--------|-------------|
+| `getCardSlaMeasurements(cardId:)` | Get card SLA measurements |
+
+SLA measurements exist only for service desk request cards; for any other card,
+and for archived cards, the API answers HTTP 400.
+
 ## Pagination
 
 Most list endpoints accept `offset` and `limit` parameters and return a `Page<T>`:

--- a/Sources/KaitenSDK/KaitenClient+CardSla.swift
+++ b/Sources/KaitenSDK/KaitenClient+CardSla.swift
@@ -1,0 +1,33 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - Card SLA
+
+extension KaitenClient {
+  /// Retrieves SLA rule timing metrics for a card.
+  ///
+  /// Kaiten computes SLA measurements only for service desk request cards; for any other
+  /// card, and for archived cards, the API answers HTTP 400, which surfaces as
+  /// ``KaitenError/unexpectedResponse(statusCode:body:)``.
+  ///
+  /// - Parameter cardId: The card identifier.
+  /// - Returns: The card's SLA measurements: the calendars used for the calculations and
+  ///   the per-rule timing data. Both collections are empty when no SLA rules apply to the card.
+  /// - Throws:
+  ///   - ``KaitenError/notFound(resource:id:)`` if the card does not exist.
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for bad request (400), forbidden
+  ///     (403) or other undocumented HTTP status codes.
+  public func getCardSlaMeasurements(
+    cardId: Int
+  ) async throws(KaitenError) -> Components.Schemas.CardSlaMeasurements {
+    let response = try await call {
+      try await client.get_card_sla_measurements(path: .init(card_id: cardId))
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) {
+      try $0.json
+    }
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -833,6 +833,21 @@ extension Operations.get_card_baselines.Output {
   }
 }
 
+// MARK: - Card SLA
+
+extension Operations.get_card_sla_measurements.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_card_sla_measurements.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
 // MARK: - Automations
 
 extension Operations.list_automations.Output {

--- a/Sources/kaiten/CardSla/CardSlaCommands.swift
+++ b/Sources/kaiten/CardSla/CardSlaCommands.swift
@@ -1,0 +1,24 @@
+import ArgumentParser
+import KaitenSDK
+
+struct GetCardSlaMeasurements: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "get-card-sla-measurements",
+    abstract: "Get card SLA measurements",
+    discussion: """
+      The API computes SLA measurements only for service desk request cards; any other card, \
+      and any archived card, is answered with HTTP 400.
+      """
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let measurements = try await client.getCardSlaMeasurements(cardId: cardId)
+    try printJSON(measurements, expand: global.expandedFields)
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -85,6 +85,7 @@ struct Kaiten: AsyncParsableCommand {
       ListBlockerCategories.self,
       AddBlockerCategory.self,
       RemoveBlockerCategory.self,
+      GetCardSlaMeasurements.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/CardSlaTests.swift
+++ b/Tests/KaitenSDKTests/CardSlaTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Card SLA")
+struct CardSlaTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// Live responses on the verification instance carry empty arrays (no SLA rules are
+  /// configured there), so the populated item shapes come from the documentation.
+  @Test("200 returns measurements with calendars and rule time data")
+  func success() async throws {
+    let json = """
+      {
+        "calendars": [{
+          "id": "cal-1",
+          "timezone": "Europe/Moscow",
+          "holidays": [{
+            "created": "2024-01-01T00:00:00.000Z",
+            "updated": "2024-01-01T00:00:00.000Z",
+            "id": "hol-1",
+            "calendar_id": "cal-1",
+            "day": 1,
+            "month": 1,
+            "year": null,
+            "description": "New Year"
+          }],
+          "work_days": [{
+            "created": "2024-01-01T00:00:00.000Z",
+            "updated": "2024-01-01T00:00:00.000Z",
+            "id": "wd-1",
+            "calendar_id": "cal-1",
+            "day": 1,
+            "date": null,
+            "period_start": 9,
+            "period_finish": 18
+          }]
+        }],
+        "rulesTimeData": [{
+          "rule_id": "rule-1",
+          "card_id": 123,
+          "actual_time": 3600,
+          "started": true,
+          "completed": false,
+          "last_calculated_at": "2024-02-01T12:00:00.000Z",
+          "is_last_calculated_at_work_time": true
+        }]
+      }
+      """
+    let client = try makeClient(.returning(statusCode: 200, body: json))
+
+    let measurements = try await client.getCardSlaMeasurements(cardId: 123)
+    #expect(measurements.calendars?.count == 1)
+    #expect(measurements.calendars?.first?.id == "cal-1")
+    #expect(measurements.calendars?.first?.timezone == "Europe/Moscow")
+    #expect(measurements.calendars?.first?.holidays?.first?.year == nil)
+    #expect(measurements.calendars?.first?.holidays?.first?.description == "New Year")
+    #expect(measurements.calendars?.first?.work_days?.first?.period_finish == 18)
+    #expect(measurements.rulesTimeData?.count == 1)
+    #expect(measurements.rulesTimeData?.first?.rule_id == "rule-1")
+    #expect(measurements.rulesTimeData?.first?.actual_time == 3600)
+    #expect(measurements.rulesTimeData?.first?.started == true)
+    #expect(measurements.rulesTimeData?.first?.completed == false)
+  }
+
+  /// Sanitized live response: a service desk card with no SLA rules answers with both
+  /// collections empty.
+  @Test("200 with empty collections parses")
+  func emptyCollections() async throws {
+    let json = """
+      {"calendars":[],"rulesTimeData":[]}
+      """
+    let client = try makeClient(.returning(statusCode: 200, body: json))
+
+    let measurements = try await client.getCardSlaMeasurements(cardId: 123)
+    #expect(measurements.calendars?.isEmpty == true)
+    #expect(measurements.rulesTimeData?.isEmpty == true)
+  }
+
+  /// Confirmed live: non service desk cards and archived cards answer HTTP 400,
+  /// which the docs do not list.
+  @Test("400 throws unexpectedResponse")
+  func badRequest() async throws {
+    let client = try makeClient(.returning(statusCode: 400))
+    do {
+      _ = try await client.getCardSlaMeasurements(cardId: 123)
+      Issue.record("expected KaitenError.unexpectedResponse(statusCode: 400), no error thrown")
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == 400 else {
+        Issue.record("expected KaitenError.unexpectedResponse(statusCode: 400), got \(error)")
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)")
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.getCardSlaMeasurements(cardId: 123)
+    }
+  }
+
+  @Test("404 throws notFound for the card")
+  func notFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    do {
+      _ = try await client.getCardSlaMeasurements(cardId: 999)
+      Issue.record("expected KaitenError.notFound, no error thrown")
+    } catch let error as KaitenError {
+      guard case .notFound(let resource, let id) = error, resource == "card", id == 999 else {
+        Issue.record("expected KaitenError.notFound(resource: card, id: 999), got \(error)")
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)")
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -2312,6 +2312,34 @@ paths:
           description: Invalid token
         '403':
           description: Forbidden
+  /cards/{card_id}/sla-rules-measurements:
+    get:
+      summary: Retrieve card SLA measurements
+      operationId: get_card_sla_measurements
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              # DOC_MISMATCH: docs=`Array` response type, actual=`object` with `calendars` and `rulesTimeData` arrays — https://developers.kaiten.ru/card-sla/retrieve-card-sla-measurements
+              schema:
+                $ref: '#/components/schemas/CardSlaMeasurements'
+        # DOC_MISMATCH: not in docs, actual returns 400 for archived cards and for cards that are not service desk requests — https://developers.kaiten.ru/card-sla/retrieve-card-sla-measurements
+        '400':
+          description: Bad request
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
   /spaces/{space_id}/automations:
     get:
       summary: Get list of automations
@@ -5234,6 +5262,122 @@ components:
           - string
           - 'null'
           description: Baseline end time
+    CardSlaMeasurements:
+      type: object
+      properties:
+        calendars:
+          type: array
+          items:
+            $ref: '#/components/schemas/SlaCalendar'
+          description: Calendar objects used for SLA calculations
+        rulesTimeData:
+          type: array
+          items:
+            $ref: '#/components/schemas/SlaRuleTimeData'
+          description: SLA rules data
+    SlaCalendar:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique identifier of the calendar
+        timezone:
+          type: string
+          description: Timezone used for calculations
+        holidays:
+          type: array
+          items:
+            $ref: '#/components/schemas/SlaCalendarHoliday'
+          description: List of holidays
+        work_days:
+          type: array
+          items:
+            $ref: '#/components/schemas/SlaCalendarWorkDay'
+          description: List of working days configuration
+    SlaCalendarHoliday:
+      type: object
+      properties:
+        created:
+          type: string
+          description: Timestamp when the holiday record was created
+        updated:
+          type: string
+          description: Timestamp when the holiday record was last updated
+        id:
+          type: string
+          description: Unique identifier of the holiday record
+        calendar_id:
+          type: string
+          description: Identifier of the calendar this holiday belongs to
+        day:
+          type: integer
+          description: Day of the month (1-31)
+        month:
+          type: integer
+          description: Month of the year (1-12)
+        year:
+          type:
+          - integer
+          - 'null'
+          description: Year of the holiday
+        description:
+          type: string
+          description: Description or name of the holiday
+    SlaCalendarWorkDay:
+      type: object
+      properties:
+        created:
+          type: string
+          description: The timestamp when the record was created
+        updated:
+          type: string
+          description: The timestamp when the record was last updated
+        id:
+          type: string
+          description: Identifier of the record
+        calendar_id:
+          type: string
+          description: Identifier of the calendar this record belongs to
+        day:
+          type:
+          - integer
+          - 'null'
+          description: Day number
+        date:
+          type:
+          - string
+          - 'null'
+          description: Calendar date
+        period_start:
+          type: integer
+          description: The starting hour of the working period
+        period_finish:
+          type: integer
+          description: The ending hour of the working period
+    SlaRuleTimeData:
+      type: object
+      properties:
+        rule_id:
+          type: string
+          description: Unique identifier of the SLA rule
+        card_id:
+          type: integer
+          description: Card id for SLA measurements
+        actual_time:
+          type: integer
+          description: Actual work time spent in seconds, calculated considering working hours
+        started:
+          type: boolean
+          description: Indicates if time tracking for this rule has started
+        completed:
+          type: boolean
+          description: Indicates if time tracking for this rule is completed
+        last_calculated_at:
+          type: string
+          description: Timestamp of the last calculation
+        is_last_calculated_at_work_time:
+          type: boolean
+          description: Indicates if the last calculation was during working hours
     Automation:
       type: object
       properties:

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -150,6 +150,11 @@ let sections: [Section] = [
   Section(mark: "Card Baselines", operations: [
     Operation(name: "get_card_baselines", errors: [.unauthorized, .forbidden]),
   ]),
+  Section(mark: "Card SLA", operations: [
+    Operation(
+      name: "get_card_sla_measurements",
+      errors: [.badRequest, .unauthorized, .forbidden, .notFound]),
+  ]),
   Section(mark: "Automations", operations: [
     Operation(name: "list_automations", errors: [.unauthorized, .forbidden, .notFound]),
     Operation(


### PR DESCRIPTION
## Endpoints

- [x] `GET /cards/{card_id}/sla-rules-measurements` — Retrieve card SLA measurements

## Verification

- **Live-verified (read-only GETs):** the response envelope was fetched from the live API for several service desk request cards. The instance has no SLA rules configured, so every 200 came back as `{"calendars":[],"rulesTimeData":[]}` — the item schemas for calendars, holidays, work days and rule time data are taken from the documentation (docs schema dialogs, including the nested holiday/work-day dialogs).
- Also confirmed live: the endpoint answers HTTP 400 for archived cards ("Cant't provide sla time data for archived card") and for cards that are not service desk requests ("Only service desk request can have sla time data").

## DOC_MISMATCH annotations (2)

- Docs label the 200 response type as `Array`; the API returns an object with `calendars` and `rulesTimeData` arrays.
- HTTP 400 is not listed in the docs but is returned for archived cards and for cards that are not service desk requests.

## Changes

- `openapi/kaiten.yaml`: path + `CardSlaMeasurements`, `SlaCalendar`, `SlaCalendarHoliday`, `SlaCalendarWorkDay`, `SlaRuleTimeData` schemas (no query parameters are documented for this endpoint)
- `Sources/KaitenSDK/KaitenClient+CardSla.swift`: `getCardSlaMeasurements(cardId:)` with DocC comments
- `Sources/kaiten/CardSla/CardSlaCommands.swift`: `get-card-sla-measurements` subcommand, registered in `Kaiten.swift`
- README: Card SLA section in the API Reference
- Tests: 200 populated fixture (docs-based), 200 sanitized live empty response, 400/401/404 error paths

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)