### PR TITLE
feat(custom-directory-records): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,41 @@ CLI: `list-custom-directory-fields`, `create-custom-directory-field`,
 `get-custom-directory-field`, `update-custom-directory-field`,
 `delete-custom-directory-field`, each taking `--directory-id` (and `--field-id`
 where a single field is addressed).
+### Custom Directory Records
+
+| Method | Description |
+|--------|-------------|
+| `listCustomDirectoryRecords(directoryId:query:profile:includeValues:includeAuthor:conditions:filters:filterOperator:offset:limit:)` | List records in a custom directory |
+| `createCustomDirectoryRecord(directoryId:values:responseProfile:)` | Create a record |
+| `getCustomDirectoryRecord(directoryId:recordId:profile:)` | Get a record |
+| `updateCustomDirectoryRecord(directoryId:recordId:condition:values:responseProfile:)` | Update a record's values and/or condition |
+| `deleteCustomDirectoryRecord(directoryId:recordId:)` | Soft-delete a record (condition becomes `removed`) |
+| `listCustomDirectoryRecordCards(directoryId:recordId:filter:offset:limit:)` | List cards linked to a record |
+
+The custom directories API is documented as beta and may change. Which record
+fields a response includes depends on the `profile`/`responseProfile`
+parameter (`CustomDirectoryProfile`; the documented `none` value is spelled
+`.noRelations` in Swift so it cannot be shadowed by `Optional.none`). The
+record condition is exposed as the `CustomDirectoryRecordCondition` enum with
+an `unknown(String)` case that preserves values the documentation does not
+list. Request `values` maps and populated relation objects stay free-form
+JSON — the documentation does not describe their shapes.
+
+```swift
+let page = try await client.listCustomDirectoryRecords(
+  directoryId: "d1",
+  profile: .details,
+  conditions: [.active]
+)
+for record in page.items {
+  print(record.display_value ?? "")
+}
+```
+
+CLI: `list-custom-directory-records`, `create-custom-directory-record`,
+`get-custom-directory-record`, `update-custom-directory-record`,
+`delete-custom-directory-record`, `list-custom-directory-record-cards` — all
+take `--directory-id`, the record-scoped ones also `--record-id`.
 
 ## Pagination
 

--- a/Sources/KaitenSDK/Enums.swift
+++ b/Sources/KaitenSDK/Enums.swift
@@ -1655,3 +1655,151 @@ public enum CustomDirectoryFieldType: Sendable, Equatable, CaseIterable, Codable
     try container.encode(rawValue)
   }
 }
+
+// MARK: - Custom Directory Records
+//
+// Custom directory record discriminators are declared as plain strings in the
+// OpenAPI spec, per the forward-compatibility rule at the top of this file: the
+// custom directories API is documented as beta, so a generated closed enum
+// would fail entire responses when Kaiten adds a value. The typed surface
+// lives here instead, with an `unknown(String)` case.
+
+/// Custom directory record condition.
+/// - SeeAlso: [Kaiten API – Custom directory records](https://developers.kaiten.ru/custom-directory-records/get-list-of-records)
+public enum CustomDirectoryRecordCondition: Sendable, Equatable, CaseIterable, Codable {
+  /// Record is active.
+  case active
+  /// Record is inactive.
+  case inactive
+  /// Record is soft-deleted.
+  case removed
+  /// Unknown value returned by the API (forward compatibility).
+  case unknown(String)
+
+  public static var allCases: [CustomDirectoryRecordCondition] {
+    [.active, .inactive, .removed]
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "active": self = .active
+    case "inactive": self = .inactive
+    case "removed": self = .removed
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: String {
+    switch self {
+    case .active: "active"
+    case .inactive: "inactive"
+    case .removed: "removed"
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(String.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}
+
+/// Profile controlling which relations a custom directory record response includes.
+///
+/// The `none` profile is spelled ``noRelations`` on the Swift side: a case
+/// literally named `none` would be shadowed by `Optional.none` at every
+/// `CustomDirectoryProfile?` call site, silently omitting the parameter
+/// instead of sending `profile=none`.
+/// - SeeAlso: [Kaiten API – Custom directory records](https://developers.kaiten.ru/custom-directory-records/get-list-of-records)
+public enum CustomDirectoryProfile: Sendable, Equatable, CaseIterable, Codable {
+  /// No relations. Raw value `none`. In mutating endpoints the response is `{ id }` only.
+  case noRelations
+  /// Summary relations.
+  case summary
+  /// Detailed relations.
+  case details
+  /// All relations.
+  case full
+  /// Unknown value returned by the API (forward compatibility).
+  case unknown(String)
+
+  public static var allCases: [CustomDirectoryProfile] {
+    [.noRelations, .summary, .details, .full]
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "none": self = .noRelations
+    case "summary": self = .summary
+    case "details": self = .details
+    case "full": self = .full
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: String {
+    switch self {
+    case .noRelations: "none"
+    case .summary: "summary"
+    case .details: "details"
+    case .full: "full"
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(String.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}
+
+/// Boolean operator joining the filters of a custom directory record list request.
+/// - SeeAlso: [Kaiten API – Custom directory records](https://developers.kaiten.ru/custom-directory-records/get-list-of-records)
+public enum CustomDirectoryFilterOperator: Sendable, Equatable, CaseIterable, Codable {
+  /// All filters must match.
+  case and
+  /// Any filter must match.
+  case or
+  /// Unknown value returned by the API (forward compatibility).
+  case unknown(String)
+
+  public static var allCases: [CustomDirectoryFilterOperator] {
+    [.and, .or]
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "and": self = .and
+    case "or": self = .or
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: String {
+    switch self {
+    case .and: "and"
+    case .or: "or"
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(String.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}

--- a/Sources/KaitenSDK/KaitenClient+CustomDirectoryRecords.swift
+++ b/Sources/KaitenSDK/KaitenClient+CustomDirectoryRecords.swift
@@ -1,0 +1,266 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - Typed Discriminators
+
+// The record condition travels as a plain string (see the comment above the
+// custom directory enums in `Enums.swift`). This accessor gives the generated
+// payload a typed surface without losing undocumented values.
+
+extension Components.Schemas.CustomDirectoryRecord {
+  /// The record condition, or `nil` if the API omitted the field.
+  public var recordCondition: CustomDirectoryRecordCondition? {
+    condition.map(CustomDirectoryRecordCondition.init(rawValue:))
+  }
+}
+
+// MARK: - Custom Directory Records
+
+extension KaitenClient {
+  /// Returns a page of records in a custom directory.
+  ///
+  /// The custom directories API is documented as beta and may change.
+  ///
+  /// - Parameters:
+  ///   - directoryId: The directory identifier.
+  ///   - query: Quick search by record display value (optional).
+  ///   - profile: Controls which relations the response includes (optional).
+  ///   - includeValues: Legacy switch that includes the `values` array (optional).
+  ///   - includeAuthor: Includes the author user object (optional).
+  ///   - conditions: Filter by record conditions (optional).
+  ///   - filters: Advanced field-based filters as a JSON-encoded object (optional).
+  ///   - filterOperator: Boolean operator joining `filters`; the API defaults to `and` (optional).
+  ///   - offset: Number of records to skip (default `0`).
+  ///   - limit: Maximum number of records to return (default `100`, max `100`).
+  /// - Returns: A ``Page`` of records. Returns an empty page when the directory has no
+  ///   matching records.
+  /// - Throws:
+  ///   - ``KaitenError/invalidPaginationRange(offset:limit:)`` if pagination parameters are out of range.
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for not found (404) or other
+  ///     undocumented HTTP status codes. A 404 is reported as `unexpectedResponse` rather than
+  ///     ``KaitenError/notFound(resource:id:)`` because directories are addressed by string ID.
+  public func listCustomDirectoryRecords(
+    directoryId: String,
+    query: String? = nil,
+    profile: CustomDirectoryProfile? = nil,
+    includeValues: Bool? = nil,
+    includeAuthor: Bool? = nil,
+    conditions: [CustomDirectoryRecordCondition]? = nil,
+    filters: String? = nil,
+    filterOperator: CustomDirectoryFilterOperator? = nil,
+    offset: Int = 0,
+    limit: Int = 100
+  ) async throws(KaitenError) -> Page<Components.Schemas.CustomDirectoryRecord> {
+    try validatePagination(offset: offset, limit: limit)
+    let queryInput = Operations.list_custom_directory_records.Input.Query(
+      limit: limit,
+      offset: offset,
+      query: query,
+      profile: profile?.rawValue,
+      include_values: includeValues,
+      include_author: includeAuthor,
+      conditions: conditions.map { $0.map(\.rawValue) },
+      filters: filters,
+      filter_operator: filterOperator?.rawValue
+    )
+    guard
+      let response = try await callList({
+        try await client.list_custom_directory_records(
+          path: .init(directory_id: directoryId), query: queryInput)
+      })
+    else {
+      return Page(items: [], offset: offset, limit: limit)
+    }
+    let items: [Components.Schemas.CustomDirectoryRecord] = try decodeResponse(response.toCase()) {
+      try $0.json
+    }
+    return Page(items: items, offset: offset, limit: limit)
+  }
+
+  /// Creates a record in a custom directory.
+  ///
+  /// The custom directories API is documented as beta and may change.
+  ///
+  /// - Parameters:
+  ///   - directoryId: The directory identifier.
+  ///   - values: Values map where keys are custom directory field identifiers. Each value is
+  ///     either an object (single-value field) or an array of objects (multi-select field).
+  ///     The Kaiten documentation does not describe the value shapes beyond that.
+  ///   - responseProfile: Controls the response size. ``CustomDirectoryProfile/noRelations``
+  ///     returns `{ id }` only (optional).
+  /// - Returns: The created record. Which fields are present depends on `responseProfile`.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for validation errors (400), not
+  ///     found (404) or other undocumented HTTP status codes. A 404 is reported as
+  ///     `unexpectedResponse` rather than ``KaitenError/notFound(resource:id:)`` because
+  ///     directories are addressed by string ID.
+  public func createCustomDirectoryRecord(
+    directoryId: String,
+    values: Components.Schemas.CreateCustomDirectoryRecordRequest.valuesPayload,
+    responseProfile: CustomDirectoryProfile? = nil
+  ) async throws(KaitenError) -> Components.Schemas.CustomDirectoryRecord {
+    let response = try await call {
+      try await client.create_custom_directory_record(
+        path: .init(directory_id: directoryId),
+        query: .init(response_profile: responseProfile?.rawValue),
+        body: .json(.init(values: values))
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Returns a single custom directory record.
+  ///
+  /// The custom directories API is documented as beta and may change.
+  ///
+  /// - Parameters:
+  ///   - directoryId: The directory identifier.
+  ///   - recordId: The record identifier.
+  ///   - profile: Controls which relations the response includes (optional).
+  /// - Returns: The record. Which fields are present depends on `profile`.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for not found (404) or other
+  ///     undocumented HTTP status codes. A 404 is reported as `unexpectedResponse` rather than
+  ///     ``KaitenError/notFound(resource:id:)`` because records are addressed by string ID and
+  ///     the response does not say whether the directory or the record is missing.
+  public func getCustomDirectoryRecord(
+    directoryId: String,
+    recordId: String,
+    profile: CustomDirectoryProfile? = nil
+  ) async throws(KaitenError) -> Components.Schemas.CustomDirectoryRecord {
+    let response = try await call {
+      try await client.get_custom_directory_record(
+        path: .init(directory_id: directoryId, record_id: recordId),
+        query: .init(profile: profile?.rawValue)
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Updates a custom directory record's values and/or condition.
+  ///
+  /// The custom directories API is documented as beta and may change.
+  ///
+  /// - Parameters:
+  ///   - directoryId: The directory identifier.
+  ///   - recordId: The record identifier.
+  ///   - condition: The new record condition (optional).
+  ///   - values: Values map where keys are custom directory field identifiers. Each value is
+  ///     either an object (single-value field) or an array of objects (multi-select field).
+  ///     The Kaiten documentation does not describe the value shapes beyond that (optional).
+  ///   - responseProfile: Controls the response size. ``CustomDirectoryProfile/noRelations``
+  ///     returns `{ id }` only (optional).
+  /// - Returns: The updated record. Which fields are present depends on `responseProfile`.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for validation errors (400), not
+  ///     found (404) or other undocumented HTTP status codes. A 404 is reported as
+  ///     `unexpectedResponse` rather than ``KaitenError/notFound(resource:id:)`` because records
+  ///     are addressed by string ID and the response does not say whether the directory or the
+  ///     record is missing.
+  public func updateCustomDirectoryRecord(
+    directoryId: String,
+    recordId: String,
+    condition: CustomDirectoryRecordCondition? = nil,
+    values: Components.Schemas.UpdateCustomDirectoryRecordRequest.valuesPayload? = nil,
+    responseProfile: CustomDirectoryProfile? = nil
+  ) async throws(KaitenError) -> Components.Schemas.CustomDirectoryRecord {
+    let response = try await call {
+      try await client.update_custom_directory_record(
+        path: .init(directory_id: directoryId, record_id: recordId),
+        query: .init(response_profile: responseProfile?.rawValue),
+        body: .json(.init(condition: condition?.rawValue, values: values))
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Soft-deletes a custom directory record, setting its condition to `removed`.
+  ///
+  /// The custom directories API is documented as beta and may change.
+  ///
+  /// - Parameters:
+  ///   - directoryId: The directory identifier.
+  ///   - recordId: The record identifier.
+  /// - Returns: The deleted record. The documentation lists only `id` and `condition` in
+  ///   the response.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for not found (404) or other
+  ///     undocumented HTTP status codes. A 404 is reported as `unexpectedResponse` rather than
+  ///     ``KaitenError/notFound(resource:id:)`` because records are addressed by string ID and
+  ///     the response does not say whether the directory or the record is missing.
+  public func deleteCustomDirectoryRecord(
+    directoryId: String,
+    recordId: String
+  ) async throws(KaitenError) -> Components.Schemas.CustomDirectoryRecord {
+    let response = try await call {
+      try await client.delete_custom_directory_record(
+        path: .init(directory_id: directoryId, record_id: recordId)
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Returns a page of cards linked to a custom directory record, including cards linked
+  /// through ancestor records.
+  ///
+  /// The custom directories API is documented as beta and may change.
+  ///
+  /// - Parameters:
+  ///   - directoryId: The directory identifier.
+  ///   - recordId: The record identifier.
+  ///   - filter: Base64-encoded JSON card filter, merged with the base filter (optional).
+  ///   - offset: Number of cards to skip (default `0`).
+  ///   - limit: Maximum number of cards to return (default `100`, max `100`).
+  /// - Returns: A ``Page`` of linked cards. Returns an empty page when the record has no
+  ///   linked cards.
+  /// - Throws:
+  ///   - ``KaitenError/invalidPaginationRange(offset:limit:)`` if pagination parameters are out of range.
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for validation errors (400), not
+  ///     found (404) or other undocumented HTTP status codes. A 404 is reported as
+  ///     `unexpectedResponse` rather than ``KaitenError/notFound(resource:id:)`` because records
+  ///     are addressed by string ID and the response does not say whether the directory or the
+  ///     record is missing.
+  public func listCustomDirectoryRecordCards(
+    directoryId: String,
+    recordId: String,
+    filter: String? = nil,
+    offset: Int = 0,
+    limit: Int = 100
+  ) async throws(KaitenError) -> Page<Components.Schemas.CustomDirectoryLinkedCard> {
+    try validatePagination(offset: offset, limit: limit)
+    guard
+      let response = try await callList({
+        try await client.list_custom_directory_record_cards(
+          path: .init(directory_id: directoryId, record_id: recordId),
+          query: .init(limit: limit, offset: offset, filter: filter)
+        )
+      })
+    else {
+      return Page(items: [], offset: offset, limit: limit)
+    }
+    let items: [Components.Schemas.CustomDirectoryLinkedCard] = try decodeResponse(
+      response.toCase()
+    ) {
+      try $0.json
+    }
+    return Page(items: items, offset: offset, limit: limit)
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -1499,3 +1499,85 @@ extension Operations.delete_custom_directory_field.Output {
     }
   }
 }
+
+// MARK: - Custom Directory Records
+
+extension Operations.list_custom_directory_records.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.list_custom_directory_records.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.create_custom_directory_record.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.create_custom_directory_record.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.get_custom_directory_record.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_custom_directory_record.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.update_custom_directory_record.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.update_custom_directory_record.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.delete_custom_directory_record.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.delete_custom_directory_record.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.list_custom_directory_record_cards.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.list_custom_directory_record_cards.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/CustomDirectoryRecords/CustomDirectoryRecordCommands.swift
+++ b/Sources/kaiten/CustomDirectoryRecords/CustomDirectoryRecordCommands.swift
@@ -1,0 +1,303 @@
+import ArgumentParser
+import Foundation
+import KaitenSDK
+
+// MARK: - Custom Directory Records
+
+func parseCustomDirectoryProfile(_ rawValue: String?, fieldName: String) throws
+  -> CustomDirectoryProfile?
+{
+  guard let rawValue else { return nil }
+  let profile = CustomDirectoryProfile(rawValue: rawValue)
+  guard CustomDirectoryProfile.allCases.contains(profile) else {
+    let allowed = CustomDirectoryProfile.allCases.map(\.rawValue).joined(separator: ", ")
+    throw ValidationError("Invalid \(fieldName): '\(rawValue)'. Allowed values: \(allowed)")
+  }
+  return profile
+}
+
+func parseCustomDirectoryRecordCondition(_ rawValue: String) throws
+  -> CustomDirectoryRecordCondition
+{
+  let condition = CustomDirectoryRecordCondition(rawValue: rawValue)
+  guard CustomDirectoryRecordCondition.allCases.contains(condition) else {
+    let allowed = CustomDirectoryRecordCondition.allCases.map(\.rawValue).joined(separator: ", ")
+    throw ValidationError("Invalid condition: '\(rawValue)'. Allowed values: \(allowed)")
+  }
+  return condition
+}
+
+func parseCustomDirectoryRecordConditions(_ rawValue: String?) throws
+  -> [CustomDirectoryRecordCondition]?
+{
+  guard let tokens = try parseStringCSV(rawValue, fieldName: "--conditions") else { return nil }
+  return try tokens.map(parseCustomDirectoryRecordCondition)
+}
+
+func parseCustomDirectoryFilterOperator(_ rawValue: String?) throws
+  -> CustomDirectoryFilterOperator?
+{
+  guard let rawValue else { return nil }
+  let filterOperator = CustomDirectoryFilterOperator(rawValue: rawValue)
+  guard CustomDirectoryFilterOperator.allCases.contains(filterOperator) else {
+    let allowed = CustomDirectoryFilterOperator.allCases.map(\.rawValue).joined(separator: ", ")
+    throw ValidationError("Invalid filter operator: '\(rawValue)'. Allowed values: \(allowed)")
+  }
+  return filterOperator
+}
+
+// MARK: - List Custom Directory Records
+
+struct ListCustomDirectoryRecords: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-custom-directory-records",
+    abstract: "List records in a custom directory (paginated)",
+    discussion: "The custom directories API is in beta and may change."
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Directory ID")
+  var directoryId: String
+
+  @Option(name: .long, help: "Quick search by record display value")
+  var query: String?
+
+  @Option(name: .long, help: "Included relations: none, summary, details, full")
+  var profile: String?
+
+  @Option(name: .long, help: "Legacy: include the values array")
+  var includeValues: Bool?
+
+  @Option(name: .long, help: "Include the author user object")
+  var includeAuthor: Bool?
+
+  @Option(name: .long, help: "Comma-separated conditions: active, inactive, removed")
+  var conditions: String?
+
+  @Option(name: .long, help: "Advanced field-based filters as a JSON object")
+  var filters: String?
+
+  @Option(name: .long, help: "Boolean operator for filters: and, or (default: and)")
+  var filterOperator: String?
+
+  @Option(name: .long, help: "Offset for pagination (default: 0)")
+  var offset: Int = 0
+
+  @Option(name: .long, help: "Limit for pagination (default: 100, max: 100)")
+  var limit: Int = 100
+
+  func run() async throws {
+    let parsedProfile = try parseCustomDirectoryProfile(profile, fieldName: "profile")
+    let parsedConditions = try parseCustomDirectoryRecordConditions(conditions)
+    let parsedFilterOperator = try parseCustomDirectoryFilterOperator(filterOperator)
+    let client = try await global.makeClient()
+    let page = try await client.listCustomDirectoryRecords(
+      directoryId: directoryId,
+      query: query,
+      profile: parsedProfile,
+      includeValues: includeValues,
+      includeAuthor: includeAuthor,
+      conditions: parsedConditions,
+      filters: filters,
+      filterOperator: parsedFilterOperator,
+      offset: offset,
+      limit: limit
+    )
+    try printJSON(page, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Create Custom Directory Record
+
+struct CreateCustomDirectoryRecord: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "create-custom-directory-record",
+    abstract: "Create a record in a custom directory",
+    discussion: "The custom directories API is in beta and may change."
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Directory ID")
+  var directoryId: String
+
+  @Option(
+    name: .long,
+    help:
+      "Values as a JSON object keyed by directory field ID; each value is an object or an array of objects"
+  )
+  var values: String
+
+  @Option(name: .long, help: "Response size: none, summary, details, full")
+  var responseProfile: String?
+
+  func run() async throws {
+    guard
+      let parsedValues = try parseAutomationJSON(
+        values, as: Components.Schemas.CreateCustomDirectoryRecordRequest.valuesPayload.self,
+        fieldName: "values")
+    else {
+      throw ValidationError("Invalid values: value is required")
+    }
+    let parsedResponseProfile = try parseCustomDirectoryProfile(
+      responseProfile, fieldName: "response profile")
+    let client = try await global.makeClient()
+    let record = try await client.createCustomDirectoryRecord(
+      directoryId: directoryId,
+      values: parsedValues,
+      responseProfile: parsedResponseProfile
+    )
+    try printJSON(record, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Get Custom Directory Record
+
+struct GetCustomDirectoryRecord: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "get-custom-directory-record",
+    abstract: "Get a custom directory record",
+    discussion: "The custom directories API is in beta and may change."
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Directory ID")
+  var directoryId: String
+
+  @Option(name: .long, help: "Record ID")
+  var recordId: String
+
+  @Option(name: .long, help: "Included relations: none, summary, details, full")
+  var profile: String?
+
+  func run() async throws {
+    let parsedProfile = try parseCustomDirectoryProfile(profile, fieldName: "profile")
+    let client = try await global.makeClient()
+    let record = try await client.getCustomDirectoryRecord(
+      directoryId: directoryId,
+      recordId: recordId,
+      profile: parsedProfile
+    )
+    try printJSON(record, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Update Custom Directory Record
+
+struct UpdateCustomDirectoryRecord: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "update-custom-directory-record",
+    abstract: "Update a custom directory record's values and/or condition",
+    discussion: "The custom directories API is in beta and may change."
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Directory ID")
+  var directoryId: String
+
+  @Option(name: .long, help: "Record ID")
+  var recordId: String
+
+  @Option(name: .long, help: "Record condition: active, inactive, removed")
+  var condition: String?
+
+  @Option(
+    name: .long,
+    help:
+      "Values as a JSON object keyed by directory field ID; each value is an object or an array of objects"
+  )
+  var values: String?
+
+  @Option(name: .long, help: "Response size: none, summary, details, full")
+  var responseProfile: String?
+
+  func run() async throws {
+    let parsedCondition = try condition.map(parseCustomDirectoryRecordCondition)
+    let parsedValues = try parseAutomationJSON(
+      values, as: Components.Schemas.UpdateCustomDirectoryRecordRequest.valuesPayload.self,
+      fieldName: "values")
+    let parsedResponseProfile = try parseCustomDirectoryProfile(
+      responseProfile, fieldName: "response profile")
+    let client = try await global.makeClient()
+    let record = try await client.updateCustomDirectoryRecord(
+      directoryId: directoryId,
+      recordId: recordId,
+      condition: parsedCondition,
+      values: parsedValues,
+      responseProfile: parsedResponseProfile
+    )
+    try printJSON(record, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Delete Custom Directory Record
+
+struct DeleteCustomDirectoryRecord: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "delete-custom-directory-record",
+    abstract: "Soft-delete a custom directory record (condition becomes removed)",
+    discussion: "The custom directories API is in beta and may change."
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Directory ID")
+  var directoryId: String
+
+  @Option(name: .long, help: "Record ID")
+  var recordId: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let record = try await client.deleteCustomDirectoryRecord(
+      directoryId: directoryId,
+      recordId: recordId
+    )
+    try printJSON(record, expand: global.expandedFields)
+  }
+}
+
+// MARK: - List Custom Directory Record Cards
+
+struct ListCustomDirectoryRecordCards: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-custom-directory-record-cards",
+    abstract: "List cards linked to a custom directory record (paginated)",
+    discussion: """
+      Returns cards linked to the record, including cards linked through ancestor records. \
+      The custom directories API is in beta and may change.
+      """
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Directory ID")
+  var directoryId: String
+
+  @Option(name: .long, help: "Record ID")
+  var recordId: String
+
+  @Option(name: .long, help: "Base64-encoded JSON card filter, merged with the base filter")
+  var filter: String?
+
+  @Option(name: .long, help: "Offset for pagination (default: 0)")
+  var offset: Int = 0
+
+  @Option(name: .long, help: "Limit for pagination (default: 100, max: 100)")
+  var limit: Int = 100
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let page = try await client.listCustomDirectoryRecordCards(
+      directoryId: directoryId,
+      recordId: recordId,
+      filter: filter,
+      offset: offset,
+      limit: limit
+    )
+    try printJSON(page, expand: global.expandedFields)
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -127,6 +127,12 @@ struct Kaiten: AsyncParsableCommand {
       GetCustomDirectoryField.self,
       UpdateCustomDirectoryField.self,
       DeleteCustomDirectoryField.self,
+      ListCustomDirectoryRecords.self,
+      CreateCustomDirectoryRecord.self,
+      GetCustomDirectoryRecord.self,
+      UpdateCustomDirectoryRecord.self,
+      DeleteCustomDirectoryRecord.self,
+      ListCustomDirectoryRecordCards.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/CustomDirectoryRecordsTests.swift
+++ b/Tests/KaitenSDKTests/CustomDirectoryRecordsTests.swift
@@ -1,0 +1,421 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+/// The live company used for verification has no custom directories, so every fixture is built
+/// from the documented response attributes and the documentation's request example (docs-only,
+/// with invented IDs). The custom directories API is documented as beta.
+@Suite("Custom Directory Records")
+struct CustomDirectoryRecordsTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// `KaitenError` is not `Equatable`, so the status code is matched by pattern.
+  private func expectUnexpectedResponse(
+    statusCode: Int,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      Issue.record(
+        "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), no error thrown",
+        sourceLocation: sourceLocation)
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == statusCode else {
+        Issue.record(
+          "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), got \(error)",
+          sourceLocation: sourceLocation)
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)", sourceLocation: sourceLocation)
+    }
+  }
+
+  // MARK: - List
+
+  @Test("200 returns page of records")
+  func listSuccess() async throws {
+    let json = """
+      [{
+        "id": "rec-1",
+        "display_value": "Alpha",
+        "condition": "active",
+        "values": [{
+          "id": "val-1",
+          "field_id": "fld-1",
+          "value_text": "Alpha",
+          "value_number": null,
+          "value_date": null,
+          "select_value_uid": null,
+          "catalog_value_uid": null,
+          "user_uid": null,
+          "directory_record_id": null
+        }]
+      }, {
+        "id": "rec-2",
+        "display_value": null,
+        "condition": "inactive",
+        "values": []
+      }]
+      """
+    let client = try makeClient(.returning(statusCode: 200, body: json))
+
+    let page = try await client.listCustomDirectoryRecords(directoryId: "dir-1")
+    #expect(page.items.count == 2)
+    #expect(page.items[0].id == "rec-1")
+    #expect(page.items[0].display_value == "Alpha")
+    #expect(page.items[0].recordCondition == .active)
+    #expect(page.items[0].values?.first?.value_text == "Alpha")
+    #expect(page.items[0].values?.first?.value_number == nil)
+    #expect(page.items[1].display_value == nil)
+    #expect(page.items[1].recordCondition == .inactive)
+  }
+
+  @Test("200 with empty body returns empty page")
+  func listEmptyBody() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: ""))
+    let page = try await client.listCustomDirectoryRecords(directoryId: "dir-1")
+    #expect(page.items.isEmpty)
+  }
+
+  /// The API is documented as beta, so undocumented condition values must survive as `.unknown`
+  /// instead of failing the whole response.
+  @Test("undocumented condition decodes as unknown")
+  func listUndocumentedCondition() async throws {
+    let json = """
+      [{"id": "rec-1", "display_value": "Alpha", "condition": "some_new_condition"}]
+      """
+    let client = try makeClient(.returning(statusCode: 200, body: json))
+
+    let page = try await client.listCustomDirectoryRecords(directoryId: "dir-1")
+    #expect(page.items[0].recordCondition == .unknown("some_new_condition"))
+  }
+
+  @Test("query parameters are sent")
+  func listSendsQueryParameters() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
+    let client = try makeClient(transport)
+
+    _ = try await client.listCustomDirectoryRecords(
+      directoryId: "dir-1",
+      query: "alpha",
+      profile: .summary,
+      includeValues: true,
+      includeAuthor: false,
+      conditions: [.active, .inactive],
+      filters: "{\"fld-1\":{\"value_text\":\"Alpha\"}}",
+      filterOperator: .or,
+      offset: 10,
+      limit: 50
+    )
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    let path = try #require(recorded.request.path)
+    #expect(path.hasPrefix("/company/custom-directories/dir-1/records?"))
+    #expect(path.contains("query=alpha"))
+    #expect(path.contains("profile=summary"))
+    #expect(path.contains("include_values=true"))
+    #expect(path.contains("include_author=false"))
+    #expect(path.contains("conditions=active"))
+    #expect(path.contains("conditions=inactive"))
+    #expect(path.contains("filter_operator=or"))
+    #expect(path.contains("offset=10"))
+    #expect(path.contains("limit=50"))
+  }
+
+  @Test("limit above 100 throws invalidPaginationRange")
+  func listInvalidPagination() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: "[]"))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCustomDirectoryRecords(directoryId: "dir-1", limit: 101)
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func listUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCustomDirectoryRecords(directoryId: "dir-1")
+    }
+  }
+
+  /// Directories are addressed by string ID, which ``KaitenError/notFound(resource:id:)``
+  /// cannot represent, so a 404 surfaces as `unexpectedResponse`.
+  @Test("404 throws unexpectedResponse")
+  func listNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await expectUnexpectedResponse(statusCode: 404) {
+      _ = try await client.listCustomDirectoryRecords(directoryId: "missing")
+    }
+  }
+
+  // MARK: - Create
+
+  @Test("create sends values map and parses the full record")
+  func createSendsBody() async throws {
+    let json = """
+      {
+        "id": "rec-1",
+        "custom_directory_id": "dir-1",
+        "display_value": "Alice",
+        "condition": "active",
+        "author_uid": "user-uid-1",
+        "updater_uid": "user-uid-1",
+        "created": "2026-04-01T00:00:00.000Z",
+        "updated": "2026-04-01T00:00:00.000Z",
+        "author": {"uid": "user-uid-1", "full_name": "Test User"},
+        "updater": {"uid": "user-uid-1", "full_name": "Test User"},
+        "values": [{
+          "id": "val-1",
+          "field_id": "fld-1",
+          "value_text": "Alice",
+          "value_number": null,
+          "value_date": null,
+          "select_value_uid": null,
+          "catalog_value_uid": null,
+          "user_uid": null,
+          "directory_record_id": null
+        }]
+      }
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let values = try JSONDecoder().decode(
+      Components.Schemas.CreateCustomDirectoryRecordRequest.valuesPayload.self,
+      from: Data("{\"fld-1\": {\"value_text\": \"Alice\"}}".utf8))
+    let record = try await client.createCustomDirectoryRecord(
+      directoryId: "dir-1", values: values, responseProfile: .full)
+
+    #expect(record.id == "rec-1")
+    #expect(record.custom_directory_id == "dir-1")
+    #expect(record.recordCondition == .active)
+    #expect(record.author_uid == "user-uid-1")
+    #expect(record.values?.first?.field_id == "fld-1")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .post)
+    let path = try #require(recorded.request.path)
+    #expect(path.hasPrefix("/company/custom-directories/dir-1/records"))
+    #expect(path.contains("response_profile=full"))
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    let sentValues = try #require(sent["values"] as? [String: Any])
+    let sentField = try #require(sentValues["fld-1"] as? [String: Any])
+    #expect(sentField["value_text"] as? String == "Alice")
+  }
+
+  @Test("create 400 throws unexpectedResponse")
+  func createValidationError() async throws {
+    let client = try makeClient(.returning(statusCode: 400))
+    await expectUnexpectedResponse(statusCode: 400) {
+      _ = try await client.createCustomDirectoryRecord(
+        directoryId: "dir-1", values: .init())
+    }
+  }
+
+  // MARK: - Get
+
+  @Test("200 returns the record")
+  func getSuccess() async throws {
+    let json = """
+      {
+        "id": "rec-1",
+        "custom_directory_id": "dir-1",
+        "display_value": "Alpha",
+        "values": [{
+          "id": "val-1",
+          "field_id": "fld-1",
+          "value_text": null,
+          "value_number": 42.5,
+          "value_date": null,
+          "select_value_uid": "sel-1",
+          "catalog_value_uid": null,
+          "user_uid": null,
+          "directory_record_id": null,
+          "selectValue": {"uid": "sel-1", "value": "Option A"}
+        }],
+        "author": {"uid": "user-uid-1"},
+        "updater": {"uid": "user-uid-1"}
+      }
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let record = try await client.getCustomDirectoryRecord(
+      directoryId: "dir-1", recordId: "rec-1", profile: .details)
+
+    #expect(record.id == "rec-1")
+    #expect(record.display_value == "Alpha")
+    let value = try #require(record.values?.first)
+    #expect(value.value_number == 42.5)
+    #expect(value.value_text == nil)
+    #expect(value.select_value_uid == "sel-1")
+    #expect(value.selectValue != nil)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    let path = try #require(recorded.request.path)
+    #expect(path.hasPrefix("/company/custom-directories/dir-1/records/rec-1"))
+    #expect(path.contains("profile=details"))
+  }
+
+  /// Records are addressed by string ID, which ``KaitenError/notFound(resource:id:)``
+  /// cannot represent, so a 404 surfaces as `unexpectedResponse`.
+  @Test("get 404 throws unexpectedResponse")
+  func getNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await expectUnexpectedResponse(statusCode: 404) {
+      _ = try await client.getCustomDirectoryRecord(directoryId: "dir-1", recordId: "missing")
+    }
+  }
+
+  // MARK: - Update
+
+  @Test("update targets the record and sends condition and values")
+  func updateSuccess() async throws {
+    let json = """
+      {
+        "id": "rec-1",
+        "display_value": "Beta",
+        "values": [],
+        "author": {"uid": "user-uid-1"},
+        "updater": {"uid": "user-uid-2"}
+      }
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let values = try JSONDecoder().decode(
+      Components.Schemas.UpdateCustomDirectoryRecordRequest.valuesPayload.self,
+      from: Data("{\"fld-1\": {\"value_text\": \"Beta\"}}".utf8))
+    let record = try await client.updateCustomDirectoryRecord(
+      directoryId: "dir-1",
+      recordId: "rec-1",
+      condition: .inactive,
+      values: values
+    )
+
+    #expect(record.id == "rec-1")
+    #expect(record.display_value == "Beta")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .patch)
+    let path = try #require(recorded.request.path)
+    #expect(path.hasPrefix("/company/custom-directories/dir-1/records/rec-1"))
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["condition"] as? String == "inactive")
+    let sentValues = try #require(sent["values"] as? [String: Any])
+    let sentField = try #require(sentValues["fld-1"] as? [String: Any])
+    #expect(sentField["value_text"] as? String == "Beta")
+  }
+
+  @Test("update 400 throws unexpectedResponse")
+  func updateValidationError() async throws {
+    let client = try makeClient(.returning(statusCode: 400))
+    await expectUnexpectedResponse(statusCode: 400) {
+      _ = try await client.updateCustomDirectoryRecord(
+        directoryId: "dir-1", recordId: "rec-1", condition: .active)
+    }
+  }
+
+  // MARK: - Delete
+
+  @Test("delete returns the removed record")
+  func deleteSuccess() async throws {
+    let json = """
+      {"id": "rec-1", "condition": "removed"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let record = try await client.deleteCustomDirectoryRecord(
+      directoryId: "dir-1", recordId: "rec-1")
+
+    #expect(record.id == "rec-1")
+    #expect(record.recordCondition == .removed)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .delete)
+    #expect(recorded.request.path == "/company/custom-directories/dir-1/records/rec-1")
+  }
+
+  @Test("delete 404 throws unexpectedResponse")
+  func deleteNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await expectUnexpectedResponse(statusCode: 404) {
+      _ = try await client.deleteCustomDirectoryRecord(directoryId: "dir-1", recordId: "missing")
+    }
+  }
+
+  // MARK: - Linked Cards
+
+  @Test("200 returns page of linked cards")
+  func listCardsSuccess() async throws {
+    let json = """
+      [
+        {"id": 101, "uid": "card-uid-1", "title": "First card"},
+        {"id": 102, "uid": "card-uid-2", "title": "Second card"}
+      ]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let page = try await client.listCustomDirectoryRecordCards(
+      directoryId: "dir-1", recordId: "rec-1", filter: "eyJrZXkiOiAidmFsdWUifQ==")
+
+    #expect(page.items.count == 2)
+    #expect(page.items[0].id == 101)
+    #expect(page.items[0].uid == "card-uid-1")
+    #expect(page.items[0].title == "First card")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    let path = try #require(recorded.request.path)
+    #expect(path.hasPrefix("/company/custom-directories/dir-1/records/rec-1/cards"))
+    #expect(path.contains("filter="))
+  }
+
+  @Test("linked cards 200 with empty body returns empty page")
+  func listCardsEmptyBody() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: ""))
+    let page = try await client.listCustomDirectoryRecordCards(
+      directoryId: "dir-1", recordId: "rec-1")
+    #expect(page.items.isEmpty)
+  }
+
+  @Test("linked cards limit above 100 throws invalidPaginationRange")
+  func listCardsInvalidPagination() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: "[]"))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCustomDirectoryRecordCards(
+        directoryId: "dir-1", recordId: "rec-1", limit: 101)
+    }
+  }
+
+  @Test("linked cards 400 throws unexpectedResponse")
+  func listCardsValidationError() async throws {
+    let client = try makeClient(.returning(statusCode: 400))
+    await expectUnexpectedResponse(statusCode: 400) {
+      _ = try await client.listCustomDirectoryRecordCards(
+        directoryId: "dir-1", recordId: "rec-1", filter: "not-base64")
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -3909,6 +3909,261 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /company/custom-directories/{directory_id}/records:
+    get:
+      summary: Get list of records
+      operationId: list_custom_directory_records
+      parameters:
+      - name: directory_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Directory ID
+      - name: limit
+        in: query
+        schema:
+          type: integer
+        description: 'Maximum number of records in response. Default: 100, max: 100'
+      - name: offset
+        in: query
+        schema:
+          type: integer
+        description: Number of records to skip
+      - name: query
+        in: query
+        schema:
+          type: string
+        description: Quick search by record display value
+      - name: profile
+        in: query
+        schema:
+          type: string
+        description: 'Controls included relations in response. Documented values: none, summary, details, full. Map to the CustomDirectoryProfile Swift enum, which preserves unknown values.'
+      - name: include_values
+        in: query
+        schema:
+          type: boolean
+        description: 'Legacy: include values array'
+      - name: include_author
+        in: query
+        schema:
+          type: boolean
+        description: Include author user object
+      - name: conditions
+        in: query
+        schema:
+          type: array
+          items:
+            type: string
+        description: 'Filter by condition values. Documented values: active, inactive, removed. Map to the CustomDirectoryRecordCondition Swift enum, which preserves unknown values.'
+      # NOTE: docs declare `object` (JSON); represented as a JSON-encoded string because
+      # swift-openapi-generator cannot serialize free-form objects in query parameters.
+      - name: filters
+        in: query
+        schema:
+          type: string
+        description: Advanced field-based filters as a JSON-encoded object
+      - name: filter_operator
+        in: query
+        schema:
+          type: string
+        description: 'Boolean operator for filters. Documented values: and, or. Default: and. Map to the CustomDirectoryFilterOperator Swift enum, which preserves unknown values.'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CustomDirectoryRecord'
+        '401':
+          description: Invalid token
+        # DOC_MISMATCH: docs=404 for a missing directory, actual=HTTP 500 observed for an unknown directory ID — https://developers.kaiten.ru/custom-directory-records/get-list-of-records
+        '404':
+          description: Not found
+    post:
+      summary: Create record
+      operationId: create_custom_directory_record
+      parameters:
+      - name: directory_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Directory ID
+      - name: response_profile
+        in: query
+        schema:
+          type: string
+        description: 'Controls response size. Use `none` to return `{ id }` only. Documented values: none, summary, details, full. Map to the CustomDirectoryProfile Swift enum, which preserves unknown values.'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCustomDirectoryRecordRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomDirectoryRecord'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '404':
+          description: Not found
+  /company/custom-directories/{directory_id}/records/{record_id}:
+    get:
+      summary: Get record
+      operationId: get_custom_directory_record
+      parameters:
+      - name: directory_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Directory ID
+      - name: record_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Record ID
+      - name: profile
+        in: query
+        schema:
+          type: string
+        description: 'Controls included relations in response. Documented values: none, summary, details, full. Map to the CustomDirectoryProfile Swift enum, which preserves unknown values.'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomDirectoryRecord'
+        '401':
+          description: Invalid token
+        '404':
+          description: Not found
+    patch:
+      summary: Update record
+      operationId: update_custom_directory_record
+      parameters:
+      - name: directory_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Directory ID
+      - name: record_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Record ID
+      - name: response_profile
+        in: query
+        schema:
+          type: string
+        description: 'Controls response size. Use `none` to return `{ id }` only. Documented values: none, summary, details, full. Map to the CustomDirectoryProfile Swift enum, which preserves unknown values.'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateCustomDirectoryRecordRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomDirectoryRecord'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '404':
+          description: Not found
+    delete:
+      summary: Delete record
+      operationId: delete_custom_directory_record
+      parameters:
+      - name: directory_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Directory ID
+      - name: record_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Record ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomDirectoryRecord'
+        '401':
+          description: Invalid token
+        '404':
+          description: Not found
+  /company/custom-directories/{directory_id}/records/{record_id}/cards:
+    get:
+      summary: Get cards linked to record
+      operationId: list_custom_directory_record_cards
+      parameters:
+      - name: directory_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Directory ID
+      - name: record_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Record ID
+      - name: limit
+        in: query
+        schema:
+          type: integer
+        description: 'Maximum number of cards in response. Default: 100, max: 100'
+      - name: offset
+        in: query
+        schema:
+          type: integer
+        description: Number of records to skip
+      - name: filter
+        in: query
+        schema:
+          type: string
+        description: Base64-encoded JSON card filter, merged with the base filter
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CustomDirectoryLinkedCard'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '404':
+          description: Not found
 components:
   securitySchemes:
     bearerAuth:
@@ -8898,3 +9153,140 @@ components:
         id:
           type: integer
           description: Deleted user id
+    # The Kaiten documentation describes this entity per endpoint with different subsets of
+    # fields — which fields are present depends on the requested profile/response_profile —
+    # so one shared schema declares the union with every property optional.
+    # The custom directories API is documented as beta and subject to change.
+    CustomDirectoryRecord:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Record ID (UUID)
+        custom_directory_id:
+          type: string
+          description: Directory ID (UUID)
+        display_value:
+          type:
+          - string
+          - 'null'
+          description: Pre-computed record display value
+        condition:
+          type: string
+          description: 'Record condition. Documented values: active, inactive, removed. Map to the CustomDirectoryRecordCondition Swift enum, which preserves unknown values.'
+        author_uid:
+          type: string
+          description: Author user UID (UUID)
+        updater_uid:
+          type: string
+          description: Updater user UID (UUID)
+        created:
+          type: string
+          description: Create date
+        updated:
+          type: string
+          description: Last update timestamp
+        author:
+          type: object
+          additionalProperties: true
+          description: Author user object. Included depending on profile/include_author; its shape is not described in the Kaiten documentation
+        updater:
+          type: object
+          additionalProperties: true
+          description: Updater user object. Included depending on profile; its shape is not described in the Kaiten documentation
+        values:
+          type: array
+          items:
+            $ref: '#/components/schemas/CustomDirectoryRecordValue'
+          description: Field values. Included depending on profile/include_values
+    CustomDirectoryRecordValue:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Value ID (UUID)
+        field_id:
+          type: string
+          description: Field ID (UUID)
+        value_text:
+          type:
+          - string
+          - 'null'
+          description: Text value (string/email/url/phone/checkbox)
+        value_number:
+          type:
+          - number
+          - 'null'
+          description: Numeric value
+        value_date:
+          type:
+          - string
+          - 'null'
+          description: Date value as ISO string
+        select_value_uid:
+          type:
+          - string
+          - 'null'
+          description: Select option UID
+        catalog_value_uid:
+          type:
+          - string
+          - 'null'
+          description: Catalog value UID
+        user_uid:
+          type:
+          - string
+          - 'null'
+          description: User UID
+        directory_record_id:
+          type:
+          - string
+          - 'null'
+          description: Linked directory record ID (UUID)
+        selectValue:
+          type: object
+          additionalProperties: true
+          description: Populated select option (when profile includes values). Its shape is not described in the Kaiten documentation
+        catalogValue:
+          type: object
+          additionalProperties: true
+          description: Populated catalog value (when profile includes values). Its shape is not described in the Kaiten documentation
+        user:
+          type: object
+          additionalProperties: true
+          description: Populated user object (when profile includes values). Its shape is not described in the Kaiten documentation
+        linkedRecord:
+          type: object
+          additionalProperties: true
+          description: Populated linked record (directory_link field). Its shape is not described in the Kaiten documentation
+    CustomDirectoryLinkedCard:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Card ID
+        uid:
+          type: string
+          description: Card UID (UUID)
+        title:
+          type: string
+          description: Card title
+    CreateCustomDirectoryRecordRequest:
+      type: object
+      required:
+      - values
+      properties:
+        values:
+          type: object
+          additionalProperties: true
+          description: Values map where keys are custom directory field IDs. Each value is either an object (single-value) or an array of objects (multi-select)
+    UpdateCustomDirectoryRecordRequest:
+      type: object
+      properties:
+        condition:
+          type: string
+          description: 'Custom directory record condition. Documented values: active, inactive, removed. Map to the CustomDirectoryRecordCondition Swift enum, which preserves unknown values.'
+        values:
+          type: object
+          additionalProperties: true
+          description: Values map where keys are custom directory field IDs. Each value is either an object (single-value) or an array of objects (multi-select)

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -292,6 +292,17 @@ let sections: [Section] = [
     Operation(name: "update_custom_directory_field", errors: [.unauthorized, .notFound]),
     Operation(name: "delete_custom_directory_field", errors: [.unauthorized, .notFound]),
   ]),
+  Section(mark: "Custom Directory Records", operations: [
+    Operation(name: "list_custom_directory_records", errors: [.unauthorized, .notFound]),
+    Operation(
+      name: "create_custom_directory_record", errors: [.badRequest, .unauthorized, .notFound]),
+    Operation(name: "get_custom_directory_record", errors: [.unauthorized, .notFound]),
+    Operation(
+      name: "update_custom_directory_record", errors: [.badRequest, .unauthorized, .notFound]),
+    Operation(name: "delete_custom_directory_record", errors: [.unauthorized, .notFound]),
+    Operation(
+      name: "list_custom_directory_record_cards", errors: [.badRequest, .unauthorized, .notFound]),
+  ]),
 ]
 
 // MARK: - Generator


### PR DESCRIPTION
Adds SDK, CLI and OpenAPI spec support for the six documented `custom-directory-records` endpoints.

## Endpoints

- [x] `GET /company/custom-directories/{directory_id}/records` — `listCustomDirectoryRecords` / `list-custom-directory-records`
- [x] `POST /company/custom-directories/{directory_id}/records` — `createCustomDirectoryRecord` / `create-custom-directory-record`
- [x] `GET /company/custom-directories/{directory_id}/records/{record_id}` — `getCustomDirectoryRecord` / `get-custom-directory-record`
- [x] `PATCH /company/custom-directories/{directory_id}/records/{record_id}` — `updateCustomDirectoryRecord` / `update-custom-directory-record`
- [x] `DELETE /company/custom-directories/{directory_id}/records/{record_id}` — `deleteCustomDirectoryRecord` / `delete-custom-directory-record`
- [x] `GET /company/custom-directories/{directory_id}/records/{record_id}/cards` — `listCustomDirectoryRecordCards` / `list-custom-directory-record-cards`

## Live verification vs docs-only

The live company used for verification has **no custom directories** (`GET /company/custom-directories` returns `[]`), so no record GET could be exercised against real data. All schemas are therefore built strictly from the documentation pages, including every nested schema dialog (record values). Test fixtures follow the documented response attributes and the documentation's request example, with invented IDs.

One live observation was possible: probing the records list with a syntactically valid but nonexistent directory ID answers HTTP **500**, where the docs document 404 for "Not found".

## DOC_MISMATCH annotations

1 annotation added:

- `GET .../records` 404 response: docs=404 for a missing directory, actual=HTTP 500 observed for an unknown directory ID.

Additionally, two `# NOTE:` comments document representation choices that are not doc/API divergences: the `filters` query parameter is declared as a JSON-encoded string because `swift-openapi-generator` cannot serialize free-form objects in query parameters, and the record schema is a single union of the per-endpoint documented subsets because field presence depends on the requested profile.

## Details

- Discriminators (`condition`, `profile`, `filter_operator`) are plain strings in the spec with hand-written enums in `Enums.swift` (`CustomDirectoryRecordCondition`, `CustomDirectoryProfile`, `CustomDirectoryFilterOperator`), each with an `unknown(String)` case (FR-020a pattern) — the API is documented as beta, so unknown values must not fail responses.
- The documented `none` profile value is spelled `.noRelations` in Swift: a case literally named `none` is shadowed by `Optional.none` at every `CustomDirectoryProfile?` call site, silently omitting the parameter instead of sending `profile=none`.
- All documented query parameters are exposed (FR-010), including the legacy `include_values`/`include_author` switches and the Base64 `filter` on the linked-cards endpoint.
- Both list endpoints are paginated (`limit` capped at 100) and return `Page<T>`; limits are validated locally (FR-014).
- Records and directories are addressed by string IDs, so 404s surface as `unexpectedResponse` per FR-021.
- Request `values` maps and populated relation objects (`author`, `updater`, `selectValue`, `catalogValue`, `user`, `linkedRecord`) stay free-form JSON — the documentation does not describe their shapes.
- 18 tests: every endpoint has a 200 parsing test plus error paths (400/401/404), pagination validation, query-parameter serialization, request-body assertions, and unknown-discriminator preservation.
- README API Reference and CLI documentation updated; `ResponseMapping.swift` regenerated via its generator script.

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)
