### PR TITLE
feat(custom-directories): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,46 @@ for event in page.items {
 CLI: `kaiten list-audit-logs` with `--from`, `--to`, `--author-id`,
 `--author-uid`, `--categories`, `--actions`, `--id`, `--offset`, `--limit`.
 
+### Custom Directories
+
+| Method | Description |
+|--------|-------------|
+| `listCustomDirectories(includeFields:includeAuthor:includeRecordsCount:query:conditions:offset:limit:)` | List custom directories in the company |
+| `createCustomDirectory(name:description:multiSelect:allowEditing:displayFieldIndex:fields:)` | Create a custom directory |
+| `getCustomDirectory(directoryId:)` | Get a custom directory |
+| `updateCustomDirectory(directoryId:name:description:condition:multiSelect:allowEditing:fields:)` | Update a custom directory |
+| `deleteCustomDirectory(directoryId:)` | Delete a custom directory (soft delete, condition becomes `removed`) |
+
+The custom-directories API is documented as beta: parameters, attributes and
+response formats are subject to change. Directory and field conditions and
+field types are exposed as Swift enums (`CustomDirectoryCondition`,
+`CustomDirectoryFieldType`), each with an `unknown(String)` case that preserves
+values the documentation does not list.
+
+```swift
+let directory = try await client.createCustomDirectory(
+  name: "Contacts",
+  fields: [
+    .init(fieldType: .string, name: "Name", required: true),
+    .init(fieldType: .email, name: "Email"),
+  ]
+)
+
+let page = try await client.listCustomDirectories(conditions: [.active, .inactive])
+for directory in page.items {
+  print(directory.name ?? "")
+}
+```
+
+CLI: `list-custom-directories` with `--include-fields`, `--include-author`,
+`--include-records-count`, `--query`, `--conditions`, `--offset`, `--limit`;
+`create-custom-directory --name <name>` with `--description`, `--multi-select`,
+`--allow-editing`, `--display-field-index`, `--fields <json>`;
+`get-custom-directory --directory-id <id>`;
+`update-custom-directory --directory-id <id>` with `--name`, `--description`,
+`--clear-description`, `--condition`, `--multi-select`, `--allow-editing`,
+`--fields <json>`; `delete-custom-directory --directory-id <id>`.
+
 ## Pagination
 
 Most list endpoints accept `offset` and `limit` parameters and return a `Page<T>`:

--- a/Sources/KaitenSDK/Enums.swift
+++ b/Sources/KaitenSDK/Enums.swift
@@ -1518,3 +1518,140 @@ public enum CustomPropertyValuesType: Sendable, Equatable, CaseIterable, Codable
     try container.encode(rawValue)
   }
 }
+
+// MARK: - Custom Directories
+//
+// Custom directory discriminators are declared as plain strings in the OpenAPI
+// spec: the custom-directories API is documented as beta and subject to change,
+// and a generated closed enum would fail the entire response on the first value
+// the documentation does not list. The typed surface lives here instead — with
+// an `unknown(String)` case that preserves anything new the API adds.
+
+/// Custom directory (and directory field) condition.
+/// - SeeAlso: [Kaiten API – Custom directories](https://developers.kaiten.ru/custom-directories/get-list-of-custom-directories)
+public enum CustomDirectoryCondition: Sendable, Equatable, CaseIterable, Codable {
+  /// Directory or field is active.
+  case active
+  /// Directory or field is inactive.
+  case inactive
+  /// Directory or field is soft-deleted.
+  case removed
+  /// Unknown value returned by the API (forward compatibility).
+  case unknown(String)
+
+  public static var allCases: [CustomDirectoryCondition] {
+    [.active, .inactive, .removed]
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "active": self = .active
+    case "inactive": self = .inactive
+    case "removed": self = .removed
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: String {
+    switch self {
+    case .active: "active"
+    case .inactive: "inactive"
+    case .removed: "removed"
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(String.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}
+
+/// Custom directory field type.
+/// - SeeAlso: [Kaiten API – Custom directories](https://developers.kaiten.ru/custom-directories/create-custom-directory)
+public enum CustomDirectoryFieldType: Sendable, Equatable, CaseIterable, Codable {
+  /// Text field.
+  case string
+  /// Numeric field.
+  case number
+  /// Date field.
+  case date
+  /// Email field.
+  case email
+  /// URL field.
+  case url
+  /// Phone number field.
+  case phone
+  /// Checkbox field.
+  case checkbox
+  /// Select field backed by a custom property.
+  case select
+  /// User field backed by a custom property.
+  case user
+  /// Catalog field backed by a custom property.
+  case catalog
+  /// Link to a record of another custom directory.
+  case directoryLink
+  /// File field.
+  case file
+  /// Unknown value returned by the API (forward compatibility).
+  case unknown(String)
+
+  public static var allCases: [CustomDirectoryFieldType] {
+    [
+      .string, .number, .date, .email, .url, .phone, .checkbox, .select, .user, .catalog,
+      .directoryLink, .file,
+    ]
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "string": self = .string
+    case "number": self = .number
+    case "date": self = .date
+    case "email": self = .email
+    case "url": self = .url
+    case "phone": self = .phone
+    case "checkbox": self = .checkbox
+    case "select": self = .select
+    case "user": self = .user
+    case "catalog": self = .catalog
+    case "directory_link": self = .directoryLink
+    case "file": self = .file
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: String {
+    switch self {
+    case .string: "string"
+    case .number: "number"
+    case .date: "date"
+    case .email: "email"
+    case .url: "url"
+    case .phone: "phone"
+    case .checkbox: "checkbox"
+    case .select: "select"
+    case .user: "user"
+    case .catalog: "catalog"
+    case .directoryLink: "directory_link"
+    case .file: "file"
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(String.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}

--- a/Sources/KaitenSDK/KaitenClient+CustomDirectories.swift
+++ b/Sources/KaitenSDK/KaitenClient+CustomDirectories.swift
@@ -1,0 +1,308 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - Typed Discriminators
+
+// Custom directory discriminators travel as plain strings (see the comment
+// above the custom directory enums in `Enums.swift`). These accessors and
+// initializers give the generated payloads a typed surface without losing
+// undocumented values.
+
+extension Components.Schemas.CustomDirectory {
+  /// The directory condition, or `nil` if the API omitted the field.
+  public var directoryCondition: CustomDirectoryCondition? {
+    condition.map(CustomDirectoryCondition.init(rawValue:))
+  }
+}
+
+extension Components.Schemas.CustomDirectoryField {
+  /// The field type, or `nil` if the API omitted the field.
+  public var fieldType: CustomDirectoryFieldType? {
+    _type.map(CustomDirectoryFieldType.init(rawValue:))
+  }
+
+  /// The field condition, or `nil` if the API omitted the field.
+  public var fieldCondition: CustomDirectoryCondition? {
+    condition.map(CustomDirectoryCondition.init(rawValue:))
+  }
+}
+
+extension Components.Schemas.DeleteCustomDirectoryResponse {
+  /// The directory condition after deletion, or `nil` if the API omitted the field.
+  public var directoryCondition: CustomDirectoryCondition? {
+    condition.map(CustomDirectoryCondition.init(rawValue:))
+  }
+}
+
+extension Components.Schemas.CreateCustomDirectoryFieldRequest {
+  /// Creates a field definition from a typed field type.
+  ///
+  /// - Parameters:
+  ///   - fieldType: The field type.
+  ///   - name: The field name.
+  ///   - required: Whether the field is required.
+  ///   - sortOrder: The field position.
+  ///   - customPropertyUid: The custom property UID. Required for `select`, `user` and
+  ///     `catalog` fields.
+  ///   - linkedDirectoryId: The linked custom directory ID. Required for `directory_link`
+  ///     fields.
+  public init(
+    fieldType: CustomDirectoryFieldType,
+    name: String,
+    required: Bool? = nil,
+    sortOrder: Int? = nil,
+    customPropertyUid: String? = nil,
+    linkedDirectoryId: String? = nil
+  ) {
+    self.init(
+      name: name,
+      _type: fieldType.rawValue,
+      required: required,
+      sort_order: sortOrder,
+      custom_property_uid: customPropertyUid,
+      linked_directory_id: linkedDirectoryId
+    )
+  }
+}
+
+extension Components.Schemas.UpdateCustomDirectoryFieldRequest {
+  /// Creates a field update from a typed field type.
+  ///
+  /// - Parameters:
+  ///   - id: The field ID. Pass to update an existing field; omit to create a new one.
+  ///   - fieldType: The field type.
+  ///   - name: The field name.
+  ///   - required: Whether the field is required.
+  ///   - isDisplay: Whether the field is the display field. Only one field should have
+  ///     `isDisplay` set to `true`.
+  ///   - sortOrder: The field position.
+  ///   - customPropertyUid: The custom property UID. Required for `select`, `user` and
+  ///     `catalog` fields.
+  ///   - linkedDirectoryId: The linked custom directory ID. Required for `directory_link`
+  ///     fields.
+  public init(
+    id: String? = nil,
+    fieldType: CustomDirectoryFieldType? = nil,
+    name: String? = nil,
+    required: Bool? = nil,
+    isDisplay: Bool? = nil,
+    sortOrder: Int? = nil,
+    customPropertyUid: String? = nil,
+    linkedDirectoryId: String? = nil
+  ) {
+    self.init(
+      id: id,
+      name: name,
+      _type: fieldType?.rawValue,
+      required: required,
+      is_display: isDisplay,
+      sort_order: sortOrder,
+      custom_property_uid: customPropertyUid,
+      linked_directory_id: linkedDirectoryId
+    )
+  }
+}
+
+// MARK: - Custom Directories
+
+extension KaitenClient {
+  /// Returns a page of custom directories for the current company.
+  ///
+  /// The custom-directories API is documented as beta: parameters, attributes and response
+  /// formats are subject to change. Directories whose condition is not `active` are returned
+  /// only when `conditions` names them.
+  ///
+  /// - Parameters:
+  ///   - includeFields: Include directory fields in each directory (optional).
+  ///   - includeAuthor: Include the author user object in each directory (optional).
+  ///   - includeRecordsCount: Include `records_count` in each directory (optional).
+  ///   - query: Search by directory name, case-insensitive (optional).
+  ///   - conditions: Filter by condition values (optional).
+  ///   - offset: Number of directories to skip (default `0`).
+  ///   - limit: Maximum number of directories to return (default `200`, max `200`).
+  /// - Returns: A ``Page`` of custom directories. Returns an empty page when no directories match.
+  /// - Throws:
+  ///   - ``KaitenError/invalidPaginationRange(offset:limit:)`` if pagination parameters are out of range.
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for forbidden (403) or other
+  ///     undocumented HTTP status codes.
+  public func listCustomDirectories(
+    includeFields: Bool? = nil,
+    includeAuthor: Bool? = nil,
+    includeRecordsCount: Bool? = nil,
+    query: String? = nil,
+    conditions: [CustomDirectoryCondition]? = nil,
+    offset: Int = 0,
+    limit: Int = 200
+  ) async throws(KaitenError) -> Page<Components.Schemas.CustomDirectory> {
+    guard offset >= 0, (1...200).contains(limit) else {
+      throw .invalidPaginationRange(offset: offset, limit: limit)
+    }
+    let query = Operations.list_custom_directories.Input.Query(
+      include_fields: includeFields,
+      include_author: includeAuthor,
+      include_records_count: includeRecordsCount,
+      limit: limit,
+      offset: offset,
+      query: query,
+      conditions_lbrack__rbrack_: conditions.map { $0.map(\.rawValue) }
+    )
+    guard
+      let response = try await callList({
+        try await client.list_custom_directories(query: query)
+      })
+    else {
+      return Page(items: [], offset: offset, limit: limit)
+    }
+    let items: [Components.Schemas.CustomDirectory] = try decodeResponse(response.toCase()) {
+      try $0.json
+    }
+    return Page(items: items, offset: offset, limit: limit)
+  }
+
+  /// Creates a custom directory.
+  ///
+  /// The custom-directories API is documented as beta: parameters, attributes and response
+  /// formats are subject to change.
+  ///
+  /// - Parameters:
+  ///   - name: The directory name.
+  ///   - description: The directory description.
+  ///   - multiSelect: Whether directory records can store multiple values per field.
+  ///   - allowEditing: Whether directory records can be edited from cards without the custom
+  ///     properties permission.
+  ///   - displayFieldIndex: Index of the field to use as the display field. If omitted, the
+  ///     first field is used.
+  ///   - fields: The directory fields definition.
+  /// - Returns: The created directory.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for validation errors (400),
+  ///     forbidden (403) or other undocumented HTTP status codes.
+  public func createCustomDirectory(
+    name: String,
+    description: String? = nil,
+    multiSelect: Bool? = nil,
+    allowEditing: Bool? = nil,
+    displayFieldIndex: Int? = nil,
+    fields: [Components.Schemas.CreateCustomDirectoryFieldRequest]? = nil
+  ) async throws(KaitenError) -> Components.Schemas.CustomDirectory {
+    let response = try await call {
+      try await client.create_custom_directory(
+        body: .json(
+          .init(
+            name: name,
+            description: description,
+            multi_select: multiSelect,
+            allow_editing: allowEditing,
+            display_field_index: displayFieldIndex,
+            fields: fields
+          ))
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Returns a custom directory.
+  ///
+  /// The custom-directories API is documented as beta: parameters, attributes and response
+  /// formats are subject to change.
+  ///
+  /// - Parameter directoryId: The directory ID.
+  /// - Returns: The directory.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for not found (404) or other
+  ///     undocumented HTTP status codes. A 404 is reported as `unexpectedResponse` rather than
+  ///     ``KaitenError/notFound(resource:id:)`` because directories are addressed by string ID.
+  ///     Directories in the `removed` condition also answer 404.
+  public func getCustomDirectory(
+    directoryId: String
+  ) async throws(KaitenError) -> Components.Schemas.CustomDirectory {
+    let response = try await call {
+      try await client.get_custom_directory(path: .init(directory_id: directoryId))
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Updates a custom directory.
+  ///
+  /// The custom-directories API is documented as beta: parameters, attributes and response
+  /// formats are subject to change.
+  ///
+  /// - Parameters:
+  ///   - directoryId: The directory ID.
+  ///   - name: The updated directory name.
+  ///   - description: The updated directory description. Pass `.some(nil)` to clear it;
+  ///     `nil` leaves it unchanged.
+  ///   - condition: The updated directory condition.
+  ///   - multiSelect: Whether directory records can store multiple values per field.
+  ///   - allowEditing: Whether directory records can be edited from cards without the custom
+  ///     properties permission.
+  ///   - fields: The full fields list. Fields omitted from this array are soft-deleted
+  ///     (their condition becomes `removed`).
+  /// - Returns: The updated directory.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for validation errors (400),
+  ///     not found (404) or other undocumented HTTP status codes. A 404 is reported as
+  ///     `unexpectedResponse` rather than ``KaitenError/notFound(resource:id:)`` because
+  ///     directories are addressed by string ID.
+  public func updateCustomDirectory(
+    directoryId: String,
+    name: String? = nil,
+    description: String?? = .none,
+    condition: CustomDirectoryCondition? = nil,
+    multiSelect: Bool? = nil,
+    allowEditing: Bool? = nil,
+    fields: [Components.Schemas.UpdateCustomDirectoryFieldRequest]? = nil
+  ) async throws(KaitenError) -> Components.Schemas.CustomDirectory {
+    let response = try await call {
+      try await client.update_custom_directory(
+        path: .init(directory_id: directoryId),
+        body: .json(
+          .init(
+            name: name,
+            description: description.map { $0.map(ExplicitNullString.value) ?? .null },
+            condition: condition?.rawValue,
+            multi_select: multiSelect,
+            allow_editing: allowEditing,
+            fields: fields
+          ))
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Deletes a custom directory.
+  ///
+  /// The directory is soft-deleted: its condition becomes `removed`. Deletion is not allowed
+  /// while active custom properties are linked to the directory.
+  ///
+  /// - Parameter directoryId: The directory ID.
+  /// - Returns: The deletion result carrying the directory ID and its condition.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for validation errors (400,
+  ///     including deletion blocked by linked custom properties), not found (404) or other
+  ///     undocumented HTTP status codes. A 404 is reported as `unexpectedResponse` rather than
+  ///     ``KaitenError/notFound(resource:id:)`` because directories are addressed by string ID.
+  public func deleteCustomDirectory(
+    directoryId: String
+  ) async throws(KaitenError) -> Components.Schemas.DeleteCustomDirectoryResponse {
+    let response = try await call {
+      try await client.delete_custom_directory(path: .init(directory_id: directoryId))
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -1336,3 +1336,63 @@ extension Operations.retrieve_cards_with_checklist.Output {
     }
   }
 }
+
+// MARK: - Custom Directories
+
+extension Operations.list_custom_directories.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_custom_directories.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.create_custom_directory.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.create_custom_directory.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.get_custom_directory.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_custom_directory.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.update_custom_directory.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.update_custom_directory.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.delete_custom_directory.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.delete_custom_directory.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/CustomDirectories/CustomDirectoryCommands.swift
+++ b/Sources/kaiten/CustomDirectories/CustomDirectoryCommands.swift
@@ -1,0 +1,257 @@
+import ArgumentParser
+import Foundation
+import KaitenSDK
+
+// MARK: - Custom Directories
+
+func parseCustomDirectoryConditions(_ rawValue: String?) throws -> [CustomDirectoryCondition]? {
+  guard let tokens = try parseStringCSV(rawValue, fieldName: "--conditions") else { return nil }
+  return try tokens.map { token in
+    let condition = CustomDirectoryCondition(rawValue: token)
+    guard CustomDirectoryCondition.allCases.contains(condition) else {
+      let allowed = CustomDirectoryCondition.allCases.map(\.rawValue).joined(separator: ", ")
+      throw ValidationError(
+        "Invalid custom directory condition: '\(token)'. Allowed values: \(allowed)")
+    }
+    return condition
+  }
+}
+
+func parseCustomDirectoryCondition(_ rawValue: String?) throws -> CustomDirectoryCondition? {
+  guard let rawValue else { return nil }
+  let condition = CustomDirectoryCondition(rawValue: rawValue)
+  guard CustomDirectoryCondition.allCases.contains(condition) else {
+    let allowed = CustomDirectoryCondition.allCases.map(\.rawValue).joined(separator: ", ")
+    throw ValidationError(
+      "Invalid custom directory condition: '\(rawValue)'. Allowed values: \(allowed)")
+  }
+  return condition
+}
+
+/// Decodes a JSON command-line argument into a generated OpenAPI type.
+///
+/// Malformed JSON fails locally with a validation error — the value is never
+/// silently dropped or forwarded to the SDK.
+func parseCustomDirectoryJSON<T: Decodable>(
+  _ rawValue: String?, as type: T.Type, fieldName: String
+) throws -> T? {
+  guard let rawValue else { return nil }
+  do {
+    return try JSONDecoder().decode(T.self, from: Data(rawValue.utf8))
+  } catch {
+    throw ValidationError("Invalid \(fieldName) JSON: \(error.localizedDescription)")
+  }
+}
+
+// MARK: - List Custom Directories
+
+struct ListCustomDirectories: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-custom-directories",
+    abstract: "List custom directories in the company (paginated)",
+    discussion: """
+      Directories in conditions other than active are returned only when \
+      --conditions names them.
+      """
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Flag(name: .long, help: "Include directory fields in each directory")
+  var includeFields = false
+
+  @Flag(name: .long, help: "Include the author user object in each directory")
+  var includeAuthor = false
+
+  @Flag(name: .long, help: "Include records_count in each directory")
+  var includeRecordsCount = false
+
+  @Option(name: .long, help: "Search by directory name (case-insensitive)")
+  var query: String?
+
+  @Option(name: .long, help: "Comma-separated conditions: active, inactive, removed")
+  var conditions: String?
+
+  @Option(name: .long, help: "Offset for pagination (default: 0)")
+  var offset: Int = 0
+
+  @Option(name: .long, help: "Limit for pagination (default: 200, max: 200)")
+  var limit: Int = 200
+
+  func run() async throws {
+    let parsedConditions = try parseCustomDirectoryConditions(conditions)
+    let client = try await global.makeClient()
+    let page = try await client.listCustomDirectories(
+      includeFields: includeFields ? true : nil,
+      includeAuthor: includeAuthor ? true : nil,
+      includeRecordsCount: includeRecordsCount ? true : nil,
+      query: query,
+      conditions: parsedConditions,
+      offset: offset,
+      limit: limit
+    )
+    try printJSON(page, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Create Custom Directory
+
+struct CreateCustomDirectory: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "create-custom-directory",
+    abstract: "Create a custom directory"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Directory name")
+  var name: String
+
+  @Option(name: .long, help: "Directory description")
+  var description: String?
+
+  @Option(name: .long, help: "Allow multiple values per field in records")
+  var multiSelect: Bool?
+
+  @Option(
+    name: .long, help: "Allow editing records from cards without custom properties permission")
+  var allowEditing: Bool?
+
+  @Option(name: .long, help: "Index of the field to use as a display field")
+  var displayFieldIndex: Int?
+
+  @Option(
+    name: .long,
+    help: "Fields as a JSON array, e.g. '[{\"name\":\"Name\",\"type\":\"string\"}]'")
+  var fields: String?
+
+  func run() async throws {
+    let parsedFields = try parseCustomDirectoryJSON(
+      fields, as: [Components.Schemas.CreateCustomDirectoryFieldRequest].self, fieldName: "fields")
+    let client = try await global.makeClient()
+    let directory = try await client.createCustomDirectory(
+      name: name,
+      description: description,
+      multiSelect: multiSelect,
+      allowEditing: allowEditing,
+      displayFieldIndex: displayFieldIndex,
+      fields: parsedFields
+    )
+    try printJSON(directory, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Get Custom Directory
+
+struct GetCustomDirectory: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "get-custom-directory",
+    abstract: "Get a custom directory"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Directory ID")
+  var directoryId: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let directory = try await client.getCustomDirectory(directoryId: directoryId)
+    try printJSON(directory, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Update Custom Directory
+
+struct UpdateCustomDirectory: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "update-custom-directory",
+    abstract: "Update a custom directory",
+    discussion: """
+      When --fields is provided it must carry the full fields list: fields \
+      omitted from the array are soft-deleted (condition=removed).
+      """
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Directory ID")
+  var directoryId: String
+
+  @Option(name: .long, help: "Directory name")
+  var name: String?
+
+  @Option(name: .long, help: "Directory description")
+  var description: String?
+
+  @Flag(name: .long, help: "Clear the directory description")
+  var clearDescription = false
+
+  @Option(name: .long, help: "Directory condition: active, inactive, removed")
+  var condition: String?
+
+  @Option(name: .long, help: "Allow multiple values per field in records")
+  var multiSelect: Bool?
+
+  @Option(
+    name: .long, help: "Allow editing records from cards without custom properties permission")
+  var allowEditing: Bool?
+
+  @Option(name: .long, help: "Full fields list as a JSON array")
+  var fields: String?
+
+  func validate() throws {
+    if description != nil && clearDescription {
+      throw ValidationError("--description and --clear-description are mutually exclusive")
+    }
+  }
+
+  func run() async throws {
+    let parsedCondition = try parseCustomDirectoryCondition(condition)
+    let parsedFields = try parseCustomDirectoryJSON(
+      fields, as: [Components.Schemas.UpdateCustomDirectoryFieldRequest].self, fieldName: "fields")
+    let descriptionUpdate: String?? =
+      if clearDescription {
+        .some(nil)
+      } else if let description {
+        .some(description)
+      } else {
+        .none
+      }
+    let client = try await global.makeClient()
+    let directory = try await client.updateCustomDirectory(
+      directoryId: directoryId,
+      name: name,
+      description: descriptionUpdate,
+      condition: parsedCondition,
+      multiSelect: multiSelect,
+      allowEditing: allowEditing,
+      fields: parsedFields
+    )
+    try printJSON(directory, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Delete Custom Directory
+
+struct DeleteCustomDirectory: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "delete-custom-directory",
+    abstract: "Delete a custom directory",
+    discussion: """
+      Soft-deletes the directory (condition=removed). Deletion is not allowed \
+      while active custom properties are linked to the directory.
+      """
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Directory ID")
+  var directoryId: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let result = try await client.deleteCustomDirectory(directoryId: directoryId)
+    try printJSON(result, expand: global.expandedFields)
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -114,6 +114,11 @@ struct Kaiten: AsyncParsableCommand {
       RemoveCardBlockerUser.self,
       GetCurrentUserBlockers.self,
       ListChecklistCards.self,
+      ListCustomDirectories.self,
+      CreateCustomDirectory.self,
+      GetCustomDirectory.self,
+      UpdateCustomDirectory.self,
+      DeleteCustomDirectory.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/CustomDirectoriesTests.swift
+++ b/Tests/KaitenSDKTests/CustomDirectoriesTests.swift
@@ -1,0 +1,381 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Custom Directories")
+struct CustomDirectoriesTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// `KaitenError` is not `Equatable`, so the status code is matched by pattern.
+  private func expectUnexpectedResponse(
+    statusCode: Int,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      Issue.record(
+        "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), no error thrown",
+        sourceLocation: sourceLocation)
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == statusCode else {
+        Issue.record(
+          "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), got \(error)",
+          sourceLocation: sourceLocation)
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)", sourceLocation: sourceLocation)
+    }
+  }
+
+  // MARK: - List
+
+  /// Fixture shape matches a sanitized live response: `created`, `updated`, `author_uid` and
+  /// `company_uid` come back even though the list documentation does not mention them, and
+  /// `records_count` and `author` appear because the request asked for them.
+  @Test("200 returns page of CustomDirectory")
+  func listSuccess() async throws {
+    let json = """
+      [{
+        "created": "2023-01-02T03:04:05.678Z",
+        "updated": "2023-01-02T03:04:08.901Z",
+        "id": "d1000000-0000-0000-0000-000000000001",
+        "name": "Contacts",
+        "description": null,
+        "condition": "removed",
+        "settings": {"multi_select": false, "allow_editing": true},
+        "author_uid": "a1000000-0000-0000-0000-000000000001",
+        "company_uid": "c1000000-0000-0000-0000-000000000001",
+        "records_count": 0,
+        "author": {
+          "id": 42,
+          "uid": "a1000000-0000-0000-0000-000000000001",
+          "full_name": "Test User",
+          "email": "user@example.com",
+          "username": "test_user",
+          "avatar_initials_url": "data:image/png;base64,xyz",
+          "avatar_uploaded_url": "https://files.example.com/avatar.jpg",
+          "initials": "TU",
+          "avatar_type": 3,
+          "lng": "en",
+          "timezone": "UTC",
+          "theme": "auto",
+          "created": "2022-01-01T00:00:00.000Z",
+          "updated": "2023-01-01T00:00:00.000Z",
+          "activated": true,
+          "ui_version": 2,
+          "virtual": false,
+          "email_blocked": null,
+          "email_blocked_reason": null,
+          "delete_requested_at": null
+        }
+      }]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let page = try await client.listCustomDirectories(
+      includeAuthor: true,
+      includeRecordsCount: true,
+      conditions: [.active, .removed]
+    )
+    #expect(page.items.count == 1)
+    let directory = try #require(page.items.first)
+    #expect(directory.id == "d1000000-0000-0000-0000-000000000001")
+    #expect(directory.name == "Contacts")
+    #expect(directory.description == nil)
+    #expect(directory.directoryCondition == .removed)
+    #expect(directory.settings?.multi_select == false)
+    #expect(directory.settings?.allow_editing == true)
+    #expect(directory.records_count == 0)
+    #expect(directory.author?.full_name == "Test User")
+  }
+
+  /// Kaiten ignores a single bare `conditions` value, so the client must send the
+  /// bracket form the API actually honors.
+  @Test("conditions serialize with the bracket form")
+  func listConditionsSerialization() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
+    let client = try makeClient(transport)
+
+    _ = try await client.listCustomDirectories(conditions: [.removed])
+
+    let recorded = try #require(transport.recordedRequests.first)
+    let path = try #require(recorded.request.path)
+    #expect(path.contains("conditions%5B%5D=removed") || path.contains("conditions[]=removed"))
+    #expect(recorded.request.method == .get)
+  }
+
+  @Test("200 with empty body returns empty page")
+  func listEmptyBody() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: ""))
+    let page = try await client.listCustomDirectories()
+    #expect(page.items.isEmpty)
+  }
+
+  @Test("invalid pagination throws invalidPaginationRange")
+  func listInvalidPagination() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: "[]"))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCustomDirectories(limit: 201)
+    }
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCustomDirectories(offset: -1)
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func listUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCustomDirectories()
+    }
+  }
+
+  // MARK: - Get
+
+  /// The live API answers 404 for a removed directory, so the fields and author shapes
+  /// come from the documentation.
+  @Test("200 returns CustomDirectory with fields")
+  func getSuccess() async throws {
+    let json = """
+      {
+        "id": "d1000000-0000-0000-0000-000000000001",
+        "name": "Contacts",
+        "description": "Company contacts directory",
+        "condition": "active",
+        "settings": {"multi_select": false, "allow_editing": false},
+        "fields": [{
+          "id": "f1000000-0000-0000-0000-000000000001",
+          "custom_directory_id": "d1000000-0000-0000-0000-000000000001",
+          "name": "Name",
+          "type": "string",
+          "required": true,
+          "is_display": true,
+          "sort_order": 0,
+          "custom_property_uid": null,
+          "linked_directory_id": null,
+          "condition": "active",
+          "created": "2023-01-02T03:04:05.678Z",
+          "updated": "2023-01-02T03:04:05.678Z"
+        }],
+        "author": {"id": 42, "uid": "a1000000-0000-0000-0000-000000000001"}
+      }
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let directory = try await client.getCustomDirectory(
+      directoryId: "d1000000-0000-0000-0000-000000000001")
+
+    #expect(directory.directoryCondition == .active)
+    #expect(directory.description == "Company contacts directory")
+    let field = try #require(directory.fields?.first)
+    #expect(field.fieldType == .string)
+    #expect(field.fieldCondition == .active)
+    #expect(field.required == true)
+    #expect(field.is_display == true)
+    #expect(field.custom_property_uid == nil)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    #expect(
+      recorded.request.path == "/company/custom-directories/d1000000-0000-0000-0000-000000000001")
+  }
+
+  /// Directories are addressed by string ID, which ``KaitenError/notFound(resource:id:)``
+  /// cannot represent, so a 404 surfaces as `unexpectedResponse`.
+  @Test("get 404 throws unexpectedResponse")
+  func getNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await expectUnexpectedResponse(statusCode: 404) {
+      _ = try await client.getCustomDirectory(directoryId: "missing")
+    }
+  }
+
+  /// Undocumented discriminator values must survive as `.unknown` instead of failing
+  /// the whole response — the custom-directories API is documented as beta.
+  @Test("undocumented discriminators decode as unknown")
+  func undocumentedDiscriminators() async throws {
+    let json = """
+      {
+        "id": "d1",
+        "condition": "some_new_condition",
+        "fields": [{"id": "f1", "type": "some_new_type", "condition": "another_condition"}]
+      }
+      """
+    let client = try makeClient(.returning(statusCode: 200, body: json))
+
+    let directory = try await client.getCustomDirectory(directoryId: "d1")
+    #expect(directory.directoryCondition == .unknown("some_new_condition"))
+    #expect(directory.fields?.first?.fieldType == .unknown("some_new_type"))
+    #expect(directory.fields?.first?.fieldCondition == .unknown("another_condition"))
+  }
+
+  // MARK: - Create
+
+  /// Response fixture follows the create documentation, which declares `author_uid`,
+  /// `company_uid`, `created`, `updated` and `fields` on the created directory.
+  @Test("create sends name and fields in the body")
+  func createSendsBody() async throws {
+    let json = """
+      {
+        "id": "d2000000-0000-0000-0000-000000000002",
+        "name": "Contacts",
+        "description": "Company contacts directory",
+        "condition": "active",
+        "settings": {"multi_select": false, "allow_editing": false},
+        "author_uid": "a1000000-0000-0000-0000-000000000001",
+        "company_uid": "c1000000-0000-0000-0000-000000000001",
+        "created": "2023-01-02T03:04:05.678Z",
+        "updated": "2023-01-02T03:04:05.678Z",
+        "fields": [{
+          "id": "f1000000-0000-0000-0000-000000000001",
+          "custom_directory_id": "d2000000-0000-0000-0000-000000000002",
+          "name": "Name",
+          "type": "string",
+          "required": true,
+          "is_display": true,
+          "sort_order": 0,
+          "custom_property_uid": null,
+          "linked_directory_id": null,
+          "condition": "active",
+          "created": "2023-01-02T03:04:05.678Z",
+          "updated": "2023-01-02T03:04:05.678Z"
+        }]
+      }
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let directory = try await client.createCustomDirectory(
+      name: "Contacts",
+      description: "Company contacts directory",
+      fields: [
+        .init(fieldType: .string, name: "Name", required: true),
+        .init(fieldType: .email, name: "Email"),
+      ]
+    )
+
+    #expect(directory.id == "d2000000-0000-0000-0000-000000000002")
+    #expect(directory.directoryCondition == .active)
+    #expect(directory.author_uid == "a1000000-0000-0000-0000-000000000001")
+    #expect(directory.fields?.first?.fieldType == .string)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .post)
+    #expect(recorded.request.path == "/company/custom-directories")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["name"] as? String == "Contacts")
+    let sentFields = try #require(sent["fields"] as? [[String: Any]])
+    #expect(sentFields.count == 2)
+    #expect(sentFields.first?["type"] as? String == "string")
+    #expect(sentFields.first?["required"] as? Bool == true)
+    #expect(sentFields.last?["type"] as? String == "email")
+  }
+
+  @Test("create 400 throws unexpectedResponse")
+  func createBadRequest() async throws {
+    let client = try makeClient(.returning(statusCode: 400))
+    await expectUnexpectedResponse(statusCode: 400) {
+      _ = try await client.createCustomDirectory(name: "")
+    }
+  }
+
+  // MARK: - Update
+
+  @Test("update targets the directory ID and clears description with explicit null")
+  func updateSuccess() async throws {
+    let json = """
+      {
+        "id": "d1000000-0000-0000-0000-000000000001",
+        "name": "Renamed",
+        "description": null,
+        "condition": "inactive",
+        "settings": {"multi_select": true, "allow_editing": false}
+      }
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let directory = try await client.updateCustomDirectory(
+      directoryId: "d1000000-0000-0000-0000-000000000001",
+      name: "Renamed",
+      description: .some(nil),
+      condition: .inactive,
+      multiSelect: true
+    )
+
+    #expect(directory.name == "Renamed")
+    #expect(directory.directoryCondition == .inactive)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .patch)
+    #expect(
+      recorded.request.path == "/company/custom-directories/d1000000-0000-0000-0000-000000000001")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["name"] as? String == "Renamed")
+    #expect(sent["condition"] as? String == "inactive")
+    #expect(sent["multi_select"] as? Bool == true)
+    // `.some(nil)` must reach the server as an explicit JSON null, not an absent key.
+    #expect(sent.keys.contains("description"))
+    #expect(sent["description"] is NSNull)
+  }
+
+  @Test("update 404 throws unexpectedResponse")
+  func updateNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await expectUnexpectedResponse(statusCode: 404) {
+      _ = try await client.updateCustomDirectory(directoryId: "missing", name: "Renamed")
+    }
+  }
+
+  // MARK: - Delete
+
+  @Test("delete returns the removed directory ID and condition")
+  func deleteSuccess() async throws {
+    let json = """
+      {"id": "d1000000-0000-0000-0000-000000000001", "condition": "removed"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let result = try await client.deleteCustomDirectory(
+      directoryId: "d1000000-0000-0000-0000-000000000001")
+
+    #expect(result.id == "d1000000-0000-0000-0000-000000000001")
+    #expect(result.directoryCondition == .removed)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .delete)
+    #expect(
+      recorded.request.path == "/company/custom-directories/d1000000-0000-0000-0000-000000000001")
+  }
+
+  /// Deletion is not allowed while active custom properties are linked to the directory —
+  /// the API answers 400.
+  @Test("delete 400 throws unexpectedResponse")
+  func deleteBadRequest() async throws {
+    let client = try makeClient(.returning(statusCode: 400))
+    await expectUnexpectedResponse(statusCode: 400) {
+      _ = try await client.deleteCustomDirectory(directoryId: "d1")
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -3444,6 +3444,158 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /company/custom-directories:
+    get:
+      summary: Get list of custom directories
+      operationId: list_custom_directories
+      parameters:
+      - name: include_fields
+        in: query
+        schema:
+          type: boolean
+        description: Include directory fields in each directory
+      - name: include_author
+        in: query
+        schema:
+          type: boolean
+        description: Include the author user object in each directory
+      - name: include_records_count
+        in: query
+        schema:
+          type: boolean
+        description: Include records_count in each directory
+      - name: limit
+        in: query
+        schema:
+          type: integer
+        description: 'Maximum number of directories to return. Default: 200, max: 200'
+      - name: offset
+        in: query
+        schema:
+          type: integer
+        description: Number of directories to skip
+      - name: query
+        in: query
+        schema:
+          type: string
+        description: Search by directory name (case-insensitive)
+      # DOC_MISMATCH: docs=`conditions` array of strings, actual requires the bracket form `conditions[]` — a single bare `conditions` value is silently ignored and the default filter applies — https://developers.kaiten.ru/custom-directories/get-list-of-custom-directories
+      - name: conditions[]
+        in: query
+        schema:
+          type: array
+          items:
+            type: string
+        description: 'Filter by condition values. Documented values: active, inactive, removed. Default: active'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CustomDirectory'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+    post:
+      summary: Create custom directory
+      operationId: create_custom_directory
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCustomDirectoryRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomDirectory'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+  /company/custom-directories/{directory_id}:
+    get:
+      summary: Get custom directory
+      operationId: get_custom_directory
+      parameters:
+      - name: directory_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Directory ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomDirectory'
+        '401':
+          description: Invalid token
+        '404':
+          description: Not found
+    patch:
+      summary: Update custom directory
+      operationId: update_custom_directory
+      parameters:
+      - name: directory_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Directory ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateCustomDirectoryRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomDirectory'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '404':
+          description: Not found
+    delete:
+      summary: Delete custom directory
+      operationId: delete_custom_directory
+      parameters:
+      - name: directory_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Directory ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteCustomDirectoryResponse'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '404':
+          description: Not found
 components:
   securitySchemes:
     bearerAuth:
@@ -7784,3 +7936,234 @@ components:
           - string
           - 'null'
           description: Card key
+    CustomDirectory:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Directory ID (UUID)
+        name:
+          type: string
+          description: Directory name
+        description:
+          type:
+          - string
+          - 'null'
+          description: Directory description
+        condition:
+          type: string
+          description: 'Directory condition. Documented values: active, inactive, removed. Map to the CustomDirectoryCondition Swift enum, which preserves unknown values.'
+        settings:
+          $ref: '#/components/schemas/CustomDirectorySettings'
+          description: Directory settings
+        # DOC_MISMATCH: not in list/get docs (documented only for the create response), present in actual list responses — https://developers.kaiten.ru/custom-directories/get-list-of-custom-directories
+        author_uid:
+          type: string
+          description: Author user UID (UUID)
+        # DOC_MISMATCH: not in list/get docs (documented only for the create response), present in actual list responses — https://developers.kaiten.ru/custom-directories/get-list-of-custom-directories
+        company_uid:
+          type: string
+          description: Company UID (UUID)
+        # DOC_MISMATCH: not in list/get docs (documented only for the create response), present in actual list responses — https://developers.kaiten.ru/custom-directories/get-list-of-custom-directories
+        created:
+          type: string
+          description: Create date
+        # DOC_MISMATCH: not in list/get docs (documented only for the create response), present in actual list responses — https://developers.kaiten.ru/custom-directories/get-list-of-custom-directories
+        updated:
+          type: string
+          description: Last update timestamp
+        records_count:
+          type: integer
+          description: Records count. Present only when the list is requested with include_records_count
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/CustomDirectoryField'
+          description: Directory fields. Present in create and get responses, and in list responses requested with include_fields
+        author:
+          $ref: '#/components/schemas/User'
+          description: Author user object. Present in get responses, and in list responses requested with include_author
+    CustomDirectorySettings:
+      type: object
+      properties:
+        multi_select:
+          type: boolean
+          description: Allow multiple values per field in records
+        allow_editing:
+          type: boolean
+          description: Allow editing records from cards without custom properties permission
+    CustomDirectoryField:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Field ID (UUID)
+        custom_directory_id:
+          type: string
+          description: Directory ID (UUID)
+        name:
+          type: string
+          description: Field name
+        type:
+          type: string
+          description: 'Field type. Documented values: string, number, date, email, url, phone, checkbox, select, user, catalog, directory_link, file. Map to the CustomDirectoryFieldType Swift enum, which preserves unknown values.'
+        required:
+          type: boolean
+          description: Required flag
+        is_display:
+          type: boolean
+          description: Display field flag
+        sort_order:
+          type: integer
+          description: Field position
+        custom_property_uid:
+          type:
+          - string
+          - 'null'
+          description: Custom property UID (for select/user/catalog fields)
+        linked_directory_id:
+          type:
+          - string
+          - 'null'
+          description: Linked directory ID (for directory_link fields)
+        condition:
+          type: string
+          description: 'Field condition. Documented values: active, inactive, removed. Map to the CustomDirectoryCondition Swift enum, which preserves unknown values.'
+        created:
+          type: string
+          description: Create date
+        updated:
+          type: string
+          description: Last update timestamp
+    CreateCustomDirectoryRequest:
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Custom directory name
+        description:
+          type:
+          - string
+          - 'null'
+          description: Custom directory description
+        multi_select:
+          type: boolean
+          default: false
+          description: When enabled, directory records can store multiple values per field
+        allow_editing:
+          type: boolean
+          default: false
+          description: When enabled, directory records can be edited from cards without custom properties permission
+        display_field_index:
+          type: integer
+          minimum: 0
+          description: Index of the field to use as a display field. If omitted, the first field is used
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreateCustomDirectoryFieldRequest'
+          description: Directory fields definition
+    CreateCustomDirectoryFieldRequest:
+      type: object
+      required:
+      - name
+      - type
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Field name
+        type:
+          type: string
+          description: 'Field type. Documented values: string, number, date, email, url, phone, checkbox, select, user, catalog, directory_link, file.'
+        required:
+          type: boolean
+          default: false
+          description: Required field flag
+        sort_order:
+          type: integer
+          minimum: 0
+          description: Field position
+        custom_property_uid:
+          type:
+          - string
+          - 'null'
+          description: Custom property UID (required for select/user/catalog fields)
+        linked_directory_id:
+          type:
+          - string
+          - 'null'
+          description: Linked custom directory ID (required for directory_link fields)
+    UpdateCustomDirectoryRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Custom directory name
+        description:
+          $ref: '#/components/schemas/NullableString'
+          description: Custom directory description. Send null to clear
+        condition:
+          type: string
+          description: 'Custom directory condition. Documented values: active, inactive, removed.'
+        multi_select:
+          type: boolean
+          description: When enabled, directory records can store multiple values per field
+        allow_editing:
+          type: boolean
+          description: When enabled, directory records can be edited from cards without custom properties permission
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/UpdateCustomDirectoryFieldRequest'
+          description: Full fields list. Fields omitted from this array are soft-deleted (condition=removed)
+    UpdateCustomDirectoryFieldRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Field ID (for updating an existing field)
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Field name
+        type:
+          type: string
+          description: 'Field type. Documented values: string, number, date, email, url, phone, checkbox, select, user, catalog, directory_link, file.'
+        required:
+          type: boolean
+          description: Required field flag
+        is_display:
+          type: boolean
+          description: Display field flag (only one field should have is_display=true)
+        sort_order:
+          type: integer
+          minimum: 0
+          description: Field position
+        custom_property_uid:
+          type:
+          - string
+          - 'null'
+          description: Custom property UID (required for select/user/catalog fields)
+        linked_directory_id:
+          type:
+          - string
+          - 'null'
+          description: Linked custom directory ID (required for directory_link fields)
+    DeleteCustomDirectoryResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Directory ID (UUID)
+        condition:
+          type: string
+          description: 'Directory condition after deletion. Documented value: removed. Map to the CustomDirectoryCondition Swift enum, which preserves unknown values.'

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -267,6 +267,16 @@ let sections: [Section] = [
       name: "retrieve_cards_with_checklist",
       errors: [.badRequest, .unauthorized, .forbidden, .notFound]),
   ]),
+  Section(mark: "Custom Directories", operations: [
+    Operation(name: "list_custom_directories", errors: [.unauthorized, .forbidden]),
+    Operation(
+      name: "create_custom_directory", errors: [.badRequest, .unauthorized, .forbidden]),
+    Operation(name: "get_custom_directory", errors: [.unauthorized, .notFound]),
+    Operation(
+      name: "update_custom_directory", errors: [.badRequest, .unauthorized, .notFound]),
+    Operation(
+      name: "delete_custom_directory", errors: [.badRequest, .unauthorized, .notFound]),
+  ]),
 ]
 
 // MARK: - Generator


### PR DESCRIPTION
Adds the 5 `custom-directories` endpoints to the OpenAPI spec, SDK and CLI.

## Endpoints

- [x] `GET /company/custom-directories` — `listCustomDirectories` / `list-custom-directories`
- [x] `POST /company/custom-directories` — `createCustomDirectory` / `create-custom-directory`
- [x] `GET /company/custom-directories/{directory_id}` — `getCustomDirectory` / `get-custom-directory`
- [x] `PATCH /company/custom-directories/{directory_id}` — `updateCustomDirectory` / `update-custom-directory`
- [x] `DELETE /company/custom-directories/{directory_id}` — `deleteCustomDirectory` / `delete-custom-directory`

## Live verification

- **List** — verified against the live API. The company has one directory (in the `removed` condition), fetched with every include flag and all condition filters; the list test fixture is that response, sanitized. Two behaviours surfaced that the docs do not state:
  - `created`, `updated`, `author_uid`, `company_uid` come back in list responses although the list docs do not mention them (they are documented only for the create response).
  - The `conditions` filter only works in array form: a single bare `conditions=x` pair is silently ignored and the default filter applies. Repeated pairs and the bracket form both work, so the spec declares the parameter as `conditions[]`, which serializes correctly for one value and for many. A dedicated test pins the serialization.
  - `fields` did not appear even with `include_fields=true`; the only available directory is `removed`, so this could not be attributed conclusively and is not annotated. The property stays optional per docs.
- **Get** — requested live; the API answered 404 for the removed directory, which also pinned the documented 404 error body (`message`, `code`). The 200 fixture follows the docs.
- **Create / Update / Delete** — mutating; schema strictly from docs, fixtures from the docs' example response shapes. No mutating request was sent to the live instance.

## DOC_MISMATCH annotations (5)

- `conditions[]` query parameter (bracket form required) — list endpoint.
- `CustomDirectory.author_uid`, `company_uid`, `created`, `updated` — present in actual list responses, absent from list/get docs.

## Notes

- Directory/field `condition` and field `type` are plain `string` in the spec with hand-written `CustomDirectoryCondition` and `CustomDirectoryFieldType` enums carrying `unknown(String)` (FR-020a) — the API is documented as beta, so closed enums would be fragile.
- `author` reuses the existing `User` schema — the live author object matches it field for field.
- `updateCustomDirectory` supports clearing the description through the existing `NullableString`/`ExplicitNullString` mechanism (`--clear-description` in the CLI).
- All documented query parameters are exposed (FR-010); the list wrapper returns `Page` and validates `offset`/`limit` like other paginated endpoints.
- README API Reference and CLI docs updated; `swift format lint --strict` clean; full `swift test` green.

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)
