### PR TITLE
feat(cli): resolve credentials from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ let card = try await client.getCard(id: 123)
 
 ### As a CLI
 
-The CLI resolves credentials in order: flags → config file.
+The CLI resolves each credential independently: environment variable → config file.
 
 #### 1. Get a Kaiten API Token
 
@@ -67,7 +67,7 @@ Get your API token at `https://<your-company>.kaiten.ru/profile/api-key`.
 
 #### 2. Configure Credentials
 
-**Option 1 — Config file** (recommended):
+**Option 1 — Config file** (recommended for interactive use):
 
 Create `~/.config/kaiten/config.json`:
 
@@ -84,6 +84,18 @@ Then run commands:
 kaiten list-spaces
 kaiten get-card --id 123
 ```
+
+**Option 2 — Environment variables** (recommended for CI):
+
+```bash
+export KAITEN_URL="https://<your-company>.kaiten.ru/api/latest"
+export KAITEN_TOKEN="<your-api-token>"
+kaiten list-spaces
+```
+
+No file on disk. An environment variable overrides the same parameter from the
+config file; one set to an empty string counts as unset, so a missing CI secret
+fails resolution instead of sending an empty token.
 
 #### 3. Output Size
 

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -147,18 +147,43 @@ struct GlobalOptions: ParsableArguments {
   func makeClient() async throws -> KaitenClient {
     let configPath = selectedConfigPath
     let config = try await Self.loadConfigReader(configPath: configPath)
+    let connection = try Self.resolveConnection(
+      environment: ProcessInfo.processInfo.environment,
+      configURL: config?.string(forKey: "url"),
+      configToken: config?.string(forKey: "token"),
+      configPath: configPath
+    )
+    return try KaitenClient(baseURL: connection.url, token: connection.token)
+  }
 
-    guard let baseURL = config?.string(forKey: "url") else {
+  /// Resolves each connection parameter independently: environment variable first,
+  /// selected config file second. An empty environment value counts as unset —
+  /// CI substitutes an empty string for a missing secret, and an empty token must
+  /// fail here rather than reach the API.
+  static func resolveConnection(
+    environment: [String: String],
+    configURL: String?,
+    configToken: String?,
+    configPath: String
+  ) throws -> (url: String, token: String) {
+    guard let url = nonEmpty(environment["KAITEN_URL"]) ?? configURL else {
       throw ValidationError(
-        "Missing Kaiten API URL. Pass --config <path> or set \"url\" in \(configPath)"
+        "Missing Kaiten API URL. Set KAITEN_URL, set \"url\" in \(configPath), "
+          + "or pass --config <path>"
       )
     }
-    guard let apiToken = config?.string(forKey: "token") else {
+    guard let token = nonEmpty(environment["KAITEN_TOKEN"]) ?? configToken else {
       throw ValidationError(
-        "Missing Kaiten API token. Pass --config <path> or set \"token\" in \(configPath)"
+        "Missing Kaiten API token. Set KAITEN_TOKEN, set \"token\" in \(configPath), "
+          + "or pass --config <path>"
       )
     }
-    return try KaitenClient(baseURL: baseURL, token: apiToken)
+    return (url, token)
+  }
+
+  private static func nonEmpty(_ value: String?) -> String? {
+    guard let value, !value.isEmpty else { return nil }
+    return value
   }
 
   static var defaultConfigPath: String {

--- a/Tests/KaitenSDKTests/ConnectionResolutionTests.swift
+++ b/Tests/KaitenSDKTests/ConnectionResolutionTests.swift
@@ -1,0 +1,104 @@
+import ArgumentParser
+import Testing
+
+@testable import kaiten
+
+@Suite("Connection resolution")
+struct ConnectionResolutionTests {
+  private let configPath = "/tmp/test-config.json"
+
+  @Test("Environment alone resolves both parameters")
+  func environmentOnly() throws {
+    let connection = try GlobalOptions.resolveConnection(
+      environment: [
+        "KAITEN_URL": "https://env.kaiten.ru/api/latest",
+        "KAITEN_TOKEN": "env-token",
+      ],
+      configURL: nil,
+      configToken: nil,
+      configPath: configPath
+    )
+    #expect(connection.url == "https://env.kaiten.ru/api/latest")
+    #expect(connection.token == "env-token")
+  }
+
+  @Test("Environment wins over config per parameter")
+  func environmentWinsOverConfig() throws {
+    let connection = try GlobalOptions.resolveConnection(
+      environment: [
+        "KAITEN_URL": "https://env.kaiten.ru/api/latest",
+        "KAITEN_TOKEN": "env-token",
+      ],
+      configURL: "https://file.kaiten.ru/api/latest",
+      configToken: "file-token",
+      configPath: configPath
+    )
+    #expect(connection.url == "https://env.kaiten.ru/api/latest")
+    #expect(connection.token == "env-token")
+  }
+
+  @Test("Each parameter falls back independently")
+  func mixedSources() throws {
+    let connection = try GlobalOptions.resolveConnection(
+      environment: ["KAITEN_TOKEN": "env-token"],
+      configURL: "https://file.kaiten.ru/api/latest",
+      configToken: nil,
+      configPath: configPath
+    )
+    #expect(connection.url == "https://file.kaiten.ru/api/latest")
+    #expect(connection.token == "env-token")
+  }
+
+  @Test("Empty environment value counts as unset")
+  func emptyEnvironmentFallsBack() throws {
+    let connection = try GlobalOptions.resolveConnection(
+      environment: ["KAITEN_URL": "", "KAITEN_TOKEN": ""],
+      configURL: "https://file.kaiten.ru/api/latest",
+      configToken: "file-token",
+      configPath: configPath
+    )
+    #expect(connection.url == "https://file.kaiten.ru/api/latest")
+    #expect(connection.token == "file-token")
+  }
+
+  @Test("Missing URL names KAITEN_URL in the error")
+  func missingURLError() {
+    #expect(throws: ValidationError.self) {
+      _ = try GlobalOptions.resolveConnection(
+        environment: ["KAITEN_TOKEN": "env-token"],
+        configURL: nil,
+        configToken: nil,
+        configPath: configPath
+      )
+    }
+    do {
+      _ = try GlobalOptions.resolveConnection(
+        environment: ["KAITEN_TOKEN": "env-token"],
+        configURL: nil,
+        configToken: nil,
+        configPath: configPath
+      )
+    } catch let error as ValidationError {
+      #expect(error.message.contains("KAITEN_URL"))
+    } catch {
+      Issue.record("Expected ValidationError, got \(error)")
+    }
+  }
+
+  @Test("Missing token names KAITEN_TOKEN in the error")
+  func missingTokenError() {
+    do {
+      _ = try GlobalOptions.resolveConnection(
+        environment: [:],
+        configURL: "https://file.kaiten.ru/api/latest",
+        configToken: nil,
+        configPath: configPath
+      )
+      Issue.record("Expected ValidationError")
+    } catch let error as ValidationError {
+      #expect(error.message.contains("KAITEN_TOKEN"))
+    } catch {
+      Issue.record("Expected ValidationError, got \(error)")
+    }
+  }
+}

--- a/specs/002-kaiten-cli/spec.md
+++ b/specs/002-kaiten-cli/spec.md
@@ -33,10 +33,22 @@ stdout confirms it works.
 3. **Given** both default and custom config files exist with different values,
    **When** the user specifies `--config`, **Then** the specified config path
    takes priority over the default config path.
-4. **Given** neither selected config file nor default config file provide a required
-   parameter, **When** the user runs a subcommand, **Then** the
+4. **Given** neither the environment nor the selected config file provide a
+   required parameter, **When** the user runs a subcommand, **Then** the
    CLI exits with a clear error message indicating which parameter
-   is missing and where it can be set (config file).
+   is missing and where it can be set (environment variable or config file).
+4a. **Given** `KAITEN_URL` and `KAITEN_TOKEN` are set and no config file
+   exists, **When** the user runs a subcommand, **Then** the CLI uses the
+   environment values without error.
+4b. **Given** an environment variable and the config file both provide the
+   same parameter with different values, **When** the user runs a subcommand,
+   **Then** the environment value wins for that parameter.
+4c. **Given** the config file provides only `url` and `KAITEN_TOKEN` is set,
+   **When** the user runs a subcommand, **Then** both parameters resolve —
+   each parameter falls back independently.
+4d. **Given** an environment variable is set to an empty string, **When** the
+   user runs a subcommand, **Then** the CLI treats it as unset and falls back
+   to the config file.
 5. **Given** the SDK returns an error, **When** the user runs a
    subcommand, **Then** the CLI outputs a human-readable error
    message to stderr and exits with a non-zero exit code.
@@ -61,8 +73,9 @@ stdout confirms it works.
 - What if the config file exists but contains invalid JSON? The CLI
   MUST output an error describing the configuration problem.
 - What if the config file does not exist and no `--config` is passed?
-  The CLI MUST output an error with instructions: pass `--config` or
-  create `~/.config/kaiten/config.json`.
+  If the environment supplies the missing parameters, the CLI proceeds;
+  otherwise it MUST output an error with instructions: set `KAITEN_URL` /
+  `KAITEN_TOKEN`, pass `--config`, or create `~/.config/kaiten/config.json`.
 - What if enum-like options are invalid (for example lane condition,
   column type, card state)? The CLI MUST fail with a validation error
   listing allowed values.
@@ -86,10 +99,13 @@ stdout confirms it works.
 - **FR-002a**: The CLI MUST support a `--config` argument that points
   to the configuration file path. If omitted, CLI uses the default
   `~/.config/kaiten/config.json`.
-- **FR-003**: The CLI MUST resolve connection parameters in
-   priority order: explicit `--config` path > default config path.
-   URL and token MUST be read from the selected config file.
-   Environment variables are NOT used.
+- **FR-003**: The CLI MUST resolve each connection parameter independently in
+   priority order: environment variable > selected config file. `KAITEN_URL`
+   supplies the URL and `KAITEN_TOKEN` supplies the token; whichever is unset
+   falls back to the selected config file (explicit `--config` path > default
+   config path). An environment variable set to an empty string MUST be
+   treated as unset — CI systems substitute an empty string for a missing
+   secret, and an empty token must fail resolution rather than reach the API.
 - **FR-004**: The CLI MUST output structured data to stdout and
   errors to stderr.
 - **FR-005**: The CLI MUST exit with code 0 on success and
@@ -136,8 +152,11 @@ stdout confirms it works.
   Silent dropping via optional coercion is forbidden.
 - **FR-015**: CSV/list-style ID filters MUST use strict token parsing consistently
   across commands (including `list-users --ids`); malformed tokens MUST fail locally.
-- **FR-016**: The only supported connection argument is `--config`.
-  URL and token input is allowed only via selected config file (`--config` path or default config path).
+- **FR-016**: The only supported connection argument is `--config`. There are
+  no `--url` or `--token` flags: a token in argv is visible to process lists
+  and shell history. Connection input comes from the `KAITEN_URL` /
+  `KAITEN_TOKEN` environment variables or the selected config file
+  (`--config` path or default config path).
 - **FR-017**: SDK inputs that are free-form JSON objects rather than scalars
   (card custom properties) MUST still be reachable from the CLI, as a single
   option carrying a JSON object string. The CLI MUST parse and validate that
@@ -232,8 +251,10 @@ stdout confirms it works.
 ### Measurable Outcomes
 
 - **SC-001**: The CLI can be used in automation scripts — each
-  subcommand accepts all input via selected config file and
-  produces machine-readable output.
+  subcommand accepts all input via environment variables or the selected
+  config file and produces machine-readable output. A CI job can run the
+  CLI with credentials passed entirely through the environment, writing
+  no file to disk.
 - **SC-002**: The CLI contains no duplication of SDK logic — each
   subcommand only calls the corresponding SDK method.
 - **SC-003**: The CLI compiles and runs on macOS (ARM) and


### PR DESCRIPTION
## Problem

The CLI reads credentials only from a config file. In CI that forces writing the token to disk on the runner — the llm-factory Kaiten datasource needs to pass credentials through the environment like every other secret it handles.

## Change

- `GlobalOptions.resolveConnection`: each connection parameter resolves independently, `KAITEN_URL` / `KAITEN_TOKEN` first, selected config file second.
- An environment variable set to an empty string counts as unset: CI substitutes an empty string for a missing secret, and that must fail resolution rather than reach the API as an empty token.
- Error messages now name the environment variable, the config key and `--config`.
- Spec updated first (FR-003, FR-016, scenarios 4a–4d), README credentials section documents the CI path.

## Verification

- 6 new unit tests in `ConnectionResolutionTests` — all pass.
- Live smoke: `KAITEN_URL=… KAITEN_TOKEN=… kaiten get-current-user --config /nonexistent` returns the user; without env the error names `KAITEN_URL`.
- `swift format lint --strict` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)