### PR TITLE
feat(card-time-logs): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ Quote the `?` — unquoted it is a shell glob and never reaches the CLI.
 | `getCardLocationHistory(...)` | Get card location history |
 | `getCardBaselines(...)` | Get card baselines |
 | `listCardAllowedUsers(cardId:...)` | List users with access to a card |
+| `getCardTimeLogs(cardId:forDate:personal:)` | List time logs on a card |
+| `createCardTimeLog(cardId:roleId:timeSpent:forDate:comment:)` | Add a time log to a card |
+| `updateCardTimeLog(cardId:timeLogId:...)` | Update a time log |
+| `deleteCardTimeLog(cardId:timeLogId:)` | Remove a time log |
 
 ### Checklists
 

--- a/Sources/KaitenSDK/KaitenClient+CardTimeLogs.swift
+++ b/Sources/KaitenSDK/KaitenClient+CardTimeLogs.swift
@@ -1,0 +1,130 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - Card Time Logs
+
+extension KaitenClient {
+  /// Fetches time logs on a card.
+  ///
+  /// - Parameters:
+  ///   - cardId: The card identifier.
+  ///   - forDate: Filter by the `for_date` attribute (`YYYY-MM-DD`).
+  ///   - personal: When `true`, returns only the current user's time logs.
+  /// - Returns: An array of time logs. Returns an empty array if the card has no time logs.
+  /// - Throws:
+  ///   - ``KaitenError/notFound(resource:id:)`` if the card does not exist.
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for forbidden (403) or other undocumented HTTP status codes.
+  public func getCardTimeLogs(
+    cardId: Int,
+    forDate: String? = nil,
+    personal: Bool? = nil
+  ) async throws(KaitenError) -> [Components.Schemas.CardTimeLog] {
+    guard
+      let response = try await callList({
+        try await client.get_card_time_logs(
+          path: .init(card_id: cardId),
+          query: .init(for_date: forDate, personal: personal)
+        )
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) { try $0.json }
+  }
+
+  /// Adds a time log to a card.
+  ///
+  /// - Parameters:
+  ///   - cardId: The card identifier.
+  ///   - roleId: The role identifier. The predefined role `-1` is Employee.
+  ///   - timeSpent: Minutes to log. Kaiten requires at least 1.
+  ///   - forDate: Log date in `YYYY-MM-DD` format.
+  ///   - comment: Optional comment for the time log. Kaiten accepts up to 4096 characters.
+  /// - Returns: The created time log.
+  /// - Throws:
+  ///   - ``KaitenError/notFound(resource:id:)`` if the card does not exist.
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for validation error (400),
+  ///     unsupported tariff (402), forbidden (403) or other undocumented HTTP status codes.
+  public func createCardTimeLog(
+    cardId: Int,
+    roleId: Int,
+    timeSpent: Int,
+    forDate: String,
+    comment: String? = nil
+  ) async throws(KaitenError) -> Components.Schemas.CardTimeLog {
+    let response = try await call {
+      try await client.create_card_time_log(
+        path: .init(card_id: cardId),
+        body: .json(
+          .init(role_id: roleId, time_spent: timeSpent, for_date: forDate, comment: comment))
+      )
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("card", cardId)) { try $0.json }
+  }
+
+  /// Updates a time log on a card.
+  ///
+  /// - Parameters:
+  ///   - cardId: The card identifier.
+  ///   - timeLogId: The time log identifier.
+  ///   - roleId: The updated role identifier. The predefined role `-1` is Employee.
+  ///   - timeSpent: Updated minutes to log. Kaiten requires at least 1.
+  ///   - forDate: Updated log date in `YYYY-MM-DD` format.
+  ///   - comment: Updated comment. Kaiten accepts up to 4096 characters.
+  /// - Returns: The updated time log.
+  /// - Throws:
+  ///   - ``KaitenError/notFound(resource:id:)`` if the card or time log does not exist.
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for validation error (400),
+  ///     unsupported tariff (402), forbidden (403) or other undocumented HTTP status codes.
+  public func updateCardTimeLog(
+    cardId: Int,
+    timeLogId: Int,
+    roleId: Int? = nil,
+    timeSpent: Int? = nil,
+    forDate: String? = nil,
+    comment: String? = nil
+  ) async throws(KaitenError) -> Components.Schemas.CardTimeLog {
+    let response = try await call {
+      try await client.update_card_time_log(
+        path: .init(card_id: cardId, id: timeLogId),
+        body: .json(
+          .init(role_id: roleId, time_spent: timeSpent, for_date: forDate, comment: comment))
+      )
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("timeLog", timeLogId)) {
+      try $0.json
+    }
+  }
+
+  /// Removes a time log from a card.
+  ///
+  /// - Parameters:
+  ///   - cardId: The card identifier.
+  ///   - timeLogId: The time log identifier.
+  /// - Returns: The deleted time log ID.
+  /// - Throws:
+  ///   - ``KaitenError/notFound(resource:id:)`` if the card or time log does not exist.
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for unsupported tariff (402),
+  ///     forbidden (403) or other undocumented HTTP status codes.
+  public func deleteCardTimeLog(cardId: Int, timeLogId: Int) async throws(KaitenError) -> Int {
+    let response = try await call {
+      try await client.delete_card_time_log(path: .init(card_id: cardId, id: timeLogId))
+    }
+    let result: Components.Schemas.DeletedTimeLogResponse = try decodeResponse(
+      response.toCase(), notFoundResource: ("timeLog", timeLogId)
+    ) { try $0.json }
+    return result.id
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -1064,3 +1064,58 @@ extension Operations.retrieve_card_allowed_users.Output {
     }
   }
 }
+
+// MARK: - Card Time Logs
+
+extension Operations.get_card_time_logs.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_card_time_logs.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.create_card_time_log.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.create_card_time_log.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.update_card_time_log.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.update_card_time_log.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.delete_card_time_log.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.delete_card_time_log.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/CardTimeLogs/CardTimeLogCommands.swift
+++ b/Sources/kaiten/CardTimeLogs/CardTimeLogCommands.swift
@@ -1,0 +1,128 @@
+import ArgumentParser
+import Foundation
+import KaitenSDK
+
+// MARK: - Get Card Time Logs
+
+struct GetCardTimeLogs: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "get-card-time-logs",
+    abstract: "List time logs on a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Filter by log date (YYYY-MM-DD)")
+  var forDate: String?
+
+  @Flag(name: .long, help: "Only the current user's time logs")
+  var personal: Bool = false
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let timeLogs = try await client.getCardTimeLogs(
+      cardId: cardId, forDate: forDate, personal: personal ? true : nil)
+    try printJSON(timeLogs, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Add Time Log
+
+struct AddTimeLog: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "add-time-log",
+    abstract: "Add a time log to a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Role ID; the predefined role -1 is Employee")
+  var roleId: Int
+
+  @Option(name: .long, help: "Minutes to log (at least 1)")
+  var timeSpent: Int
+
+  @Option(name: .long, help: "Log date (YYYY-MM-DD)")
+  var forDate: String
+
+  @Option(name: .long, help: "Comment (up to 4096 characters)")
+  var comment: String?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let timeLog = try await client.createCardTimeLog(
+      cardId: cardId, roleId: roleId, timeSpent: timeSpent, forDate: forDate, comment: comment)
+    try printJSON(timeLog, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Update Time Log
+
+struct UpdateTimeLog: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "update-time-log",
+    abstract: "Update a time log on a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Time log ID")
+  var timeLogId: Int
+
+  @Option(name: .long, help: "Role ID; the predefined role -1 is Employee")
+  var roleId: Int?
+
+  @Option(name: .long, help: "Minutes to log (at least 1)")
+  var timeSpent: Int?
+
+  @Option(name: .long, help: "Log date (YYYY-MM-DD)")
+  var forDate: String?
+
+  @Option(name: .long, help: "Comment (up to 4096 characters)")
+  var comment: String?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let timeLog = try await client.updateCardTimeLog(
+      cardId: cardId,
+      timeLogId: timeLogId,
+      roleId: roleId,
+      timeSpent: timeSpent,
+      forDate: forDate,
+      comment: comment
+    )
+    try printJSON(timeLog, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Remove Time Log
+
+struct RemoveTimeLog: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "remove-time-log",
+    abstract: "Remove a time log from a card"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Card ID")
+  var cardId: Int
+
+  @Option(name: .long, help: "Time log ID")
+  var timeLogId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let deletedId = try await client.deleteCardTimeLog(cardId: cardId, timeLogId: timeLogId)
+    try printJSON(["id": deletedId], expand: global.expandedFields)
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -93,6 +93,10 @@ struct Kaiten: AsyncParsableCommand {
       ListCardTypeTreeEntities.self,
       AddCardTypeTreeEntity.self,
       DeleteCardTypeTreeEntity.self,
+      GetCardTimeLogs.self,
+      AddTimeLog.self,
+      UpdateTimeLog.self,
+      RemoveTimeLog.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/CardTimeLogsTests.swift
+++ b/Tests/KaitenSDKTests/CardTimeLogsTests.swift
@@ -1,0 +1,305 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Card Time Logs")
+struct CardTimeLogsTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// `KaitenError` is not `Equatable`, so the status code is matched by pattern.
+  private func expectUnexpectedResponse(
+    statusCode: Int,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      Issue.record(
+        "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), no error thrown",
+        sourceLocation: sourceLocation)
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == statusCode else {
+        Issue.record(
+          "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), got \(error)",
+          sourceLocation: sourceLocation)
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)", sourceLocation: sourceLocation)
+    }
+  }
+
+  // MARK: - Get
+
+  /// Fixture follows the documented GET response: the list items carry nested
+  /// `role`, `user` and `author` objects, and `comment` is nullable.
+  @Test("get 200 returns array of CardTimeLog")
+  func getSuccess() async throws {
+    let json = """
+      [{
+        "updated": "2024-05-21T10:15:00.000Z",
+        "created": "2024-05-20T10:00:00.000Z",
+        "id": 501,
+        "card_id": 123,
+        "user_id": 11,
+        "role_id": -1,
+        "author_id": 12,
+        "updater_id": 12,
+        "time_spent": 90,
+        "for_date": "2024-05-20",
+        "comment": null,
+        "role": {
+          "created": "2024-01-01T00:00:00.000Z",
+          "updated": "2024-01-01T00:00:00.000Z",
+          "id": -1,
+          "name": "Employee",
+          "company_id": null
+        },
+        "user": {
+          "id": 11,
+          "full_name": "Test User",
+          "email": "user@example.com",
+          "username": "testuser",
+          "activated": true,
+          "initials": "TU",
+          "avatar_type": 2,
+          "avatar_initials_url": "https://test.kaiten.ru/avatar/tu",
+          "avatar_uploaded_url": null,
+          "lng": "en",
+          "timezone": "UTC",
+          "theme": "auto",
+          "ui_version": 2,
+          "created": "2024-01-01T00:00:00.000Z",
+          "updated": "2024-01-01T00:00:00.000Z"
+        },
+        "author": {
+          "id": 12,
+          "full_name": "Other User",
+          "email": "other@example.com",
+          "username": "otheruser",
+          "activated": true,
+          "initials": "OU",
+          "avatar_type": 2,
+          "avatar_initials_url": "https://test.kaiten.ru/avatar/ou",
+          "avatar_uploaded_url": null
+        }
+      }]
+      """
+    let client = try makeClient(.returning(statusCode: 200, body: json))
+
+    let timeLogs = try await client.getCardTimeLogs(cardId: 123)
+    #expect(timeLogs.count == 1)
+    #expect(timeLogs[0].id == 501)
+    #expect(timeLogs[0].card_id == 123)
+    #expect(timeLogs[0].role_id == -1)
+    #expect(timeLogs[0].time_spent == 90)
+    #expect(timeLogs[0].for_date == "2024-05-20")
+    #expect(timeLogs[0].comment == nil)
+    #expect(timeLogs[0].role?.name == "Employee")
+    #expect(timeLogs[0].role?.company_id == nil)
+    #expect(timeLogs[0].user?.id == 11)
+    #expect(timeLogs[0].author?.id == 12)
+  }
+
+  /// Cards without time logs return `[]` (confirmed live).
+  @Test("get 200 empty array returns empty array")
+  func getEmptyList() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: "[]"))
+    let timeLogs = try await client.getCardTimeLogs(cardId: 123)
+    #expect(timeLogs.isEmpty)
+  }
+
+  @Test("get 200 with empty body returns empty array")
+  func getEmptyBody() async throws {
+    let client = try makeClient(.returning(statusCode: 200))
+    let timeLogs = try await client.getCardTimeLogs(cardId: 123)
+    #expect(timeLogs.isEmpty)
+  }
+
+  @Test("get sends for_date and personal query parameters")
+  func getSendsQuery() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
+    let client = try makeClient(transport)
+
+    _ = try await client.getCardTimeLogs(cardId: 123, forDate: "2024-05-20", personal: true)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    let path = try #require(recorded.request.path)
+    #expect(path.hasPrefix("/cards/123/time-logs?"))
+    #expect(path.contains("for_date=2024-05-20"))
+    #expect(path.contains("personal=true"))
+  }
+
+  @Test("get 404 throws notFound")
+  func getNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.getCardTimeLogs(cardId: 999)
+    }
+  }
+
+  @Test("get 401 throws unauthorized")
+  func getUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.getCardTimeLogs(cardId: 123)
+    }
+  }
+
+  // MARK: - Create
+
+  /// Fixture follows the documented POST response, which stops at `comment` and
+  /// carries no nested `role`, `user` or `author` objects.
+  @Test("create sends body and parses 200")
+  func createSuccess() async throws {
+    let json = """
+      {
+        "updated": "2024-05-21T10:15:00.000Z",
+        "created": "2024-05-21T10:15:00.000Z",
+        "id": 502,
+        "card_id": 123,
+        "user_id": 11,
+        "role_id": -1,
+        "author_id": 11,
+        "updater_id": 11,
+        "time_spent": 30,
+        "for_date": "2024-05-21",
+        "comment": "Code review"
+      }
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let timeLog = try await client.createCardTimeLog(
+      cardId: 123, roleId: -1, timeSpent: 30, forDate: "2024-05-21", comment: "Code review")
+
+    #expect(timeLog.id == 502)
+    #expect(timeLog.time_spent == 30)
+    #expect(timeLog.comment == "Code review")
+    #expect(timeLog.role == nil)
+    #expect(timeLog.user == nil)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .post)
+    #expect(recorded.request.path == "/cards/123/time-logs")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["role_id"] as? Int == -1)
+    #expect(sent["time_spent"] as? Int == 30)
+    #expect(sent["for_date"] as? String == "2024-05-21")
+    #expect(sent["comment"] as? String == "Code review")
+  }
+
+  @Test("create 400 throws unexpectedResponse")
+  func createValidationError() async throws {
+    let client = try makeClient(.returning(statusCode: 400))
+    await expectUnexpectedResponse(statusCode: 400) {
+      _ = try await client.createCardTimeLog(
+        cardId: 123, roleId: -1, timeSpent: 0, forDate: "2024-05-21")
+    }
+  }
+
+  @Test("create 402 unsupported tariff throws unexpectedResponse")
+  func createPaymentRequired() async throws {
+    let client = try makeClient(.returning(statusCode: 402))
+    await expectUnexpectedResponse(statusCode: 402) {
+      _ = try await client.createCardTimeLog(
+        cardId: 123, roleId: -1, timeSpent: 30, forDate: "2024-05-21")
+    }
+  }
+
+  // MARK: - Update
+
+  @Test("update targets the time log and parses 200")
+  func updateSuccess() async throws {
+    let json = """
+      {
+        "updated": "2024-05-22T09:00:00.000Z",
+        "created": "2024-05-21T10:15:00.000Z",
+        "id": 502,
+        "card_id": 123,
+        "user_id": 11,
+        "role_id": -1,
+        "author_id": 11,
+        "updater_id": 12,
+        "time_spent": 45,
+        "for_date": "2024-05-21",
+        "comment": null
+      }
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let timeLog = try await client.updateCardTimeLog(cardId: 123, timeLogId: 502, timeSpent: 45)
+
+    #expect(timeLog.id == 502)
+    #expect(timeLog.time_spent == 45)
+    #expect(timeLog.comment == nil)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .patch)
+    #expect(recorded.request.path == "/cards/123/time-logs/502")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["time_spent"] as? Int == 45)
+    #expect(sent["role_id"] == nil)
+  }
+
+  @Test("update 404 throws notFound")
+  func updateNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    do {
+      _ = try await client.updateCardTimeLog(cardId: 123, timeLogId: 999, timeSpent: 45)
+      Issue.record("expected KaitenError.notFound, no error thrown")
+    } catch let error as KaitenError {
+      guard case .notFound = error else {
+        Issue.record("expected KaitenError.notFound, got \(error)")
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)")
+    }
+  }
+
+  // MARK: - Delete
+
+  @Test("delete returns the deleted time log id")
+  func deleteSuccess() async throws {
+    let json = """
+      {"id": 502}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let deletedId = try await client.deleteCardTimeLog(cardId: 123, timeLogId: 502)
+
+    #expect(deletedId == 502)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .delete)
+    #expect(recorded.request.path == "/cards/123/time-logs/502")
+  }
+
+  @Test("delete 403 throws unexpectedResponse")
+  func deleteForbidden() async throws {
+    let client = try makeClient(.returning(statusCode: 403))
+    await expectUnexpectedResponse(statusCode: 403) {
+      _ = try await client.deleteCardTimeLog(cardId: 123, timeLogId: 502)
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -2508,6 +2508,146 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /cards/{card_id}/time-logs:
+    get:
+      summary: Get time logs
+      operationId: get_card_time_logs
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      - name: for_date
+        in: query
+        schema:
+          type: string
+        description: Filter by for_date attribute
+      - name: personal
+        in: query
+        schema:
+          type: boolean
+        description: Filter time logs by current user
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CardTimeLog'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    post:
+      summary: Add time log
+      operationId: create_card_time_log
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTimeLogRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CardTimeLog'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+  /cards/{card_id}/time-logs/{id}:
+    patch:
+      summary: Update log record
+      operationId: update_card_time_log
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Time log ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateTimeLogRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CardTimeLog'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    delete:
+      summary: Remove time log
+      operationId: delete_card_time_log
+      parameters:
+      - name: card_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card ID
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Time log ID
+      responses:
+        '200':
+          description: Time log deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeletedTimeLogResponse'
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
   /spaces/{space_id}/automations:
     get:
       summary: Get list of automations
@@ -5980,3 +6120,118 @@ components:
         uid:
           type: string
           description: Blocker category UID
+    CardTimeLog:
+      type: object
+      properties:
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        id:
+          type: integer
+          description: Card time log id
+        card_id:
+          type: integer
+          description: Card id
+        user_id:
+          type: integer
+          description: User id
+        role_id:
+          type: integer
+          description: 'Role id, predefined role is: -1 - Employee'
+        author_id:
+          type: integer
+          description: Author id
+        updater_id:
+          type: integer
+          description: Last updater id
+        time_spent:
+          type: integer
+          description: Minutes to log
+        for_date:
+          type: string
+          description: Log date
+        comment:
+          type:
+          - string
+          - 'null'
+          description: Time log comment
+        # `role`, `user` and `author` are documented only on the GET response;
+        # POST and PATCH responses stop at `comment`, so all three stay optional.
+        role:
+          $ref: '#/components/schemas/TimeLogRole'
+          description: Role info
+        user:
+          $ref: '#/components/schemas/User'
+          description: User info
+        author:
+          $ref: '#/components/schemas/User'
+          description: Author info
+    TimeLogRole:
+      type: object
+      properties:
+        created:
+          type: string
+          description: Create date
+        updated:
+          type: string
+          description: Last update timestamp
+        id:
+          type: integer
+          description: Role id
+        name:
+          type: string
+          description: Role name
+        company_id:
+          type:
+          - integer
+          - 'null'
+          description: Role company id
+    CreateTimeLogRequest:
+      type: object
+      required:
+      - role_id
+      - time_spent
+      - for_date
+      properties:
+        role_id:
+          type: integer
+          description: 'Role id, predefined role is: -1 - Employee'
+        time_spent:
+          type: integer
+          minimum: 1
+          description: Minutes to log
+        for_date:
+          type: string
+          description: Log date in format YYYY-MM-DD
+        comment:
+          type: string
+          maxLength: 4096
+          description: Time log comment
+    UpdateTimeLogRequest:
+      type: object
+      properties:
+        role_id:
+          type: integer
+          description: 'Role id, predefined role is: -1 - Employee'
+        time_spent:
+          type: integer
+          minimum: 1
+          description: Minutes to log
+        for_date:
+          type: string
+          description: Log date in format YYYY-MM-DD
+        comment:
+          type: string
+          maxLength: 4096
+          description: Time log comment
+    DeletedTimeLogResponse:
+      type: object
+      required:
+      - id
+      properties:
+        id:
+          type: integer
+          description: Deleted time log id

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -202,6 +202,18 @@ let sections: [Section] = [
   Section(mark: "Card Allowed Users", operations: [
     Operation(name: "retrieve_card_allowed_users", errors: [.unauthorized, .forbidden, .notFound])
   ]),
+  Section(mark: "Card Time Logs", operations: [
+    Operation(name: "get_card_time_logs", errors: [.unauthorized, .forbidden, .notFound]),
+    Operation(
+      name: "create_card_time_log",
+      errors: [.badRequest, .unauthorized, .paymentRequired, .forbidden, .notFound]),
+    Operation(
+      name: "update_card_time_log",
+      errors: [.badRequest, .unauthorized, .paymentRequired, .forbidden, .notFound]),
+    Operation(
+      name: "delete_card_time_log",
+      errors: [.unauthorized, .paymentRequired, .forbidden, .notFound]),
+  ]),
 ]
 
 // MARK: - Generator


### PR DESCRIPTION
Adds the four documented `card-time-logs` endpoints to the OpenAPI spec, SDK and CLI.

## Endpoints

- [x] `GET /cards/{card_id}/time-logs` — `getCardTimeLogs(cardId:forDate:personal:)` / `kaiten get-card-time-logs`
- [x] `POST /cards/{card_id}/time-logs` — `createCardTimeLog(cardId:roleId:timeSpent:forDate:comment:)` / `kaiten add-time-log`
- [x] `PATCH /cards/{card_id}/time-logs/{id}` — `updateCardTimeLog(...)` / `kaiten update-time-log`
- [x] `DELETE /cards/{card_id}/time-logs/{id}` — `deleteCardTimeLog(cardId:timeLogId:)` / `kaiten remove-time-log`

Both documented query parameters of the GET endpoint (`for_date`, `personal`) are exposed (FR-010).

## Live verification vs docs-only

- **GET** was verified live end-to-end (direct `curl` and through the built CLI, with and without query parameters): the endpoint returns `200` with an array. Every probed card — including all cards with `time_spent_sum` tracked, across active and archived batches — returned an **empty list**: this instance does not use time tracking. The item schema therefore comes strictly from the docs, and the GET test fixture is docs-based with invented values.
- **POST / PATCH / DELETE** are mutating and were not sent to the live API; schemas and fixtures come from the docs. Per the docs, the POST/PATCH responses stop at `comment` — the nested `role`, `user` and `author` objects appear only on the GET list response, so all three stay optional on the shared `CardTimeLog` schema. `user`/`author` reuse the existing `User` schema; `role` gets a new `TimeLogRole` schema.

## DOC_MISMATCH

None added — no divergence between docs and the API was observable (the live list was empty).

## Other changes

- Backfilled `create_select_value` into `scripts/generate-response-mapping.swift`: #458 edited the generated `ResponseMapping.swift` by hand, so regenerating the file dropped that operation. The generator config now matches the checked-in mapping.
- README "API Reference" Cards table gained the four new methods.
- 13 new tests in `Tests/KaitenSDKTests/CardTimeLogsTests.swift` (success, query-serialization, empty-list, and error paths per endpoint). Full suite: 326 tests green; `swift format lint --strict` clean.

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)
