### PR TITLE
feat(company-users): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,23 @@ CLI: `create-custom-property --name <name> [--type <type>] ...`,
 | `getCurrentUser()` | Get the current user |
 | `getCurrentUserBlockers()` | Get cards blocked on the current user (see [Card Blocker Users](#card-blocker-users)) |
 
+### Company Users
+
+| Method | Description |
+|--------|-------------|
+| `listCompanyUsers(invitesOnly:withTransferAccessStatus:forMembersSection:ownerOnly:onlyPaid:onlyRecordsCount:onlyVirtual:offset:limit:query:accessTypePermissions:sdAccessType:takeLicence:temporarilyInactiveStatus:groupIds:permissions:)` | List company users |
+| `updateCompanyUser(id:appsPermissions:temporarilyInactive:)` | Update a company user |
+| `removeVirtualUser(id:)` | Remove a virtual user |
+
+Listing and updating require an API token of a user with access to the
+administrative section "Members"; removing a virtual user requires access to
+the administrative section "Resource planning". Without that access the API
+returns 403.
+
+CLI: `kaiten list-company-users` (with the same filters as the SDK method),
+`kaiten update-company-user` with `--id`, `--apps-permissions`,
+`--temporarily-inactive`, and `kaiten remove-virtual-user` with `--id`.
+
 ### Card Types & Sprints
 
 | Method | Description |

--- a/Sources/KaitenSDK/KaitenClient+CompanyUsers.swift
+++ b/Sources/KaitenSDK/KaitenClient+CompanyUsers.swift
@@ -1,0 +1,151 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - Company Users
+
+extension KaitenClient {
+  /// Lists company users filtered by query parameters.
+  ///
+  /// Requires an API token of a user with access to the administrative section "Members".
+  ///
+  /// - Parameters:
+  ///   - invitesOnly: Return only invites.
+  ///   - withTransferAccessStatus: Add data about the user rights transfer process.
+  ///   - forMembersSection: Return users for the "Members" administrative section,
+  ///     paginated with `limit` and `offset`.
+  ///   - ownerOnly: Return the company owner.
+  ///   - onlyPaid: Return only users with paid access.
+  ///   - onlyRecordsCount: Return only the number of users. Works only together with
+  ///     `forMembersSection` or `onlyVirtual`. The count-only response shape is not described
+  ///     in the Kaiten documentation and is not modelled, so the call throws
+  ///     ``KaitenError/decodingError(underlying:)``.
+  ///   - onlyVirtual: Return only virtual users, paginated with `limit` and `offset`.
+  ///   - offset: Number of records to skip.
+  ///   - limit: Maximum amount of users in the response (default 100, max 100).
+  ///   - query: Filter by email and full name. Works only with `forMembersSection`.
+  ///   - accessTypePermissions: Filter by access to Kaiten. Works only with `forMembersSection`.
+  ///   - sdAccessType: Filter by access to Service Desk. Works only with `forMembersSection`.
+  ///   - takeLicence: Filter by users consuming the license. Works only with `forMembersSection`.
+  ///   - temporarilyInactiveStatus: Filter by temporarily inactive users. Works only with
+  ///     `forMembersSection`.
+  ///   - groupIds: Filter by group IDs. Works only with `forMembersSection`.
+  ///   - permissions: Filter by access granted to users. Works only with `forMembersSection`.
+  /// - Returns: An array of company users. Returns an empty array when the response body is empty.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for forbidden (403, the token
+  ///     lacks access to the "Members" administrative section), not found (404) or other
+  ///     undocumented HTTP status codes.
+  public func listCompanyUsers(
+    invitesOnly: Bool? = nil,
+    withTransferAccessStatus: Bool? = nil,
+    forMembersSection: Bool? = nil,
+    ownerOnly: Bool? = nil,
+    onlyPaid: Bool? = nil,
+    onlyRecordsCount: Bool? = nil,
+    onlyVirtual: Bool? = nil,
+    offset: Int? = nil,
+    limit: Int? = nil,
+    query: String? = nil,
+    accessTypePermissions: String? = nil,
+    sdAccessType: String? = nil,
+    takeLicence: String? = nil,
+    temporarilyInactiveStatus: String? = nil,
+    groupIds: [Int]? = nil,
+    permissions: [Int]? = nil
+  ) async throws(KaitenError) -> [Components.Schemas.CompanyUser] {
+    guard
+      let response = try await callList({
+        try await client.get_company_users(
+          query: .init(
+            invitesOnly: invitesOnly,
+            withTransferAccessStatus: withTransferAccessStatus,
+            for_members_section: forMembersSection,
+            owner_only: ownerOnly,
+            only_paid: onlyPaid,
+            only_records_count: onlyRecordsCount,
+            only_virtual: onlyVirtual,
+            offset: offset,
+            limit: limit,
+            query: query,
+            access_type_permissions: accessTypePermissions,
+            sd_access_type: sdAccessType,
+            take_licence: takeLicence,
+            temporarily_inactive_status: temporarilyInactiveStatus,
+            group_ids: groupIds,
+            permissions: permissions
+          )
+        )
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Updates a company user.
+  ///
+  /// Requires an API token of a user with access to the administrative section "Members".
+  ///
+  /// - Parameters:
+  ///   - id: The user identifier.
+  ///   - appsPermissions: User access. Documented values: 0 — no access; 1 — full access to
+  ///     Kaiten, access to service desk denied; 2 — guest access to Kaiten, access to service
+  ///     desk denied; 4 — access only to service desk; 5 — full access to Kaiten and service
+  ///     desk; 6 — guest access to Kaiten, access to service desk.
+  ///   - temporarilyInactive: Temporarily inactive: the user stays in the company but cannot
+  ///     sign in and does not need a license.
+  /// - Returns: The updated company user.
+  /// - Throws:
+  ///   - ``KaitenError/notFound(resource:id:)`` if the user does not exist.
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for validation errors (400),
+  ///     forbidden (403) or other undocumented HTTP status codes.
+  public func updateCompanyUser(
+    id: Int,
+    appsPermissions: Int? = nil,
+    temporarilyInactive: Bool? = nil
+  ) async throws(KaitenError) -> Components.Schemas.CompanyUser {
+    let response = try await call {
+      try await client.update_company_user(
+        path: .init(id: id),
+        body: .json(
+          .init(
+            apps_permissions: appsPermissions,
+            temporarily_inactive: temporarilyInactive
+          ))
+      )
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("user", id)) {
+      try $0.json
+    }
+  }
+
+  /// Removes a virtual user.
+  ///
+  /// Requires an API token of a user with access to the administrative section
+  /// "Resource planning".
+  ///
+  /// - Parameter id: The user identifier.
+  /// - Returns: The removed user's identifier.
+  /// - Throws:
+  ///   - ``KaitenError/notFound(resource:id:)`` if the user does not exist.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for forbidden (403) or other
+  ///     undocumented HTTP status codes, including unauthorized (401), which the documentation
+  ///     does not list for this endpoint.
+  public func removeVirtualUser(id: Int) async throws(KaitenError) -> Int {
+    let response = try await call {
+      try await client.remove_virtual_user(path: .init(id: id))
+    }
+    let result: Components.Schemas.DeletedCompanyUserResponse = try decodeResponse(
+      response.toCase(), notFoundResource: ("user", id)
+    ) { try $0.json }
+    return result.id
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -1396,3 +1396,41 @@ extension Operations.delete_custom_directory.Output {
     }
   }
 }
+
+// MARK: - Company Users
+
+extension Operations.get_company_users.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_company_users.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.update_company_user.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.update_company_user.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.remove_virtual_user.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.remove_virtual_user.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/CompanyUsers/CompanyUserCommands.swift
+++ b/Sources/kaiten/CompanyUsers/CompanyUserCommands.swift
@@ -1,0 +1,174 @@
+import ArgumentParser
+import KaitenSDK
+
+// MARK: - List Company Users
+
+struct ListCompanyUsers: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-company-users",
+    abstract: "List company users",
+    discussion: """
+      Requires an API token of a user with access to the administrative section "Members"; \
+      without it the API returns 403.
+      """
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Flag(name: .long, help: "Return only invites")
+  var invitesOnly: Bool = false
+
+  @Flag(name: .long, help: "Add data about the user rights transfer process")
+  var withTransferAccessStatus: Bool = false
+
+  @Flag(
+    name: .long,
+    help: "Return users for the \"Members\" administrative section, paginated with --limit/--offset"
+  )
+  var forMembersSection: Bool = false
+
+  @Flag(name: .long, help: "Return the company owner")
+  var ownerOnly: Bool = false
+
+  @Flag(name: .long, help: "Return only users with paid access")
+  var onlyPaid: Bool = false
+
+  @Flag(
+    name: .long,
+    help:
+      "Return only the number of users (works only with --for-members-section or --only-virtual)"
+  )
+  var onlyRecordsCount: Bool = false
+
+  @Flag(name: .long, help: "Return only virtual users, paginated with --limit/--offset")
+  var onlyVirtual: Bool = false
+
+  @Option(name: .long, help: "Number of records to skip")
+  var offset: Int?
+
+  @Option(name: .long, help: "Maximum amount of users in response (default 100, max 100)")
+  var limit: Int?
+
+  @Option(
+    name: .long, help: "Filter by email and full name (works only with --for-members-section)")
+  var query: String?
+
+  @Option(name: .long, help: "Filter by access to Kaiten (works only with --for-members-section)")
+  var accessTypePermissions: String?
+
+  @Option(
+    name: .long, help: "Filter by access to Service Desk (works only with --for-members-section)")
+  var sdAccessType: String?
+
+  @Option(
+    name: .long,
+    help: "Filter by users consuming the license (works only with --for-members-section)")
+  var takeLicence: String?
+
+  @Option(
+    name: .long,
+    help: "Filter by temporarily inactive users (works only with --for-members-section)")
+  var temporarilyInactiveStatus: String?
+
+  @Option(
+    name: .long,
+    help: "Comma-separated group IDs to filter by (works only with --for-members-section)")
+  var groupIds: String?
+
+  @Option(
+    name: .long,
+    help: "Comma-separated permissions to filter by (works only with --for-members-section)")
+  var permissions: String?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let users = try await client.listCompanyUsers(
+      invitesOnly: invitesOnly ? true : nil,
+      withTransferAccessStatus: withTransferAccessStatus ? true : nil,
+      forMembersSection: forMembersSection ? true : nil,
+      ownerOnly: ownerOnly ? true : nil,
+      onlyPaid: onlyPaid ? true : nil,
+      onlyRecordsCount: onlyRecordsCount ? true : nil,
+      onlyVirtual: onlyVirtual ? true : nil,
+      offset: offset,
+      limit: limit,
+      query: query,
+      accessTypePermissions: accessTypePermissions,
+      sdAccessType: sdAccessType,
+      takeLicence: takeLicence,
+      temporarilyInactiveStatus: temporarilyInactiveStatus,
+      groupIds: try parseIntegerCSV(groupIds, fieldName: "--group-ids"),
+      permissions: try parseIntegerCSV(permissions, fieldName: "--permissions")
+    )
+    try printJSON(users, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Update Company User
+
+struct UpdateCompanyUser: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "update-company-user",
+    abstract: "Update a company user",
+    discussion: """
+      Requires an API token of a user with access to the administrative section "Members"; \
+      without it the API returns 403.
+      """
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "User ID")
+  var id: Int
+
+  @Option(
+    name: .long,
+    help: """
+      User access: 0 - no access, 1 - full access to Kaiten without service desk, \
+      2 - guest access to Kaiten without service desk, 4 - access only to service desk, \
+      5 - full access to Kaiten and service desk, 6 - guest access to Kaiten and service desk
+      """
+  )
+  var appsPermissions: Int?
+
+  @Option(
+    name: .long,
+    help:
+      "Temporarily inactive: user stays in the company but cannot sign in and does not need a license"
+  )
+  var temporarilyInactive: Bool?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let user = try await client.updateCompanyUser(
+      id: id,
+      appsPermissions: appsPermissions,
+      temporarilyInactive: temporarilyInactive
+    )
+    try printJSON(user, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Remove Virtual User
+
+struct RemoveVirtualUser: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "remove-virtual-user",
+    abstract: "Remove a virtual user",
+    discussion: """
+      Requires an API token of a user with access to the administrative section \
+      "Resource planning"; without it the API returns 403.
+      """
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "User ID")
+  var id: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let deletedId = try await client.removeVirtualUser(id: id)
+    try printJSON(["id": deletedId])
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -119,6 +119,9 @@ struct Kaiten: AsyncParsableCommand {
       GetCustomDirectory.self,
       UpdateCustomDirectory.self,
       DeleteCustomDirectory.self,
+      ListCompanyUsers.self,
+      UpdateCompanyUser.self,
+      RemoveVirtualUser.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/CompanyUsersTests.swift
+++ b/Tests/KaitenSDKTests/CompanyUsersTests.swift
@@ -1,0 +1,310 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("CompanyUsers")
+struct CompanyUsersTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// `KaitenError` is not `Equatable`, so the status code is matched by pattern.
+  private func expectUnexpectedResponse(
+    statusCode: Int,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      Issue.record(
+        "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), no error thrown",
+        sourceLocation: sourceLocation)
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == statusCode else {
+        Issue.record(
+          "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), got \(error)",
+          sourceLocation: sourceLocation)
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)", sourceLocation: sourceLocation)
+    }
+  }
+
+  /// A full company user as the get-list-of-users documentation describes it. The live
+  /// endpoint could not be verified (the verification token lacks access to the "Members"
+  /// administrative section), so the fixture follows the documented schema with invented values.
+  private static let companyUserJSON = """
+    {
+      "id": 101,
+      "uid": "fake-user-uid-1",
+      "full_name": "Jane Doe",
+      "email": "jane.doe@example.com",
+      "avatar_initials_url": "https://example.kaiten.ru/avatars/jd.png",
+      "avatar_uploaded_url": null,
+      "initials": "JD",
+      "avatar_type": 2,
+      "lng": "en",
+      "timezone": "UTC",
+      "theme": "auto",
+      "updated": "2024-01-02T03:04:05.678Z",
+      "created": "2023-01-02T03:04:05.678Z",
+      "activated": true,
+      "ui_version": 2,
+      "virtual": false,
+      "email_blocked": null,
+      "email_blocked_reason": null,
+      "delete_requested_at": null,
+      "permissions": 1024,
+      "own_permissions": 1024,
+      "user_id": 101,
+      "company_id": 7,
+      "default_space_id": null,
+      "role": 2,
+      "email_frequency": 2,
+      "email_settings": {"deadlines": true, "subject_by": 1},
+      "slack_id": null,
+      "slack_settings": null,
+      "notification_settings": {"card_add": ["inner", "email"], "card_move": []},
+      "notification_enabled_channels": ["inner", "email"],
+      "slack_private_channel_id": null,
+      "telegram_sd_bot_enabled": false,
+      "apps_permissions": 5,
+      "invite_last_sent_at": "2023-01-02T03:04:05.678Z",
+      "external": false,
+      "last_request_date": "2024-05-06T07:08:09.101Z",
+      "last_request_method": "GET",
+      "work_time_settings": {"work_days": [1, 2, 3, 4, 5], "hours_count": 8},
+      "personal_settings": {"current_card_view_id": "fake-view-uid-1"},
+      "locked": false,
+      "take_licence": true,
+      "spaces": [{
+        "id": 11,
+        "uid": "fake-space-uid-1",
+        "title": "Demo space",
+        "external_id": null,
+        "company_id": 7,
+        "path": "11",
+        "sort_order": 1.5,
+        "parent_entity_uid": null,
+        "archived": false,
+        "access": "private",
+        "for_everyone_access_role_id": "3",
+        "entity_uid": "fake-entity-uid-1",
+        "user_id": 101,
+        "access_mod": "direct",
+        "role": "3"
+      }],
+      "groups": {
+        "updated": "2024-01-02T03:04:05.678Z",
+        "created": "2023-01-02T03:04:05.678Z",
+        "id": 5,
+        "uid": "fake-group-uid-1",
+        "name": "Engineers",
+        "permissions": 0,
+        "company_id": 7,
+        "add_to_cards_and_spaces_enabled": true,
+        "user_id": 101,
+        "group_id": 5,
+        "spaces": [{"id": 11}]
+      }
+    }
+    """
+
+  // MARK: - List
+
+  @Test("200 returns array of CompanyUser")
+  func listSuccess() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: "[\(Self.companyUserJSON)]"))
+
+    let users = try await client.listCompanyUsers()
+    #expect(users.count == 1)
+    let user = try #require(users.first)
+    #expect(user.id == 101)
+    #expect(user.full_name == "Jane Doe")
+    #expect(user.avatar_uploaded_url == nil)
+    #expect(user.email_blocked == nil)
+    #expect(user.default_space_id == nil)
+    #expect(user.role == 2)
+    #expect(user.apps_permissions == 5)
+    #expect(user.email_settings?.deadlines == true)
+    #expect(user.email_settings?.subject_by == 1)
+    #expect(user.notification_settings?.card_add == ["inner", "email"])
+    #expect(user.notification_enabled_channels == ["inner", "email"])
+    #expect(user.work_time_settings?.work_days == [1, 2, 3, 4, 5])
+    #expect(user.work_time_settings?.hours_count == 8)
+    #expect(user.personal_settings?.current_card_view_id == "fake-view-uid-1")
+    #expect(user.take_licence == true)
+    #expect(user.spaces?.first?.title == "Demo space")
+    #expect(user.spaces?.first?.sort_order == 1.5)
+    #expect(user.spaces?.first?.role == "3")
+    #expect(user.groups?.name == "Engineers")
+    #expect(user.groups?.spaces?.count == 1)
+  }
+
+  /// The user serializer returns explicit JSON `null` for settings objects the documentation
+  /// declares as non-nullable; plain optional `$ref` properties must decode that to `nil`.
+  @Test("null settings objects decode to nil")
+  func listNullSettings() async throws {
+    let json = """
+      [{"id": 102, "email_settings": null, "personal_settings": null, "slack_settings": null}]
+      """
+    let client = try makeClient(.returning(statusCode: 200, body: json))
+
+    let users = try await client.listCompanyUsers()
+    #expect(users.count == 1)
+    #expect(users[0].id == 102)
+    #expect(users[0].email_settings == nil)
+    #expect(users[0].personal_settings == nil)
+    #expect(users[0].slack_settings == nil)
+  }
+
+  @Test("200 with empty body returns empty array")
+  func listEmptyBody() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: ""))
+    let users = try await client.listCompanyUsers()
+    #expect(users.isEmpty)
+  }
+
+  @Test("list sends all query parameters")
+  func listSendsQueryParameters() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
+    let client = try makeClient(transport)
+
+    _ = try await client.listCompanyUsers(
+      invitesOnly: true,
+      withTransferAccessStatus: true,
+      forMembersSection: true,
+      ownerOnly: true,
+      onlyPaid: true,
+      onlyRecordsCount: true,
+      onlyVirtual: true,
+      offset: 20,
+      limit: 10,
+      query: "jane",
+      accessTypePermissions: "full",
+      sdAccessType: "none",
+      takeLicence: "true",
+      temporarilyInactiveStatus: "active",
+      groupIds: [5, 6],
+      permissions: [1, 4]
+    )
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    let path = try #require(recorded.request.path)
+    #expect(path.hasPrefix("/company/users?"))
+    for expected in [
+      "invitesOnly=true", "withTransferAccessStatus=true", "for_members_section=true",
+      "owner_only=true", "only_paid=true", "only_records_count=true", "only_virtual=true",
+      "offset=20", "limit=10", "query=jane", "access_type_permissions=full",
+      "sd_access_type=none", "take_licence=true", "temporarily_inactive_status=active",
+      "group_ids=5", "group_ids=6", "permissions=1", "permissions=4",
+    ] {
+      #expect(path.contains(expected), "missing \(expected) in \(path)")
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func listUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCompanyUsers()
+    }
+  }
+
+  @Test("403 throws unexpectedResponse")
+  func listForbidden() async throws {
+    let client = try makeClient(.returning(statusCode: 403))
+    await expectUnexpectedResponse(statusCode: 403) {
+      _ = try await client.listCompanyUsers()
+    }
+  }
+
+  // MARK: - Update
+
+  @Test("update sends PATCH with body and parses the response")
+  func updateSuccess() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: Self.companyUserJSON)
+    let client = try makeClient(transport)
+
+    let user = try await client.updateCompanyUser(
+      id: 101, appsPermissions: 0, temporarilyInactive: true)
+
+    #expect(user.id == 101)
+    #expect(user.email == "jane.doe@example.com")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .patch)
+    #expect(recorded.request.path == "/company/users/101")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["apps_permissions"] as? Int == 0)
+    #expect(sent["temporarily_inactive"] as? Bool == true)
+  }
+
+  @Test("update 400 throws unexpectedResponse")
+  func updateBadRequest() async throws {
+    let client = try makeClient(.returning(statusCode: 400, body: #"{"message": "bad"}"#))
+    await expectUnexpectedResponse(statusCode: 400) {
+      _ = try await client.updateCompanyUser(id: 1, appsPermissions: 99)
+    }
+  }
+
+  @Test("update 404 throws notFound")
+  func updateNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    do {
+      _ = try await client.updateCompanyUser(id: 999, temporarilyInactive: false)
+      Issue.record("expected KaitenError.notFound, no error thrown")
+    } catch let error as KaitenError {
+      guard case .notFound(let resource, let id) = error else {
+        Issue.record("expected KaitenError.notFound, got \(error)")
+        return
+      }
+      #expect(resource == "user")
+      #expect(id == 999)
+    } catch {
+      Issue.record("expected KaitenError, got \(error)")
+    }
+  }
+
+  // MARK: - Remove
+
+  @Test("remove sends DELETE and returns the deleted user id")
+  func removeSuccess() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: #"{"id": 101}"#)
+    let client = try makeClient(transport)
+
+    let deletedId = try await client.removeVirtualUser(id: 101)
+    #expect(deletedId == 101)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .delete)
+    #expect(recorded.request.path == "/company/users/101")
+  }
+
+  @Test("remove 404 throws notFound")
+  func removeNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.removeVirtualUser(id: 999)
+    }
+  }
+
+  @Test("remove 403 throws unexpectedResponse")
+  func removeForbidden() async throws {
+    let client = try makeClient(.returning(statusCode: 403))
+    await expectUnexpectedResponse(statusCode: 403) {
+      _ = try await client.removeVirtualUser(id: 1)
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -3596,6 +3596,166 @@ paths:
           description: Invalid token
         '404':
           description: Not found
+  /company/users:
+    get:
+      summary: Get list of users
+      operationId: get_company_users
+      description: Get company users filtered by query parameters. Requires access to the administrative section "Members".
+      parameters:
+      - name: invitesOnly
+        in: query
+        schema:
+          type: boolean
+        description: Filter to return only invites
+      - name: withTransferAccessStatus
+        in: query
+        schema:
+          type: boolean
+        description: Data about the user rights transfer process is added
+      - name: for_members_section
+        in: query
+        schema:
+          type: boolean
+        description: When this flag is enabled, users for the "Members" administrative section are returned and the result is displayed page by page (see limit and offset params)
+      - name: owner_only
+        in: query
+        schema:
+          type: boolean
+        description: When this flag is enabled the company owner is returned
+      - name: only_paid
+        in: query
+        schema:
+          type: boolean
+        description: Only users with paid access are returned
+      - name: only_records_count
+        in: query
+        schema:
+          type: boolean
+        description: Only the number of users is returned. Works only with the for_members_section or only_virtual parameters. The count-only response shape is not described in the Kaiten documentation and is not modelled here
+      - name: only_virtual
+        in: query
+        schema:
+          type: boolean
+        description: Only virtual users are returned and the result is displayed page by page (see limit and offset params)
+      - name: offset
+        in: query
+        schema:
+          type: integer
+        description: Number of records to skip. Does not apply when exporting users
+      - name: limit
+        in: query
+        schema:
+          type: integer
+        description: 'Maximum amount of users in response. Default: 100, max: 100. Does not apply when exporting users'
+      - name: query
+        in: query
+        schema:
+          type: string
+        description: Filter by email and full_name. Works only with for_members_section parameter
+      - name: access_type_permissions
+        in: query
+        schema:
+          type: string
+        description: Filter by access to Kaiten. Works only with for_members_section parameter
+      - name: sd_access_type
+        in: query
+        schema:
+          type: string
+        description: Filter by access to Service Desk. Works only with for_members_section parameter
+      - name: take_licence
+        in: query
+        schema:
+          type: string
+        description: Filter by users consuming the license. Works only with for_members_section parameter
+      - name: temporarily_inactive_status
+        in: query
+        schema:
+          type: string
+        description: Filter by temporarily inactive users. Works only with for_members_section parameter
+      - name: group_ids
+        in: query
+        schema:
+          type: array
+          items:
+            type: integer
+        description: Filter by group ids. Works only with for_members_section parameter
+      - name: permissions
+        in: query
+        schema:
+          type: array
+          items:
+            type: integer
+        description: Filter by access granted to users. Works only with for_members_section parameter
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CompanyUser'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+  /company/users/{id}:
+    patch:
+      summary: Update user
+      operationId: update_company_user
+      description: Requires access to the administrative section "Members".
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: User ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateCompanyUserRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompanyUser'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    delete:
+      summary: Remove virtual user
+      operationId: remove_virtual_user
+      description: Requires access to the administrative section "Resource planning".
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: User ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeletedCompanyUserResponse'
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
 components:
   securitySchemes:
     bearerAuth:
@@ -8167,3 +8327,381 @@ components:
         condition:
           type: string
           description: 'Directory condition after deletion. Documented value: removed. Map to the CustomDirectoryCondition Swift enum, which preserves unknown values.'
+    # NOTE: shared by get-list-of-users and update-user, whose documented response
+    # shapes differ slightly: the union of both field sets is modelled, every property
+    # is optional, and where the two pages disagree on nullability the nullable variant
+    # from the get-list-of-users page is used.
+    CompanyUser:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Id
+        uid:
+          type: string
+          description: Uid
+        full_name:
+          type: string
+          description: User full name
+        email:
+          type: string
+          description: User email
+        username:
+          type: string
+          description: Username for mentions and login
+        avatar_initials_url:
+          type: string
+          description: Default user avatar url
+        avatar_uploaded_url:
+          type:
+          - string
+          - 'null'
+          description: User uploaded avatar url
+        initials:
+          type: string
+          description: User initials
+        avatar_type:
+          type: integer
+          description: 1 - gravatar, 2 - initials, 3 - uploaded
+        lng:
+          type: string
+          description: Language
+        timezone:
+          type: string
+          description: Time zone
+        theme:
+          type: string
+          description: light - light color theme, dark - dark color theme, auto - color theme based on OS settings
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        activated:
+          type: boolean
+          description: User activated flag
+        ui_version:
+          type: integer
+          description: 1 - old ui, 2 - new ui
+        virtual:
+          type: boolean
+          description: Is user virtual
+        email_blocked:
+          type:
+          - string
+          - 'null'
+          description: Email blocked timestamp
+        email_blocked_reason:
+          type:
+          - string
+          - 'null'
+          description: Email blocked reason
+        delete_requested_at:
+          type:
+          - string
+          - 'null'
+          description: Timestamp of delete request
+        permissions:
+          type: integer
+          description: User company permissions (with inherited permissions through groups)
+        own_permissions:
+          type: integer
+          description: User personal company permissions
+        user_id:
+          type: integer
+          description: User id
+        company_id:
+          type: integer
+          description: Company id
+        default_space_id:
+          type:
+          - integer
+          - 'null'
+          description: Default space
+        role:
+          type: integer
+          description: 'User role in company: 1 - owner, 2 - user, 3 - deactivated'
+        email_frequency:
+          type: integer
+          description: 1 - never, 2 - instantly
+        # NOTE: nullable in practice, but expressed as a plain $ref rather than
+        # `anyOf: [$ref, 'null']` — swift-openapi-generator silently drops properties
+        # using that pattern; the property is optional and the synthesized decoder
+        # maps an explicit JSON `null` to `nil`.
+        email_settings:
+          $ref: '#/components/schemas/CompanyUserEmailSettings'
+          description: Email settings
+        slack_id:
+          type:
+          - integer
+          - 'null'
+          description: User slack id
+        slack_settings:
+          type:
+          - object
+          - 'null'
+          additionalProperties: true
+          description: Slack settings. The object shape is not described in the Kaiten documentation
+        notification_settings:
+          $ref: '#/components/schemas/CompanyUserNotificationSettings'
+          description: Notification settings
+        notification_enabled_channels:
+          type: array
+          items:
+            type: string
+          description: List of enabled channels for notifications
+        slack_private_channel_id:
+          type:
+          - integer
+          - 'null'
+          description: User slack private channel id
+        telegram_sd_bot_enabled:
+          type: boolean
+          description: Telegram bot enable flag
+        # DOC_MISMATCH: docs=`string`, actual=`integer` — observed via the shared user serializer on GET /users; GET /company/users itself returned 403 for the verification token — https://developers.kaiten.ru/company-users/get-list-of-users
+        apps_permissions:
+          type: integer
+          description: '0 - no access, 1 - full access to Kaiten, access to service desk denied, 2 - guest access to Kaiten, access to service desk denied, 4 - access only to service desk, 5 - full access to Kaiten and service desk, 6 - guest access to Kaiten, access to service desk'
+        invite_last_sent_at:
+          type: string
+          description: Last invite date
+        external:
+          type: boolean
+          description: Is user external
+        last_request_date:
+          type:
+          - string
+          - 'null'
+          description: Date of last request
+        last_request_method:
+          type:
+          - string
+          - 'null'
+          description: Type of last request
+        work_time_settings:
+          $ref: '#/components/schemas/CompanyUserWorkTimeSettings'
+          description: Work time settings
+        personal_settings:
+          $ref: '#/components/schemas/CompanyUserPersonalSettings'
+          description: Personal settings
+        locked:
+          type: boolean
+          description: Is user locked for update
+        take_licence:
+          type: boolean
+          description: Flag indicating whether the user holds the company's license
+        temporarily_inactive:
+          type: boolean
+          description: 'Temporarily inactive: user is still in company, but cannot sign in and does not need a license'
+        spaces:
+          type: array
+          items:
+            $ref: '#/components/schemas/CompanyUserSpace'
+          description: Spaces where the user is invited
+        groups:
+          $ref: '#/components/schemas/CompanyUserGroup'
+          description: User groups
+    CompanyUserEmailSettings:
+      type: object
+      properties:
+        deadlines:
+          type: boolean
+          description: Daily due dates digest flag
+        subject_by:
+          type: integer
+          description: 'Subject: 1 - id and title, 2 - action'
+    CompanyUserNotificationSettings:
+      type: object
+      description: Per-event lists of notification channels. The documentation does not describe the channel item type
+      properties:
+        card_add:
+          type: array
+          items:
+            type: string
+          description: Notification enabled on card add
+        card_move:
+          type: array
+          items:
+            type: string
+          description: Notification enabled on card move
+        card_unblock:
+          type: array
+          items:
+            type: string
+          description: Notification enabled on card unblock
+        card_block_add:
+          type: array
+          items:
+            type: string
+          description: Notification enabled on card add block
+        card_member_add:
+          type: array
+          items:
+            type: string
+          description: Notification enabled on card add member
+        card_comment_add:
+          type: array
+          items:
+            type: string
+          description: Notification enabled on card add comment
+        due_date_reminder:
+          type: array
+          items:
+            type: string
+          description: Notification enabled on due date remind
+        card_member_remove:
+          type: array
+          items:
+            type: string
+          description: Notification enabled on card remove member
+        card_comment_mention:
+          type: array
+          items:
+            type: string
+          description: Notification enabled on mention in card comment
+        card_due_data_change:
+          type: array
+          items:
+            type: string
+          description: Notification enabled on card due date change
+        card_description_change:
+          type: array
+          items:
+            type: string
+          description: Notification enabled on card description change
+        card_member_become_responsible:
+          type: array
+          items:
+            type: string
+          description: Notification enabled on card change set responsible
+        checklist_item_responsible_add:
+          type: array
+          items:
+            type: string
+          description: Notification enabled on card set responsible for checklist item
+    CompanyUserWorkTimeSettings:
+      type: object
+      properties:
+        work_days:
+          type: array
+          items:
+            type: integer
+          description: Work days
+        hours_count:
+          type: integer
+          description: Work time hours count
+    CompanyUserPersonalSettings:
+      type: object
+      properties:
+        current_card_view_id:
+          type: string
+          description: Current card view uid
+    CompanyUserSpace:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Space id
+        uid:
+          type: string
+          description: Space uid
+        title:
+          type: string
+          description: Space title
+        external_id:
+          type:
+          - string
+          - 'null'
+          description: External id
+        company_id:
+          type: integer
+          description: Company id
+        path:
+          type: string
+          description: Inner path to entity
+        sort_order:
+          type: number
+          description: Space sort order
+        parent_entity_uid:
+          type:
+          - string
+          - 'null'
+          description: Parent entity uid
+        archived:
+          type: boolean
+          description: Space archived flag
+        access:
+          type: string
+          description: Space access
+        for_everyone_access_role_id:
+          type: string
+          description: Role id for everyone access
+        entity_uid:
+          type: string
+          description: Entity uid
+        user_id:
+          type: integer
+          description: User id
+        access_mod:
+          type: string
+          description: User access modifier
+        role:
+          type: string
+          description: 'User space role: 1 - commentator, 2 - writer, 3 - admin'
+    CompanyUserGroup:
+      type: object
+      properties:
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        id:
+          type: integer
+          description: Group id
+        uid:
+          type: string
+          description: Group uid
+        name:
+          type: string
+          description: Group name
+        permissions:
+          type: integer
+          description: Group permissions
+        company_id:
+          type: integer
+          description: Company id
+        add_to_cards_and_spaces_enabled:
+          type: boolean
+          description: Should add cards and spaces
+        user_id:
+          type: integer
+          description: User id
+        group_id:
+          type: integer
+          description: Group id
+        spaces:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+          description: Group spaces. Item shape is not described in the Kaiten documentation
+    UpdateCompanyUserRequest:
+      type: object
+      properties:
+        apps_permissions:
+          type: integer
+          description: 'User access: 0 - no access, 1 - full access to Kaiten, access to service desk denied, 2 - guest access to Kaiten, access to service desk denied, 4 - access only to service desk, 5 - full access to Kaiten and service desk, 6 - guest access to Kaiten, access to service desk'
+        temporarily_inactive:
+          type: boolean
+          description: 'Temporarily inactive: user is still in company, but cannot sign in and does not need a license'
+    DeletedCompanyUserResponse:
+      type: object
+      required:
+      - id
+      properties:
+        id:
+          type: integer
+          description: Deleted user id

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -277,6 +277,13 @@ let sections: [Section] = [
     Operation(
       name: "delete_custom_directory", errors: [.badRequest, .unauthorized, .notFound]),
   ]),
+  Section(mark: "Company Users", operations: [
+    Operation(name: "get_company_users", errors: [.unauthorized, .forbidden, .notFound]),
+    Operation(
+      name: "update_company_user",
+      errors: [.badRequest, .unauthorized, .forbidden, .notFound]),
+    Operation(name: "remove_virtual_user", errors: [.forbidden, .notFound]),
+  ]),
 ]
 
 // MARK: - Generator


### PR DESCRIPTION
## Endpoints

- [x] `GET /company/users` — `listCompanyUsers` / `kaiten list-company-users`
- [x] `PATCH /company/users/{id}` — `updateCompanyUser` / `kaiten update-company-user`
- [x] `DELETE /company/users/{id}` — `removeVirtualUser` / `kaiten remove-virtual-user`

## Live verification

- `GET /company/users` could **not** be verified live: the endpoint requires access to the administrative section "Members", and the verification token receives **403** for every parameter combination tried (default, `owner_only`, `only_virtual`, `for_members_section`). The `CompanyUser` schema therefore follows the documentation; the test fixture is docs-based with invented values.
- The CLI was still exercised end-to-end against the live instance (read-only): `kaiten list-company-users` surfaces the 403 as `Unexpected HTTP response: 403`.
- `PATCH` and `DELETE` are mutating and were never sent to the live API; their schemas come strictly from the docs.

## DOC_MISMATCH

One annotation added:

- `CompanyUser.apps_permissions` — docs declare `string`, but the shared user serializer emits an `integer` (observed on the read-only `GET /users`, which returns the same user shape; `/company/users` itself is 403 for the verification token).

## Notes

- `CompanyUser` is shared by the list and update responses, whose documented shapes differ slightly: the union of both field sets is modelled, all properties optional, nullability taken from the get-list-of-users page where the pages disagree.
- Settings objects (`email_settings`, `personal_settings`, `work_time_settings`, `notification_settings`) are plain optional `$ref`s, so an explicit JSON `null` decodes to `nil`; no `anyOf: [$ref, 'null']` anywhere (guarded by `OpenAPISpecIntegrityTests`).
- All 16 documented query parameters of the list endpoint are exposed in the SDK and CLI (FR-010). `only_records_count` is exposed but its count-only response shape is undocumented and not modelled; the DocC comment says so.
- `DELETE` is documented without a 401 response, so an unauthorized answer surfaces as `unexpectedResponse(401)`.
- 12 new tests in `Tests/KaitenSDKTests/CompanyUsersTests.swift`; full suite (399 tests) green, `swift format lint --strict` clean.

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)