### PR TITLE
feat(checklists): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,13 +212,17 @@ Quote the `?` — unquoted it is a shell glob and never reaches the CLI.
 | `createChecklistItem(checklistId:text:...)` | Add an item to a checklist by checklist ID |
 | `updateChecklistItem(checklistId:itemId:...)` | Update a checklist item by checklist ID |
 | `removeChecklistItem(checklistId:itemId:)` | Remove a checklist item by checklist ID |
+| `listCardsWithChecklist(checklistId:onlySharedCards:)` | List cards that use a checklist |
 
-The last three address a checklist directly (`/checklists/{checklist_id}/items`),
-without card context.
+The three checklist-item methods above address a checklist directly
+(`/checklists/{checklist_id}/items`), without card context.
 
 CLI: `add-item-to-checklist --checklist-id <id> --text <text>`,
 `update-item-in-checklist --checklist-id <id> --item-id <id>`,
-`remove-item-from-checklist --checklist-id <id> --item-id <id>`.
+`remove-item-from-checklist --checklist-id <id> --item-id <id>`,
+`list-checklist-cards --checklist-id <id> --only-shared-cards <bool>`.
+The `only_shared_cards` query parameter is required by the API — requests
+without it are rejected with 400 — but no filtering effect has been observed.
 
 ### External Links
 

--- a/Sources/KaitenSDK/KaitenClient+Checklists.swift
+++ b/Sources/KaitenSDK/KaitenClient+Checklists.swift
@@ -4,6 +4,41 @@ import OpenAPIRuntime
 // MARK: - Checklists
 
 extension KaitenClient {
+  /// Lists the cards that use a checklist.
+  ///
+  /// - Parameters:
+  ///   - checklistId: The checklist identifier.
+  ///   - onlySharedCards: Required by the API; requests without it are rejected with 400. No
+  ///     filtering effect has been observed — a card that is neither public nor shared is
+  ///     returned with either value.
+  /// - Returns: An array of cards that use the checklist. Returns an empty array if the API
+  ///   responds with an empty body.
+  /// - Throws:
+  ///   - ``KaitenError/notFound(resource:id:)`` if the checklist does not exist.
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for validation error (400),
+  ///     forbidden (403) or other undocumented HTTP status codes.
+  public func listCardsWithChecklist(
+    checklistId: Int,
+    onlySharedCards: Bool
+  ) async throws(KaitenError) -> [Components.Schemas.ChecklistCard] {
+    guard
+      let response = try await callList({
+        try await client.retrieve_cards_with_checklist(
+          path: .init(id: checklistId),
+          query: .init(only_shared_cards: onlySharedCards)
+        )
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("checklist", checklistId)) {
+      try $0.json
+    }
+  }
+
   /// Creates a checklist on a card.
   ///
   /// - Parameters:

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -1269,3 +1269,20 @@ extension Operations.retrieve_current_user_blockers.Output {
     }
   }
 }
+
+// MARK: - Checklist Cards
+
+extension Operations.retrieve_cards_with_checklist.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.retrieve_cards_with_checklist.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/Checklists/ChecklistsCommands.swift
+++ b/Sources/kaiten/Checklists/ChecklistsCommands.swift
@@ -1,0 +1,33 @@
+import ArgumentParser
+import KaitenSDK
+
+// MARK: - Checklist Cards
+
+struct ListChecklistCards: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-checklist-cards",
+    abstract: "List cards that use a checklist"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Checklist ID")
+  var checklistId: Int
+
+  @Option(
+    name: .long,
+    help: ArgumentHelp(
+      "Required by the API; requests without it are rejected with 400.",
+      discussion:
+        "No filtering effect has been observed — a card that is neither public nor shared is returned with either value."
+    )
+  )
+  var onlySharedCards: Bool
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let cards = try await client.listCardsWithChecklist(
+      checklistId: checklistId, onlySharedCards: onlySharedCards)
+    try printJSON(cards, expand: global.expandedFields)
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -109,6 +109,7 @@ struct Kaiten: AsyncParsableCommand {
       AddCardBlockerUser.self,
       RemoveCardBlockerUser.self,
       GetCurrentUserBlockers.self,
+      ListChecklistCards.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/ChecklistCardsTests.swift
+++ b/Tests/KaitenSDKTests/ChecklistCardsTests.swift
@@ -1,0 +1,206 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Checklist Cards")
+struct ChecklistCardsTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// `KaitenError` is not `Equatable`, so the status code is matched by pattern.
+  private func expectUnexpectedResponse(
+    statusCode: Int,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      Issue.record(
+        "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), no error thrown",
+        sourceLocation: sourceLocation)
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == statusCode else {
+        Issue.record(
+          "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), got \(error)",
+          sourceLocation: sourceLocation)
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)", sourceLocation: sourceLocation)
+    }
+  }
+
+  /// Sanitized copy of a live response: field set, types and nullability are preserved.
+  private static let cardJSON = """
+    [
+      {
+        "archived": true,
+        "asap": false,
+        "blocked": false,
+        "blocking_card": false,
+        "board_id": 5,
+        "calculated_planned_end": null,
+        "calculated_planned_start": null,
+        "card_cp_value_fts_version": "3",
+        "card_tag_fts_version": "2",
+        "children_count": 0,
+        "children_done": 0,
+        "children_ids": null,
+        "children_number_properties_sum": null,
+        "column_changed_at": "2024-10-25T10:37:26.375Z",
+        "column_id": 3,
+        "comment_last_added_at": "2024-10-25T08:36:57.209Z",
+        "comments_total": 1,
+        "completed_at": null,
+        "completed_on_time": null,
+        "condition": 2,
+        "counters_recalculated_at": "2026-02-25T08:57:50.771Z",
+        "created": "2024-10-14T10:48:16.594Z",
+        "description": "Steps to reproduce",
+        "description_filled": true,
+        "due_date": null,
+        "due_date_time_present": false,
+        "estimate_workload": 0,
+        "expires_later": false,
+        "external_id": null,
+        "external_user_emails": null,
+        "fifo_order": null,
+        "first_moved_to_in_progress_at": "2024-10-19T10:58:38.655Z",
+        "fts_version": "1",
+        "goals_done": 1,
+        "goals_total": 1,
+        "has_access_to_space": true,
+        "has_blocked_children": false,
+        "id": 101,
+        "import_id": null,
+        "key": null,
+        "lane_changed_at": "2024-10-14T10:48:16.594Z",
+        "lane_id": 4,
+        "last_moved_at": "2024-10-25T10:37:26.375Z",
+        "last_moved_to_done_at": "2024-10-25T10:37:26.375Z",
+        "locked": null,
+        "milestone_id": null,
+        "owner_id": 7,
+        "parent_checklist_ids": null,
+        "parent_link_ids": null,
+        "parents_count": 0,
+        "parents_ids": null,
+        "path_data": {
+          "board": {"id": 5, "title": "Sprint"},
+          "column": {"id": 3, "sort_order": 3, "title": "Done"},
+          "lane": {"id": 4, "sort_order": 40.65, "title": "Default"},
+          "space": {"id": 9, "title": "Demo space"}
+        },
+        "planned_end": null,
+        "planned_start": null,
+        "properties": {},
+        "public": false,
+        "sd_external_recipients": null,
+        "sd_new_comment": false,
+        "service_id": null,
+        "share_id": null,
+        "share_settings": null,
+        "size": null,
+        "size_text": null,
+        "size_unit": null,
+        "sort_order": 16.0009,
+        "source": "app",
+        "space_id": 9,
+        "sprint_id": null,
+        "state": 3,
+        "tag_ids": null,
+        "time_blocked_sum": 0,
+        "time_spent_sum": 0,
+        "title": "Fix login",
+        "type_id": 2,
+        "uid": "00000000-0000-0000-0000-000000000001",
+        "updated": "2024-10-28T14:36:34.877Z",
+        "updater_id": 8,
+        "version": 6
+      }
+    ]
+    """
+
+  @Test("200 returns array of ChecklistCard")
+  func listSuccess() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: Self.cardJSON)
+    let client = try makeClient(transport)
+
+    let cards = try await client.listCardsWithChecklist(checklistId: 123, onlySharedCards: false)
+
+    #expect(cards.count == 1)
+    let card = try #require(cards.first)
+    #expect(card.id == 101)
+    #expect(card.title == "Fix login")
+    #expect(card.archived == true)
+    #expect(card.state == 3)
+    #expect(card.condition == 2)
+    #expect(card.fifo_order == nil)
+    #expect(card.sprint_id == nil)
+    #expect(card.service_id == nil)
+    #expect(card.has_access_to_space == true)
+    #expect(card.space_id == 9)
+    #expect(card.path_data?.board != nil)
+    #expect(card.path_data?.subcolumn == nil)
+    #expect(card.uid == "00000000-0000-0000-0000-000000000001")
+    #expect(card.sort_order == 16.0009)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    #expect(recorded.request.path == "/checklists/123?only_shared_cards=false")
+  }
+
+  @Test("200 with empty body returns empty array")
+  func listEmptyBody() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: ""))
+    let cards = try await client.listCardsWithChecklist(checklistId: 123, onlySharedCards: true)
+    #expect(cards.isEmpty)
+  }
+
+  @Test("404 throws notFound")
+  func listNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    do {
+      _ = try await client.listCardsWithChecklist(checklistId: 999, onlySharedCards: false)
+      Issue.record("expected KaitenError.notFound, no error thrown")
+    } catch let error as KaitenError {
+      guard case .notFound(let resource, let id) = error else {
+        Issue.record("expected KaitenError.notFound, got \(error)")
+        return
+      }
+      #expect(resource == "checklist")
+      #expect(id == 999)
+    } catch {
+      Issue.record("expected KaitenError, got \(error)")
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func listUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCardsWithChecklist(checklistId: 1, onlySharedCards: false)
+    }
+  }
+
+  @Test("400 throws unexpectedResponse")
+  func listBadRequest() async throws {
+    let client = try makeClient(.returning(statusCode: 400))
+    await expectUnexpectedResponse(statusCode: 400) {
+      _ = try await client.listCardsWithChecklist(checklistId: 1, onlySharedCards: false)
+    }
+  }
+
+  @Test("403 throws unexpectedResponse")
+  func listForbidden() async throws {
+    let client = try makeClient(.returning(statusCode: 403))
+    await expectUnexpectedResponse(statusCode: 403) {
+      _ = try await client.listCardsWithChecklist(checklistId: 1, onlySharedCards: false)
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -3202,6 +3202,41 @@ paths:
           description: Invalid token
         '403':
           description: Forbidden
+  /checklists/{id}:
+    get:
+      summary: Retrieve cards with checklist
+      operationId: retrieve_cards_with_checklist
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Card checklist ID
+      # DOC_MISMATCH: docs=required `boolean` with no description, actual has no observed filtering effect (a card that is neither public nor shared is returned with either value; omitting the parameter is rejected with 400) — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+      - name: only_shared_cards
+        in: query
+        required: true
+        schema:
+          type: boolean
+        description: Required by the API; requests without it are rejected with 400
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ChecklistCard'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
   /checklists/{checklist_id}/items:
     post:
       summary: Add item to checklist
@@ -7138,3 +7173,379 @@ components:
         full_name:
           type: string
           description: User full name
+    ChecklistCard:
+      type: object
+      description: A card that uses a checklist, as returned by the checklists endpoint
+      properties:
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        archived:
+          type: boolean
+          description: Card archived flag
+        id:
+          type: integer
+          description: Card id
+        title:
+          type: string
+          description: Card title
+        description:
+          type:
+          - string
+          - 'null'
+          description: Card description
+        asap:
+          type: boolean
+          description: Card asap flag
+        due_date:
+          type:
+          - string
+          - 'null'
+          description: Card deadline
+        # DOC_MISMATCH: docs=non-nullable `integer`, actual=`integer | null` — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+        fifo_order:
+          type:
+          - integer
+          - 'null'
+          description: Number of card in the cell when fifo rule applied to cards column
+        state:
+          type: integer
+          description: 'Card state: 1-queued, 2-inProgress, 3-done'
+        condition:
+          type: integer
+          description: 'Card condition: 1-live, 2-archived, 3-deleted'
+        expires_later:
+          type: boolean
+          description: Fixed deadline or not. Date dependant flag in terms of Kanban
+        parents_count:
+          type: integer
+          description: Card parents count
+        children_count:
+          type: integer
+          description: Card children count
+        children_done:
+          type: integer
+          description: Card children done count
+        goals_total:
+          type: integer
+          description: Card goals count
+        goals_done:
+          type: integer
+          description: Number of card done goals
+        time_spent_sum:
+          type: integer
+          description: Amount of time spent (in minutes)
+        time_blocked_sum:
+          type: integer
+          description: Amount of blocked time (in minutes)
+        children_number_properties_sum:
+          type:
+          - object
+          - 'null'
+          additionalProperties: true
+          description: Sum according to numerical data of child cards
+        parent_checklist_ids:
+          type:
+          - array
+          - 'null'
+          items:
+            type: integer
+          description: Array of card parent checklist ids
+        parents_ids:
+          type:
+          - array
+          - 'null'
+          items:
+            type: integer
+          description: Array of card parent ids
+        children_ids:
+          type:
+          - array
+          - 'null'
+          items:
+            type: integer
+          description: Array of card children ids
+        blocking_card:
+          type: boolean
+          description: Is card blocking another card
+        blocked:
+          type: boolean
+          description: Is card blocked
+        size:
+          type:
+          - number
+          - 'null'
+          description: Numerical part of size
+        size_unit:
+          type:
+          - string
+          - 'null'
+          description: Text part of size
+        size_text:
+          type:
+          - string
+          - 'null'
+          description: Size text
+        due_date_time_present:
+          type: boolean
+          description: Flag indicating that deadline is specified up to hours and minutes
+        board_id:
+          type: integer
+          description: Board id
+        column_id:
+          type: integer
+          description: Column id
+        lane_id:
+          type: integer
+          description: Lane id
+        owner_id:
+          type: integer
+          description: Card owner id
+        type_id:
+          type: integer
+          description: Card type id
+        version:
+          type: integer
+          description: Card version
+        updater_id:
+          type: integer
+          description: User id who last updated card
+        completed_on_time:
+          type:
+          - boolean
+          - 'null'
+          description: Flag indicating that card completed on time when due date present
+        completed_at:
+          type:
+          - string
+          - 'null'
+          description: Date when card moved to done type column
+        last_moved_at:
+          type:
+          - string
+          - 'null'
+          description: Date when card last moved
+        lane_changed_at:
+          type:
+          - string
+          - 'null'
+          description: Date when card changed lane
+        column_changed_at:
+          type:
+          - string
+          - 'null'
+          description: Date when card changed column
+        first_moved_to_in_progress_at:
+          type:
+          - string
+          - 'null'
+          description: Date when card first moved to inProgress type column
+        last_moved_to_done_at:
+          type:
+          - string
+          - 'null'
+          description: Date when card last moved to done type column
+        # DOC_MISMATCH: docs=non-nullable `integer`, actual=`integer | null` — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+        sprint_id:
+          type:
+          - integer
+          - 'null'
+          description: Sprint id
+        external_id:
+          type:
+          - string
+          - 'null'
+          description: External id
+        # DOC_MISMATCH: docs=non-nullable `integer`, actual=`integer | null` — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+        service_id:
+          type:
+          - integer
+          - 'null'
+          description: Service id
+        comments_total:
+          type: integer
+          description: Total card comments
+        comment_last_added_at:
+          type:
+          - string
+          - 'null'
+          description: Date when last comment added
+        properties:
+          type:
+          - object
+          - 'null'
+          additionalProperties: true
+          description: 'Card custom properties. Format: id_{propertyId}:value'
+        planned_start:
+          type:
+          - string
+          - 'null'
+          description: Card timeline planned start
+        planned_end:
+          type:
+          - string
+          - 'null'
+          description: Card timeline planned end
+        counters_recalculated_at:
+          type: string
+          description: Date of recalculating counters
+        sd_new_comment:
+          type: boolean
+          description: Has unseen service desk request author comments
+        import_id:
+          type:
+          - integer
+          - 'null'
+          description: Import id
+        public:
+          type: boolean
+          description: Is card public
+        share_settings:
+          type:
+          - object
+          - 'null'
+          description: Public share settings
+          properties:
+            fields:
+              type: object
+              additionalProperties: true
+              description: Visible card fields
+            share_due_date:
+              type: string
+              description: Share until
+            open_unauthorized_allowed:
+              type: boolean
+              description: Allow to open unauthorized to view the card in the read only mode
+        share_id:
+          type:
+          - string
+          - 'null'
+          description: Public share id
+        external_user_emails:
+          type:
+          - string
+          - 'null'
+          description: External users emails
+        description_filled:
+          type: boolean
+          description: Flag indicating that card has description
+        # DOC_MISMATCH: docs=`tags_ids` (non-nullable `array`), actual=`tag_ids` (`array | null`) — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+        tag_ids:
+          type:
+          - array
+          - 'null'
+          items:
+            type: integer
+          description: Array of card tags ids
+        has_access_to_space:
+          type: boolean
+          description: Flag indicating that user who made request has access to space
+        path_data:
+          type: object
+          description: Card path info (space, board, column, lane, etc)
+          properties:
+            lane:
+              type: object
+              additionalProperties: true
+              description: Card lane info
+            board:
+              type: object
+              additionalProperties: true
+              description: Card board info
+            space:
+              type: object
+              additionalProperties: true
+              description: Card space info
+            column:
+              type: object
+              additionalProperties: true
+              description: Card column info
+            # DOC_MISMATCH: docs=non-nullable `object`, absent from actual API responses when the card is not in a subcolumn — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+            subcolumn:
+              type: object
+              additionalProperties: true
+              description: Card subcolumn info
+        space_id:
+          type: integer
+          description: Space id
+        # DOC_MISMATCH: not in docs, present in actual API responses (`number`) — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+        sort_order:
+          type: number
+          description: Sort order in column
+        # DOC_MISMATCH: not in docs, present in actual API responses (`array | null`) — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+        parent_link_ids:
+          type:
+          - array
+          - 'null'
+          items:
+            type: integer
+          description: Parent link ids
+        # DOC_MISMATCH: not in docs, present in actual API responses (`integer | null`) — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+        milestone_id:
+          type:
+          - integer
+          - 'null'
+          description: Milestone id
+        # DOC_MISMATCH: not in docs, present in actual API responses (`string | null`) — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+        sd_external_recipients:
+          type:
+          - string
+          - 'null'
+          description: Service desk external recipients
+        # DOC_MISMATCH: not in docs, present in actual API responses (`integer`) — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+        estimate_workload:
+          type: integer
+          description: Estimated workload
+        # DOC_MISMATCH: not in docs, present in actual API responses (`boolean`) — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+        has_blocked_children:
+          type: boolean
+          description: Whether card has blocked children
+        # DOC_MISMATCH: not in docs, present in actual API responses (`string | null`) — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+        calculated_planned_start:
+          type:
+          - string
+          - 'null'
+          description: Calculated planned start
+        # DOC_MISMATCH: not in docs, present in actual API responses (`string | null`) — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+        calculated_planned_end:
+          type:
+          - string
+          - 'null'
+          description: Calculated planned end
+        # DOC_MISMATCH: not in docs, present in actual API responses (`string`) — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+        fts_version:
+          type: string
+          description: Full-text search version
+        # DOC_MISMATCH: not in docs, present in actual API responses (`string`) — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+        uid:
+          type: string
+          description: Card UID
+        # DOC_MISMATCH: not in docs, present in actual API responses (`string | null`) — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+        locked:
+          type:
+          - string
+          - 'null'
+          description: Lock status
+        # DOC_MISMATCH: not in docs, present in actual API responses (`string | null`) — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+        source:
+          type:
+          - string
+          - 'null'
+          description: Card source
+        # DOC_MISMATCH: not in docs, present in actual API responses (`string`) — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+        card_tag_fts_version:
+          type: string
+          description: Card tags full-text search version
+        # DOC_MISMATCH: not in docs, present in actual API responses (`string`) — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+        card_cp_value_fts_version:
+          type: string
+          description: Card custom property values full-text search version
+        # DOC_MISMATCH: not in docs, present in actual API responses (`string | null`) — https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist
+        key:
+          type:
+          - string
+          - 'null'
+          description: Card key

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -256,6 +256,11 @@ let sections: [Section] = [
     Operation(name: "remove_card_blocker_user", errors: [.unauthorized]),
     Operation(name: "retrieve_current_user_blockers", errors: [.unauthorized]),
   ]),
+  Section(mark: "Checklist Cards", operations: [
+    Operation(
+      name: "retrieve_cards_with_checklist",
+      errors: [.badRequest, .unauthorized, .forbidden, .notFound]),
+  ]),
 ]
 
 // MARK: - Generator


### PR DESCRIPTION
## Endpoints

- [x] `GET /checklists/{id}` — Retrieve cards with checklist ([docs](https://developers.kaiten.ru/checklists/retrieve-cards-with-checklist))

## What was done

- `openapi/kaiten.yaml`: `/checklists/{id}` path with the required `only_shared_cards` query parameter, and a new `ChecklistCard` schema built from the documentation field-by-field.
- SDK: `KaitenClient.listCardsWithChecklist(checklistId:onlySharedCards:)` in `KaitenClient+Checklists.swift`, DocC comments on the public method.
- CLI: `list-checklist-cards` subcommand (`Sources/kaiten/Checklists/ChecklistsCommands.swift`), registered in `Kaiten.swift`.
- README: API Reference row and CLI note in the Checklists section.
- Tests: `ChecklistCardsTests` — 200 with a sanitized live fixture, 200 empty body, 400, 401, 403 and 404 paths (6 tests).

## Live verification

The endpoint was fetched live (read-only GET) with both `only_shared_cards=true` and `false`, and the built CLI was run against the live API to confirm the generated schema decodes a real response. Omitting `only_shared_cards` is rejected with 400, confirming it is required.

## DOC_MISMATCH annotations (21)

- `only_shared_cards`: documented as a required boolean with no description; no filtering effect observed — a card that is neither public nor shared is returned with either value.
- `fifo_order`, `sprint_id`, `service_id`: documented non-nullable, actually nullable.
- `tags_ids`: documented name is `tags_ids` (non-nullable array); the API returns `tag_ids` (`array | null`).
- `path_data.subcolumn`: documented as a non-nullable object, absent when the card is not in a subcolumn.
- 15 fields present in live responses but not in the docs: `sort_order`, `parent_link_ids`, `milestone_id`, `sd_external_recipients`, `estimate_workload`, `has_blocked_children`, `calculated_planned_start`, `calculated_planned_end`, `fts_version`, `uid`, `locked`, `source`, `card_tag_fts_version`, `card_cp_value_fts_version`, `key`.

## Checks

- `swift format lint --strict --recursive Sources/ Tests/` clean
- `swift test`: 393 tests in 81 suites, all passing (includes `OpenAPISpecIntegrityTests`)

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)
