### PR TITLE
feat(cards): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Quote the `?` — unquoted it is a shell glob and never reaches the CLI.
 | `getCard(id:)` | Fetch a single card by ID |
 | `createCard(...)` | Create a new card |
 | `updateCard(...)` | Update a card |
+| `batchUpdateCards(...)` | Update multiple cards by criteria (background job) |
 | `deleteCard(...)` | Delete a card |
 | `listCardChildren(...)` | List child cards |
 | `addCardChild(...)` | Add a child card |
@@ -493,6 +494,34 @@ var opts = CardUpdateOptions()
 opts.title = "Updated Title"
 opts.columnId = 42
 let card = try await client.updateCard(id: 123, opts)
+```
+
+### Batch update
+
+`batchUpdateCards` updates every card matching the given criteria in one call. It runs in the
+background and returns the job's UUID rather than the updated cards. Provide at least one
+criteria parameter together with `attributes`, or `columnId` + `laneId` together with `orderBy`
+to reposition cards inside a cell:
+
+```swift
+let job = try await client.batchUpdateCards(
+  boardId: 1,
+  condition: .onBoard,
+  attributes: .init(asap: true)
+)
+print(job.id)  // UUID of the background job
+```
+
+The `orderBy` field and direction are exposed as Swift enums (`BatchUpdateOrderField`,
+`SortDirection`), each with an `unknown(String)` case preserving values the documentation
+does not list.
+
+From the CLI, criteria are plain options and the nested payloads are JSON objects:
+
+```bash
+kaiten batch-update-cards --board-id 1 --condition 1 --attributes '{"asap": true}'
+kaiten batch-update-cards --column-id 2 --lane-id 3 \
+  --order-by '{"field_type": "title", "direction": "asc"}'
 ```
 
 ### Custom properties

--- a/Sources/KaitenSDK/Enums.swift
+++ b/Sources/KaitenSDK/Enums.swift
@@ -1124,3 +1124,101 @@ public enum AuditLogAction: Sendable, Equatable, CaseIterable, Codable {
     try container.encode(rawValue)
   }
 }
+
+// MARK: - Batch Update Cards
+
+/// Field type cards are sorted by when a batch update repositions them.
+///
+/// Used in ``KaitenClient/batchUpdateCards(boardId:columnId:laneId:ownerId:typeId:condition:attributes:orderBy:)``.
+/// - SeeAlso: [Kaiten API – Batch update for cards](https://developers.kaiten.ru/cards/batch-update-for-cards)
+public enum BatchUpdateOrderField: Sendable, Equatable, CaseIterable, Codable {
+  /// Sort by a custom property (identified by the `id` sorting parameter).
+  case customProperty
+  /// Sort by card size.
+  case size
+  /// Sort by creation date.
+  case created
+  /// Sort by due date.
+  case dueDate
+  /// Sort by title.
+  case title
+  /// Unknown value (forward compatibility).
+  case unknown(String)
+
+  public static var allCases: [BatchUpdateOrderField] {
+    [.customProperty, .size, .created, .dueDate, .title]
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "cp": self = .customProperty
+    case "size": self = .size
+    case "created": self = .created
+    case "due_date": self = .dueDate
+    case "title": self = .title
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: String {
+    switch self {
+    case .customProperty: "cp"
+    case .size: "size"
+    case .created: "created"
+    case .dueDate: "due_date"
+    case .title: "title"
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(String.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}
+
+/// Sorting direction of a batch card update.
+/// - SeeAlso: [Kaiten API – Batch update for cards](https://developers.kaiten.ru/cards/batch-update-for-cards)
+public enum SortDirection: Sendable, Equatable, CaseIterable, Codable {
+  /// Ascending order.
+  case ascending
+  /// Descending order.
+  case descending
+  /// Unknown value (forward compatibility).
+  case unknown(String)
+
+  public static var allCases: [SortDirection] {
+    [.ascending, .descending]
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "asc": self = .ascending
+    case "desc": self = .descending
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: String {
+    switch self {
+    case .ascending: "asc"
+    case .descending: "desc"
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(String.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}

--- a/Sources/KaitenSDK/KaitenClient+Cards.swift
+++ b/Sources/KaitenSDK/KaitenClient+Cards.swift
@@ -1,6 +1,36 @@
 import Foundation
 import OpenAPIRuntime
 
+// MARK: - Typed Sorting Parameters
+
+// Batch-update sorting discriminators travel as plain strings (see the comment
+// above the automation enums in `Enums.swift`). These accessors and the
+// initializer give the generated payload a typed surface without losing
+// undocumented values.
+
+extension Components.Schemas.BatchUpdateCardsOrderBy {
+  /// The field cards are sorted by, or `nil` if the field is not set.
+  public var orderField: BatchUpdateOrderField? {
+    field_type.map(BatchUpdateOrderField.init(rawValue:))
+  }
+
+  /// The sorting direction, or `nil` if the field is not set.
+  public var sortDirection: SortDirection? {
+    direction.map(SortDirection.init(rawValue:))
+  }
+
+  /// Creates sorting parameters from typed values.
+  ///
+  /// - Parameters:
+  ///   - field: The field type to sort by.
+  ///   - id: The custom property identifier to sort by, required when `field`
+  ///     is ``BatchUpdateOrderField/customProperty``.
+  ///   - direction: The sorting direction.
+  public init(field: BatchUpdateOrderField, id: Int? = nil, direction: SortDirection) {
+    self.init(field_type: field.rawValue, id: id, direction: direction.rawValue)
+  }
+}
+
 // MARK: - Cards
 
 extension KaitenClient {
@@ -193,6 +223,58 @@ extension KaitenClient {
       )
     }
     return try decodeResponse(response.toCase(), notFoundResource: ("card", id)) { try $0.json }
+  }
+
+  /// Updates multiple cards selected by criteria.
+  ///
+  /// The update runs in the background — the method returns the identifier of the
+  /// background job, not the updated cards. The Kaiten documentation requires at
+  /// least one criteria parameter together with `attributes`, or `columnId` +
+  /// `laneId` together with `orderBy`.
+  ///
+  /// - Parameters:
+  ///   - boardId: Criteria board identifier.
+  ///   - columnId: Criteria column identifier.
+  ///   - laneId: Criteria lane identifier.
+  ///   - ownerId: Criteria owner identifier.
+  ///   - typeId: Criteria card type identifier.
+  ///   - condition: Criteria card condition (live or archived).
+  ///   - attributes: Attributes to change on every card matching the criteria.
+  ///   - orderBy: Sorting parameters for repositioning cards inside a cell.
+  /// - Returns: The accepted background job with its UUID.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for bad request (400), unsupported
+  ///     tariff (402), forbidden (403), not found (404) or other undocumented HTTP status codes.
+  ///     A 404 is reported as `unexpectedResponse` rather than
+  ///     ``KaitenError/notFound(resource:id:)`` because cards are selected by criteria and the
+  ///     response does not say which referenced entity is missing.
+  public func batchUpdateCards(
+    boardId: Int? = nil,
+    columnId: Int? = nil,
+    laneId: Int? = nil,
+    ownerId: Int? = nil,
+    typeId: Int? = nil,
+    condition: CardCondition? = nil,
+    attributes: Components.Schemas.BatchUpdateCardsAttributes? = nil,
+    orderBy: Components.Schemas.BatchUpdateCardsOrderBy? = nil
+  ) async throws(KaitenError) -> Components.Schemas.BatchUpdateCardsResponse {
+    let body = Components.Schemas.BatchUpdateCardsRequest(
+      board_id: boardId,
+      column_id: columnId,
+      lane_id: laneId,
+      owner_id: ownerId,
+      type_id: typeId,
+      condition: condition?.rawValue,
+      attributes: attributes,
+      order_by: orderBy
+    )
+    let response = try await call {
+      try await client.batch_update_cards(body: .json(body))
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
   }
 
   /// Deletes a card.

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -58,6 +58,20 @@ extension Operations.update_card.Output {
   }
 }
 
+extension Operations.batch_update_cards.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.batch_update_cards.Output.Accepted.Body> {
+    switch self {
+    case .accepted(let accepted): .ok(accepted.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
 // MARK: - Card Members & Comments
 
 extension Operations.retrieve_list_of_card_members.Output {

--- a/Sources/kaiten/Cards/CardCommands.swift
+++ b/Sources/kaiten/Cards/CardCommands.swift
@@ -501,6 +501,72 @@ struct UpdateCard: AsyncParsableCommand {
   }
 }
 
+struct BatchUpdateCards: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "batch-update-cards",
+    abstract: "Update multiple cards by criteria",
+    discussion: """
+      Runs in the background and prints the job ID, not the updated cards. Requires at least one \
+      criteria option together with --attributes, or --column-id and --lane-id together with \
+      --order-by.
+      """
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Criteria board ID")
+  var boardId: Int?
+
+  @Option(name: .long, help: "Criteria column ID")
+  var columnId: Int?
+
+  @Option(name: .long, help: "Criteria lane ID")
+  var laneId: Int?
+
+  @Option(name: .long, help: "Criteria owner ID")
+  var ownerId: Int?
+
+  @Option(name: .long, help: "Criteria card type ID")
+  var typeId: Int?
+
+  @Option(name: .long, help: "Criteria condition: 1 = live, 2 = archived")
+  var condition: Int?
+
+  @Option(
+    name: .long,
+    help: "Attributes to change as a JSON object, e.g. '{\"asap\": true, \"owner_id\": 42}'"
+  )
+  var attributes: String?
+
+  @Option(
+    name: .long,
+    help:
+      "Sorting parameters as a JSON object, e.g. '{\"field_type\": \"title\", \"direction\": \"asc\"}'"
+  )
+  var orderBy: String?
+
+  func run() async throws {
+    let parsedCondition = try parseCardCondition(condition)
+    let parsedAttributes = try parseAutomationJSON(
+      attributes, as: Components.Schemas.BatchUpdateCardsAttributes.self, fieldName: "attributes")
+    let parsedOrderBy = try parseAutomationJSON(
+      orderBy, as: Components.Schemas.BatchUpdateCardsOrderBy.self, fieldName: "order-by")
+
+    let client = try await global.makeClient()
+    let job = try await client.batchUpdateCards(
+      boardId: boardId,
+      columnId: columnId,
+      laneId: laneId,
+      ownerId: ownerId,
+      typeId: typeId,
+      condition: parsedCondition,
+      attributes: parsedAttributes,
+      orderBy: parsedOrderBy
+    )
+    try printJSON(job, expand: global.expandedFields)
+  }
+}
+
 struct GetCardComments: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "get-card-comments",

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -20,6 +20,7 @@ struct Kaiten: AsyncParsableCommand {
       CreateCard.self,
       GetCard.self,
       UpdateCard.self,
+      BatchUpdateCards.self,
       GetCardComments.self,
       AddComment.self,
       UpdateComment.self,

--- a/Tests/KaitenSDKTests/BatchUpdateCardsTests.swift
+++ b/Tests/KaitenSDKTests/BatchUpdateCardsTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("BatchUpdateCards")
+struct BatchUpdateCardsTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// Reads the recorded request body as a JSON dictionary.
+  private func requestBodyJSON(from transport: MockClientTransport) async throws -> [String: Any] {
+    let req = try #require(transport.recordedRequests.first)
+    let bodyData = try await Data(collecting: #require(req.body), upTo: 1024 * 1024)
+    return try #require(
+      try JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
+    )
+  }
+
+  // Fixture based on the documented 202 response: a single string `id`
+  // carrying the UUID of the background job.
+  private let jobJSON = """
+    {"id": "3fa85f64-5717-4562-b3fc-2c963f66afa6"}
+    """
+
+  @Test("202 returns background job ID")
+  func success() async throws {
+    let transport = MockClientTransport.returning(statusCode: 202, body: jobJSON)
+    let client = try makeClient(transport)
+
+    let job = try await client.batchUpdateCards(
+      boardId: 1,
+      attributes: .init(asap: true)
+    )
+    #expect(job.id == "3fa85f64-5717-4562-b3fc-2c963f66afa6")
+
+    let req = try #require(transport.recordedRequests.first)
+    #expect(req.request.method == .patch)
+    #expect(req.request.path == "/cards")
+  }
+
+  @Test("request body carries criteria, attributes and order_by")
+  func requestBody() async throws {
+    let transport = MockClientTransport.returning(statusCode: 202, body: jobJSON)
+    let client = try makeClient(transport)
+
+    _ = try await client.batchUpdateCards(
+      columnId: 2,
+      laneId: 3,
+      condition: .archived,
+      attributes: .init(owner_id: 42, title: "Renamed", asap: true),
+      orderBy: .init(field: .dueDate, direction: .ascending)
+    )
+
+    let body = try await requestBodyJSON(from: transport)
+    #expect(body["column_id"] as? Int == 2)
+    #expect(body["lane_id"] as? Int == 3)
+    #expect(body["condition"] as? Int == 2)
+    #expect(body["board_id"] == nil, "unset criteria should be absent")
+    let attributes = try #require(body["attributes"] as? [String: Any])
+    #expect(attributes["owner_id"] as? Int == 42)
+    #expect(attributes["title"] as? String == "Renamed")
+    #expect(attributes["asap"] as? Bool == true)
+    let orderBy = try #require(body["order_by"] as? [String: Any])
+    #expect(orderBy["field_type"] as? String == "due_date")
+    #expect(orderBy["direction"] as? String == "asc")
+  }
+
+  @Test("typed sorting accessors preserve undocumented values")
+  func sortingAccessors() {
+    let orderBy = Components.Schemas.BatchUpdateCardsOrderBy(
+      field_type: "some_new_field", id: 7, direction: "sideways")
+    #expect(orderBy.orderField == .unknown("some_new_field"))
+    #expect(orderBy.sortDirection == .unknown("sideways"))
+
+    let typed = Components.Schemas.BatchUpdateCardsOrderBy(
+      field: .customProperty, id: 7, direction: .descending)
+    #expect(typed.field_type == "cp")
+    #expect(typed.id == 7)
+    #expect(typed.direction == "desc")
+  }
+
+  @Test("400 throws unexpectedResponse")
+  func badRequest() async throws {
+    let client = try makeClient(.returning(statusCode: 400))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.batchUpdateCards(boardId: 1, attributes: .init(asap: true))
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    do {
+      _ = try await client.batchUpdateCards(boardId: 1, attributes: .init(asap: true))
+      Issue.record("expected KaitenError.unauthorized, no error thrown")
+    } catch {
+      guard case .unauthorized = error else {
+        Issue.record("expected KaitenError.unauthorized, got \(error)")
+        return
+      }
+    }
+  }
+
+  @Test("402 throws unexpectedResponse")
+  func paymentRequired() async throws {
+    let client = try makeClient(.returning(statusCode: 402))
+    do {
+      _ = try await client.batchUpdateCards(boardId: 1, attributes: .init(asap: true))
+      Issue.record("expected KaitenError.unexpectedResponse(402), no error thrown")
+    } catch {
+      guard case .unexpectedResponse(let code, _) = error, code == 402 else {
+        Issue.record("expected KaitenError.unexpectedResponse(402), got \(error)")
+        return
+      }
+    }
+  }
+
+  @Test("404 throws unexpectedResponse, not notFound")
+  func notFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    do {
+      _ = try await client.batchUpdateCards(boardId: 999, attributes: .init(asap: true))
+      Issue.record("expected KaitenError.unexpectedResponse(404), no error thrown")
+    } catch {
+      guard case .unexpectedResponse(let code, _) = error, code == 404 else {
+        Issue.record("expected KaitenError.unexpectedResponse(404), got \(error)")
+        return
+      }
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -446,6 +446,37 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden
+    patch:
+      summary: Batch update for cards
+      operationId: batch_update_cards
+      description: >
+        Updates multiple cards selected by criteria. Runs in the background and
+        returns a job ID. The documentation requires at least one criteria field
+        together with `attributes`, or `column_id` + `lane_id` together with
+        `order_by`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatchUpdateCardsRequest'
+      responses:
+        '202':
+          description: Batch update accepted, runs in the background
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchUpdateCardsResponse'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
   /cards/{card_id}:
     patch:
       summary: Update card
@@ -5140,6 +5171,128 @@ components:
           type: object
           additionalProperties: true
           description: "Custom properties. Format: 'id_{custom_property_id}: value'"
+    BatchUpdateCardsRequest:
+      type: object
+      description: >
+        Criteria and attributes for a batch card update. The documentation
+        requires at least one criteria field together with `attributes`, or
+        `column_id` + `lane_id` together with `order_by`.
+      properties:
+        board_id:
+          type: integer
+          description: Criteria board ID
+        column_id:
+          type: integer
+          description: Criteria column ID
+        lane_id:
+          type: integer
+          description: Criteria lane ID
+        owner_id:
+          type: integer
+          description: Criteria owner ID
+        type_id:
+          type: integer
+          description: Criteria card type ID
+        condition:
+          type: integer
+          description: "Criteria conditions: 1 - live, 2 - archived"
+        attributes:
+          $ref: '#/components/schemas/BatchUpdateCardsAttributes'
+        order_by:
+          $ref: '#/components/schemas/BatchUpdateCardsOrderBy'
+    BatchUpdateCardsAttributes:
+      type: object
+      description: Attributes to change on every card matching the criteria
+      properties:
+        board_id:
+          type: integer
+          description: Board ID
+        column_id:
+          type: integer
+          description: Column ID
+        lane_id:
+          type: integer
+          description: Lane ID
+        owner_id:
+          type: integer
+          description: Owner ID
+        type_id:
+          type: integer
+          description: Card type ID
+        condition:
+          type: integer
+          description: "1 - live, 2 - archived"
+        title:
+          type: string
+          minLength: 1
+          maxLength: 1024
+          description: Title
+        asap:
+          type: boolean
+          description: ASAP marker
+          default: false
+        due_date:
+          type:
+          - string
+          - 'null'
+          description: Deadline in ISO 8601 format (null to clear)
+        due_date_time_present:
+          type: boolean
+          description: Flag indicating that deadline is specified up to hours and minutes
+        sort_order:
+          type: number
+          exclusiveMinimum: 0
+          description: Position in the cell (board_id, column_id, lane_id)
+        description:
+          type:
+          - string
+          - 'null'
+          maxLength: 32768
+          description: Description for card (null to clear)
+        expires_later:
+          type: boolean
+          description: Fixed deadline or not. Date dependant flag in terms of Kanban
+        size_text:
+          type:
+          - string
+          - 'null'
+          maxLength: 267
+          description: "Size text (e.g. '1', 'S', 'XL', null to clear)"
+        service_id:
+          type:
+          - integer
+          - 'null'
+          description: Service ID (null to clear)
+        blocked:
+          type: boolean
+          description: Send false to release all blocks related to this card
+        external_id:
+          type:
+          - string
+          - 'null'
+          maxLength: 1024
+          description: Any external id to assign to the cards (null to clear)
+    BatchUpdateCardsOrderBy:
+      type: object
+      description: Sorting parameters for repositioning cards inside a cell
+      properties:
+        field_type:
+          type: string
+          description: "Field type to sort by: cp, size, created, due_date, title"
+        id:
+          type: integer
+          description: Field id to sort by
+        direction:
+          type: string
+          description: "Sorting direction: asc or desc"
+    BatchUpdateCardsResponse:
+      type: object
+      required:
+      - id
+      properties:
+        id:
+          type: string
+          description: Unique identifier (UUID) of the background job
     DeletedCommentResponse:
       type: object
       required:

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -23,17 +23,30 @@ enum ErrorCase: String {
   case serviceUnavailable
 }
 
+/// The documented success case of an Output enum. Most operations answer
+/// `200 OK`; background jobs answer `202 Accepted`.
+enum SuccessCase: String {
+  case ok = "Ok"
+  case accepted = "Accepted"
+
+  /// The generated enum case name (`.ok` / `.accepted`).
+  var caseName: String { rawValue.lowercased() }
+}
+
 struct Operation {
   let name: String
   let errors: [ErrorCase]
-  /// Whether the `200` response carries a body. Operations documented as
+  /// Whether the success response carries a body. Operations documented as
   /// returning no content map to `ResponseCase<Void>`.
   let hasBody: Bool
+  /// The documented success status of the operation.
+  let success: SuccessCase
 
-  init(name: String, errors: [ErrorCase], hasBody: Bool = true) {
+  init(name: String, errors: [ErrorCase], hasBody: Bool = true, success: SuccessCase = .ok) {
     self.name = name
     self.errors = errors
     self.hasBody = hasBody
+    self.success = success
   }
 }
 
@@ -48,6 +61,10 @@ let sections: [Section] = [
     Operation(name: "create_card", errors: [.badRequest, .unauthorized, .forbidden]),
     Operation(name: "get_card", errors: [.unauthorized, .notFound]),
     Operation(name: "update_card", errors: [.badRequest, .unauthorized, .forbidden, .notFound]),
+    Operation(
+      name: "batch_update_cards",
+      errors: [.badRequest, .unauthorized, .paymentRequired, .forbidden, .notFound],
+      success: .accepted),
   ]),
   Section(mark: "Card Members & Comments", operations: [
     Operation(name: "retrieve_list_of_card_members", errors: [.unauthorized, .forbidden]),
@@ -231,11 +248,16 @@ let sections: [Section] = [
 
 func generateExtension(_ op: Operation) -> String {
   let typeName = "Operations.\(op.name).Output"
-  let returnType = "KaitenClient.ResponseCase<\(op.hasBody ? "\(typeName).Ok.Body" : "Void")>"
+  let returnType =
+    "KaitenClient.ResponseCase<\(op.hasBody ? "\(typeName).\(op.success.rawValue).Body" : "Void")>"
 
   // Build switch cases
   var cases: [String] = []
-  cases.append(op.hasBody ? "    case .ok(let ok): .ok(ok.body)" : "    case .ok: .ok(())")
+  let successCase = op.success.caseName
+  cases.append(
+    op.hasBody
+      ? "    case .\(successCase)(let \(successCase)): .ok(\(successCase).body)"
+      : "    case .\(successCase): .ok(())")
 
   for error in op.errors {
     switch error {

--- a/specs/001-kaiten-sdk-core/spec.md
+++ b/specs/001-kaiten-sdk-core/spec.md
@@ -135,6 +135,7 @@ A developer requests all spaces and boards — for navigation.
 - **FR-021**: For resources addressed by a string UID rather than an integer id (currently automations), a HTTP 404 MUST surface as `unexpectedResponse(statusCode: 404)`. `notFound(resource:id:)` carries an `Int` id and MUST NOT be populated with an unrelated identifier (for example the parent space id) to fake specificity.
 - **FR-022**: Endpoints documented as returning HTTP 200 with no response body (currently `delete_automation`) MUST map to a `Void`-returning SDK method. The SDK MUST NOT invent a response payload for them.
 - **FR-023**: SDK MUST expose card blocker categories: list company categories (`GET /categories`), add a category to a blocker (`POST /blockers/{blocker_id}/categories`), and remove a category from a blocker (`DELETE /blockers/{blocker_id}/categories/{category_uuid}`). Removal returns only the removed category UID, per documentation.
+- **FR-024**: SDK MUST expose batch card updates (`PATCH /cards`). The endpoint answers HTTP 202 with only the UUID of a background job, so the SDK returns that job payload and MUST NOT pretend to return updated cards. A 404 surfaces as `unexpectedResponse(404)` per the FR-021 rationale — cards are selected by criteria, and no single integer id identifies what was missing. The `order_by` discriminators (`field_type`, `direction`) follow the FR-020a rule: plain `string` in the spec, hand-written enums with an `unknown(String)` case in `Enums.swift`.
 
 ### Non-Functional Requirements
 

--- a/specs/002-kaiten-cli/spec.md
+++ b/specs/002-kaiten-cli/spec.md
@@ -158,11 +158,12 @@ stdout confirms it works.
   `KAITEN_TOKEN` environment variables or the selected config file
   (`--config` path or default config path).
 - **FR-017**: SDK inputs that are free-form JSON objects rather than scalars
-  (card custom properties) MUST still be reachable from the CLI, as a single
-  option carrying a JSON object string. The CLI MUST parse and validate that
-  string locally before invoking the SDK method: input that is not a JSON
-  object, or that does not decode into the mapped payload, MUST produce a
-  validation error rather than being dropped or forwarded.
+  (card custom properties, batch-update `--attributes` and `--order-by`) MUST
+  still be reachable from the CLI, as a single option carrying a JSON object
+  string. The CLI MUST parse and validate that string locally before invoking
+  the SDK method: input that is not a JSON object, or that does not decode
+  into the mapped payload, MUST produce a validation error rather than being
+  dropped or forwarded.
 
 - **FR-018**: Command output MUST omit nested entities by default, keeping
   only scalar fields and `*_id` references. A `--expand` option MUST accept a


### PR DESCRIPTION
## Endpoints

- [x] `PATCH /cards` — Batch update for cards ([docs](https://developers.kaiten.ru/cards/batch-update-for-cards))

## What was done

- **Spec**: `patch` operation on `/cards` with `BatchUpdateCardsRequest`, `BatchUpdateCardsAttributes`, `BatchUpdateCardsOrderBy` and `BatchUpdateCardsResponse` schemas, built from the documentation (including both nested Schema dialogs). All documented body parameters are exposed, no subset (FR-010). The endpoint takes no query parameters.
- **SDK**: `KaitenClient.batchUpdateCards(boardId:columnId:laneId:ownerId:typeId:condition:attributes:orderBy:)` with DocC comments (NFR-007). Returns the background-job payload the API answers with — HTTP 202 and a job UUID, not the updated cards. A 404 surfaces as `unexpectedResponse(404)` because cards are selected by criteria and no single integer id identifies what was missing (FR-021 rationale, now FR-024).
- **Enums**: `order_by` discriminators (`field_type`, `direction`) are plain strings in the spec per FR-020a; typed surface is `BatchUpdateOrderField` and `SortDirection` in `Enums.swift`, each with an `unknown(String)` case.
- **Generator**: `scripts/generate-response-mapping.swift` gained a success-case option — this is the first operation whose documented success status is 202 (generated case `.accepted`) instead of 200.
- **CLI**: `kaiten batch-update-cards` with criteria options and JSON-object `--attributes` / `--order-by`, parsed and validated locally (FR-017). Registered in `Kaiten.swift`.
- **README**: Cards API Reference row + a "Batch update" subsection with SDK and CLI usage.
- **Specs**: FR-024 added to `specs/001-kaiten-sdk-core/spec.md`; FR-017 in `specs/002-kaiten-cli/spec.md` extended with the new JSON options.
- **Tests**: `Tests/KaitenSDKTests/BatchUpdateCardsTests.swift` — 7 tests: 202 success (fixture from the documented response), request-body encoding, typed sorting accessors, and 400/401/402/404 error paths.

## Live verification

The endpoint is mutating (PATCH against a production instance), so it was **not** exercised live; the schema follows the documentation strictly and the test fixture mirrors the documented 202 response (a single string `id` with the job UUID). No `DOC_MISMATCH` annotations were added.

## Checks

- `swift format lint --strict --recursive Sources/ Tests/` — clean
- `swift test` — 394 tests in 81 suites, all passing

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)