### PR TITLE
feat(card-type-tree-entities): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,9 @@ Quote the `?` — unquoted it is a shell glob and never reaches the CLI.
 | Method | Description |
 |--------|-------------|
 | `listCardTypes()` | List card types |
+| `listCardTypeTreeEntities(typeId:)` | List tree entities of a card type |
+| `addCardTypeTreeEntity(typeId:treeEntityUid:)` | Add a tree entity to a card type |
+| `deleteCardTypeTreeEntity(typeId:uid:)` | Delete a tree entity from a card type |
 | `listSprints()` | List sprints |
 | `getSprintSummary(...)` | Get sprint summary |
 

--- a/Sources/KaitenSDK/KaitenClient+CardTypeTreeEntities.swift
+++ b/Sources/KaitenSDK/KaitenClient+CardTypeTreeEntities.swift
@@ -1,0 +1,76 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - Card Type Tree Entities
+
+extension KaitenClient {
+  /// Lists the tree entities attached to a card type.
+  ///
+  /// - Parameter typeId: The card type identifier.
+  /// - Returns: An array of tree entities. Returns an empty array if the card type has none.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for unsupported tariff (402),
+  ///     forbidden (403) or other undocumented HTTP status codes.
+  public func listCardTypeTreeEntities(typeId: Int) async throws(KaitenError) -> [Components
+    .Schemas.CardTypeTreeEntity]
+  {
+    guard
+      let response = try await callList({
+        try await client.list_card_type_tree_entities(path: .init(type_id: typeId))
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Adds a tree entity to a card type.
+  ///
+  /// - Parameters:
+  ///   - typeId: The card type identifier.
+  ///   - treeEntityUid: The UID of the tree entity to attach.
+  /// - Returns: The identifier of the card type the entity was attached to.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for bad request (400), unsupported
+  ///     tariff (402), forbidden (403) or other undocumented HTTP status codes.
+  public func addCardTypeTreeEntity(
+    typeId: Int,
+    treeEntityUid: String
+  ) async throws(KaitenError) -> Components.Schemas.CardTypeIdResponse {
+    let response = try await call {
+      try await client.add_card_type_tree_entity(
+        path: .init(type_id: typeId),
+        body: .json(.init(tree_entity_uid: treeEntityUid))
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Deletes a tree entity from a card type.
+  ///
+  /// - Parameters:
+  ///   - typeId: The card type identifier.
+  ///   - uid: The UID of the tree entity to detach.
+  /// - Returns: The identifier of the card type the entity was detached from.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for unsupported tariff (402),
+  ///     forbidden (403) or other undocumented HTTP status codes.
+  public func deleteCardTypeTreeEntity(
+    typeId: Int,
+    uid: String
+  ) async throws(KaitenError) -> Components.Schemas.CardTypeIdResponse {
+    let response = try await call {
+      try await client.delete_card_type_tree_entity(path: .init(type_id: typeId, uid: uid))
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -968,3 +968,44 @@ extension Operations.remove_blocker_category.Output {
     }
   }
 }
+
+// MARK: - Card Type Tree Entities
+
+extension Operations.list_card_type_tree_entities.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_card_type_tree_entities.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.add_card_type_tree_entity.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.add_card_type_tree_entity.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.delete_card_type_tree_entity.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.delete_card_type_tree_entity.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/CardTypeTreeEntities/CardTypeTreeEntitieCommands.swift
+++ b/Sources/kaiten/CardTypeTreeEntities/CardTypeTreeEntitieCommands.swift
@@ -1,0 +1,69 @@
+import ArgumentParser
+import KaitenSDK
+
+// MARK: - List Card Type Tree Entities
+
+struct ListCardTypeTreeEntities: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-card-type-tree-entities",
+    abstract: "List tree entities of a card type"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card type ID")
+  var typeId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let entities = try await client.listCardTypeTreeEntities(typeId: typeId)
+    try printJSON(entities)
+  }
+}
+
+// MARK: - Add Card Type Tree Entity
+
+struct AddCardTypeTreeEntity: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "add-card-type-tree-entity",
+    abstract: "Add a tree entity to a card type"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card type ID")
+  var typeId: Int
+
+  @Option(name: .long, help: "Tree entity UID")
+  var treeEntityUid: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let result = try await client.addCardTypeTreeEntity(
+      typeId: typeId, treeEntityUid: treeEntityUid)
+    try printJSON(result)
+  }
+}
+
+// MARK: - Delete Card Type Tree Entity
+
+struct DeleteCardTypeTreeEntity: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "delete-card-type-tree-entity",
+    abstract: "Delete a tree entity from a card type"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card type ID")
+  var typeId: Int
+
+  @Option(name: .long, help: "Tree entity UID")
+  var uid: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let result = try await client.deleteCardTypeTreeEntity(typeId: typeId, uid: uid)
+    try printJSON(result)
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -86,6 +86,9 @@ struct Kaiten: AsyncParsableCommand {
       AddBlockerCategory.self,
       RemoveBlockerCategory.self,
       GetCardSlaMeasurements.self,
+      ListCardTypeTreeEntities.self,
+      AddCardTypeTreeEntity.self,
+      DeleteCardTypeTreeEntity.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/CardTypeTreeEntitiesTests.swift
+++ b/Tests/KaitenSDKTests/CardTypeTreeEntitiesTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("CardTypeTreeEntities")
+struct CardTypeTreeEntitiesTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// `KaitenError` is not `Equatable`, so the status code is matched by pattern.
+  private func expectUnexpectedResponse(
+    statusCode: Int,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      Issue.record(
+        "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), no error thrown",
+        sourceLocation: sourceLocation)
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == statusCode else {
+        Issue.record(
+          "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), got \(error)",
+          sourceLocation: sourceLocation)
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)", sourceLocation: sourceLocation)
+    }
+  }
+
+  // MARK: - List
+
+  /// Fixture mirrors a sanitized live response: every field the documentation
+  /// lists came back non-null, and `sort_order` is a fractional number.
+  @Test("200 returns array of CardTypeTreeEntity")
+  func listSuccess() async throws {
+    let json = """
+      [{
+        "uid": "11111111-2222-3333-4444-555555555555",
+        "access": "by_invite",
+        "for_everyone_access_role_id": "66666666-7777-8888-9999-aaaaaaaaaaaa",
+        "entity_type": "space",
+        "path": "10.abc123.def456",
+        "sort_order": 3.579284932826715,
+        "parent_entity_uid": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+        "company_id": 10,
+        "protected": false,
+        "archived": false,
+        "title": "Product space"
+      }]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let entities = try await client.listCardTypeTreeEntities(typeId: 15)
+    #expect(entities.count == 1)
+    #expect(entities[0].uid == "11111111-2222-3333-4444-555555555555")
+    #expect(entities[0].access == "by_invite")
+    #expect(entities[0].entity_type == "space")
+    #expect(entities[0].path == "10.abc123.def456")
+    #expect(entities[0].sort_order == 3.579284932826715)
+    #expect(entities[0].parent_entity_uid == "bbbbbbbb-cccc-dddd-eeee-ffffffffffff")
+    #expect(entities[0].company_id == 10)
+    #expect(entities[0].protected == false)
+    #expect(entities[0].archived == false)
+    #expect(entities[0].title == "Product space")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    #expect(recorded.request.path == "/card-types/15/tree-entities")
+  }
+
+  @Test("200 with empty array returns empty array")
+  func listEmpty() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: "[]"))
+    let entities = try await client.listCardTypeTreeEntities(typeId: 15)
+    #expect(entities.isEmpty)
+  }
+
+  @Test("401 throws unauthorized")
+  func listUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCardTypeTreeEntities(typeId: 15)
+    }
+  }
+
+  @Test("402 unsupported tariff throws unexpectedResponse")
+  func listPaymentRequired() async throws {
+    let client = try makeClient(.returning(statusCode: 402))
+    await expectUnexpectedResponse(statusCode: 402) {
+      _ = try await client.listCardTypeTreeEntities(typeId: 15)
+    }
+  }
+
+  /// A 403 comes back with an empty body on the live API.
+  @Test("403 throws unexpectedResponse")
+  func listForbidden() async throws {
+    let client = try makeClient(.returning(statusCode: 403))
+    await expectUnexpectedResponse(statusCode: 403) {
+      _ = try await client.listCardTypeTreeEntities(typeId: 15)
+    }
+  }
+
+  // MARK: - Add
+
+  /// Fixture follows the documented example response: an object with the card type id.
+  @Test("add sends tree_entity_uid and returns the card type id")
+  func addSuccess() async throws {
+    let json = """
+      {"id": 15}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let result = try await client.addCardTypeTreeEntity(
+      typeId: 15, treeEntityUid: "11111111-2222-3333-4444-555555555555")
+    #expect(result.id == 15)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .post)
+    #expect(recorded.request.path == "/card-types/15/tree-entities")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["tree_entity_uid"] as? String == "11111111-2222-3333-4444-555555555555")
+  }
+
+  @Test("add 400 throws unexpectedResponse")
+  func addBadRequest() async throws {
+    let client = try makeClient(.returning(statusCode: 400))
+    await expectUnexpectedResponse(statusCode: 400) {
+      _ = try await client.addCardTypeTreeEntity(typeId: 15, treeEntityUid: "missing-uid")
+    }
+  }
+
+  @Test("add 402 unsupported tariff throws unexpectedResponse")
+  func addPaymentRequired() async throws {
+    let client = try makeClient(.returning(statusCode: 402))
+    await expectUnexpectedResponse(statusCode: 402) {
+      _ = try await client.addCardTypeTreeEntity(typeId: 15, treeEntityUid: "some-uid")
+    }
+  }
+
+  // MARK: - Delete
+
+  /// Fixture follows the documented response schema: an object with the card type id.
+  @Test("delete targets the tree entity UID and returns the card type id")
+  func deleteSuccess() async throws {
+    let json = """
+      {"id": 15}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let result = try await client.deleteCardTypeTreeEntity(
+      typeId: 15, uid: "11111111-2222-3333-4444-555555555555")
+    #expect(result.id == 15)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .delete)
+    #expect(
+      recorded.request.path == "/card-types/15/tree-entities/11111111-2222-3333-4444-555555555555")
+  }
+
+  @Test("delete 403 throws unexpectedResponse")
+  func deleteForbidden() async throws {
+    let client = try makeClient(.returning(statusCode: 403))
+    await expectUnexpectedResponse(statusCode: 403) {
+      _ = try await client.deleteCardTypeTreeEntity(typeId: 15, uid: "some-uid")
+    }
+  }
+
+  @Test("delete 401 throws unauthorized")
+  func deleteUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.deleteCardTypeTreeEntity(typeId: 15, uid: "some-uid")
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -2541,6 +2541,93 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /card-types/{type_id}/tree-entities:
+    get:
+      summary: Get list of type tree entities
+      operationId: list_card_type_tree_entities
+      parameters:
+      - name: type_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card type ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CardTypeTreeEntity'
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
+    post:
+      summary: Add tree entity to card type
+      operationId: add_card_type_tree_entity
+      parameters:
+      - name: type_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card type ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddCardTypeTreeEntityRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CardTypeIdResponse'
+        '400':
+          description: Bad request
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
+  /card-types/{type_id}/tree-entities/{uid}:
+    delete:
+      summary: Delete tree entity from card type
+      operationId: delete_card_type_tree_entity
+      parameters:
+      - name: type_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card type ID
+      - name: uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Tree entity uid
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CardTypeIdResponse'
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
 components:
   securitySchemes:
     bearerAuth:
@@ -3819,6 +3906,56 @@ components:
         updated:
           type: string
           description: Last update timestamp
+    CardTypeTreeEntity:
+      type: object
+      properties:
+        uid:
+          type: string
+          description: Entity uid
+        title:
+          type: string
+          description: Entity title
+        sort_order:
+          type: number
+          description: Entity sort order
+        archived:
+          type: boolean
+          description: Archived flag
+        access:
+          type: string
+          description: Entity access
+        for_everyone_access_role_id:
+          type: string
+          description: Role id for when access is for_everyone
+        entity_type:
+          type: string
+          description: Entity type
+        path:
+          type: string
+          description: Inner path to entity
+        parent_entity_uid:
+          type: string
+          description: Parent entity uid
+        company_id:
+          type: integer
+          description: Company id
+        protected:
+          type: boolean
+          description: Flag that disables the display of an element in the sidebar
+    AddCardTypeTreeEntityRequest:
+      type: object
+      required:
+      - tree_entity_uid
+      properties:
+        tree_entity_uid:
+          type: string
+          description: Tree entity uuid
+    CardTypeIdResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Card type id
     ExternalLink:
       type: object
       properties:

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -179,6 +179,17 @@ let sections: [Section] = [
     Operation(name: "add_blocker_category", errors: [.unauthorized, .forbidden, .notFound]),
     Operation(name: "remove_blocker_category", errors: [.unauthorized, .forbidden, .notFound]),
   ]),
+  Section(mark: "Card Type Tree Entities", operations: [
+    Operation(
+      name: "list_card_type_tree_entities",
+      errors: [.unauthorized, .paymentRequired, .forbidden]),
+    Operation(
+      name: "add_card_type_tree_entity",
+      errors: [.badRequest, .unauthorized, .paymentRequired, .forbidden]),
+    Operation(
+      name: "delete_card_type_tree_entity",
+      errors: [.unauthorized, .paymentRequired, .forbidden]),
+  ]),
 ]
 
 // MARK: - Generator


### PR DESCRIPTION
Implements the three documented `card-type-tree-entities` endpoints.

## Endpoints

- [x] `GET /card-types/{type_id}/tree-entities` — `listCardTypeTreeEntities(typeId:)` / `list-card-type-tree-entities`
- [x] `POST /card-types/{type_id}/tree-entities` — `addCardTypeTreeEntity(typeId:treeEntityUid:)` / `add-card-type-tree-entity`
- [x] `DELETE /card-types/{type_id}/tree-entities/{uid}` — `deleteCardTypeTreeEntity(typeId:uid:)` / `delete-card-type-tree-entity`

## Verification

- **Live-verified (read-only):** `GET /card-types/{type_id}/tree-entities` — fetched real responses (an empty list, a non-empty list, and a bodiless 403). Every documented field came back present with the documented type and nullability, so the schema carries no annotations. The list test fixture is the sanitized live response. The built CLI was also run against the live endpoint end-to-end.
- **Docs-only:** `POST` and `DELETE` (mutating — never sent to the live instance). Schemas and test fixtures follow the documentation: both return `{ "id": <card type id> }` on 200.

## DOC_MISMATCH

None added — the live GET response matched the documentation exactly.

## Notes

- `access` and `entity_type` stay plain `string` in the spec and SDK: the documentation declares them as `string` and lists no enum values, so there is nothing to enumerate without guessing (FR-009).
- The endpoints document no query parameters and no 404 (FR-010; a missing type surfaces per the documented statuses).
- Restored `create_select_value` to `scripts/generate-response-mapping.swift` — the checked-in generator config had drifted from the checked-in `ResponseMapping.swift` and regenerating dropped that operation.
- Tests: 11 new tests (success with realistic fixture per endpoint, plus 400/401/402/403 error paths), following the `MockClientTransport` pattern. Full suite passes; `swift format lint --strict` clean.

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)
