### PR TITLE
feat(custom-property-tree-entities): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,9 @@ kaiten detach-card-file --card-id 123 --file-id 7
 | `listCustomPropertySelectValues(propertyId:)` | List select values for a custom property |
 | `getCustomPropertySelectValue(propertyId:id:)` | Get a single select value |
 | `createCustomPropertySelectValue(propertyId:value:color:)` | Create a select value for a custom property |
+| `listCustomPropertyTreeEntities(propertyId:)` | List tree entities of a custom property |
+| `addCustomPropertyTreeEntity(propertyId:treeEntityUid:)` | Add a tree entity to a custom property |
+| `deleteCustomPropertyTreeEntity(propertyId:uid:)` | Delete a tree entity from a custom property |
 
 Property discriminators are exposed as Swift enums (`CustomPropertyType`,
 `CustomPropertyCondition`, `CustomPropertyVoteVariant`,

--- a/Sources/KaitenSDK/KaitenClient+CustomPropertyTreeEntities.swift
+++ b/Sources/KaitenSDK/KaitenClient+CustomPropertyTreeEntities.swift
@@ -1,0 +1,77 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - Custom Property Tree Entities
+
+extension KaitenClient {
+  /// Lists the tree entities attached to a custom property.
+  ///
+  /// - Parameter propertyId: The custom property identifier.
+  /// - Returns: An array of tree entities. Returns an empty array if the custom property has none.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for unsupported tariff (402),
+  ///     forbidden (403) or other undocumented HTTP status codes.
+  public func listCustomPropertyTreeEntities(propertyId: Int) async throws(KaitenError)
+    -> [Components.Schemas.CustomPropertyTreeEntity]
+  {
+    guard
+      let response = try await callList({
+        try await client.list_custom_property_tree_entities(path: .init(property_id: propertyId))
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Adds a tree entity to a custom property.
+  ///
+  /// - Parameters:
+  ///   - propertyId: The custom property identifier.
+  ///   - treeEntityUid: The UID of the tree entity to attach.
+  /// - Returns: The identifier of the custom property the entity was attached to.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for bad request (400), unsupported
+  ///     tariff (402), forbidden (403) or other undocumented HTTP status codes.
+  public func addCustomPropertyTreeEntity(
+    propertyId: Int,
+    treeEntityUid: String
+  ) async throws(KaitenError) -> Components.Schemas.CustomPropertyIdResponse {
+    let response = try await call {
+      try await client.add_custom_property_tree_entity(
+        path: .init(property_id: propertyId),
+        body: .json(.init(tree_entity_uid: treeEntityUid))
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Deletes a tree entity from a custom property.
+  ///
+  /// - Parameters:
+  ///   - propertyId: The custom property identifier.
+  ///   - uid: The UID of the tree entity to detach.
+  /// - Returns: The identifier of the custom property the entity was detached from.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for unsupported tariff (402),
+  ///     forbidden (403) or other undocumented HTTP status codes.
+  public func deleteCustomPropertyTreeEntity(
+    propertyId: Int,
+    uid: String
+  ) async throws(KaitenError) -> Components.Schemas.CustomPropertyIdResponse {
+    let response = try await call {
+      try await client.delete_custom_property_tree_entity(
+        path: .init(property_id: propertyId, uid: uid))
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -1581,3 +1581,48 @@ extension Operations.list_custom_directory_record_cards.Output {
     }
   }
 }
+
+// MARK: - Custom Property Tree Entities
+
+extension Operations.list_custom_property_tree_entities.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.list_custom_property_tree_entities.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.add_custom_property_tree_entity.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.add_custom_property_tree_entity.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.delete_custom_property_tree_entity.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.delete_custom_property_tree_entity.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/CustomPropertyTreeEntities/CustomPropertyTreeEntitieCommands.swift
+++ b/Sources/kaiten/CustomPropertyTreeEntities/CustomPropertyTreeEntitieCommands.swift
@@ -1,0 +1,69 @@
+import ArgumentParser
+import KaitenSDK
+
+// MARK: - List Custom Property Tree Entities
+
+struct ListCustomPropertyTreeEntities: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-custom-property-tree-entities",
+    abstract: "List tree entities of a custom property"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Custom property ID")
+  var propertyId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let entities = try await client.listCustomPropertyTreeEntities(propertyId: propertyId)
+    try printJSON(entities)
+  }
+}
+
+// MARK: - Add Custom Property Tree Entity
+
+struct AddCustomPropertyTreeEntity: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "add-custom-property-tree-entity",
+    abstract: "Add a tree entity to a custom property"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Custom property ID")
+  var propertyId: Int
+
+  @Option(name: .long, help: "Tree entity UID")
+  var treeEntityUid: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let result = try await client.addCustomPropertyTreeEntity(
+      propertyId: propertyId, treeEntityUid: treeEntityUid)
+    try printJSON(result)
+  }
+}
+
+// MARK: - Delete Custom Property Tree Entity
+
+struct DeleteCustomPropertyTreeEntity: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "delete-custom-property-tree-entity",
+    abstract: "Delete a tree entity from a custom property"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Custom property ID")
+  var propertyId: Int
+
+  @Option(name: .long, help: "Tree entity UID")
+  var uid: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let result = try await client.deleteCustomPropertyTreeEntity(propertyId: propertyId, uid: uid)
+    try printJSON(result)
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -133,6 +133,9 @@ struct Kaiten: AsyncParsableCommand {
       UpdateCustomDirectoryRecord.self,
       DeleteCustomDirectoryRecord.self,
       ListCustomDirectoryRecordCards.self,
+      ListCustomPropertyTreeEntities.self,
+      AddCustomPropertyTreeEntity.self,
+      DeleteCustomPropertyTreeEntity.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/CustomPropertyTreeEntitiesTests.swift
+++ b/Tests/KaitenSDKTests/CustomPropertyTreeEntitiesTests.swift
@@ -1,0 +1,193 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("CustomPropertyTreeEntities")
+struct CustomPropertyTreeEntitiesTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// `KaitenError` is not `Equatable`, so the status code is matched by pattern.
+  private func expectUnexpectedResponse(
+    statusCode: Int,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      Issue.record(
+        "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), no error thrown",
+        sourceLocation: sourceLocation)
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == statusCode else {
+        Issue.record(
+          "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), got \(error)",
+          sourceLocation: sourceLocation)
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)", sourceLocation: sourceLocation)
+    }
+  }
+
+  // MARK: - List
+
+  /// Fixture mirrors a sanitized live response: every field the documentation
+  /// lists came back non-null, and `sort_order` is a fractional number.
+  @Test("200 returns array of CustomPropertyTreeEntity")
+  func listSuccess() async throws {
+    let json = """
+      [{
+        "uid": "11111111-2222-3333-4444-555555555555",
+        "access": "by_invite",
+        "for_everyone_access_role_id": "66666666-7777-8888-9999-aaaaaaaaaaaa",
+        "entity_type": "space",
+        "path": "10.abc123.def456",
+        "sort_order": 1.4588347597716682,
+        "parent_entity_uid": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+        "company_id": 10,
+        "protected": false,
+        "archived": false,
+        "title": "Product space"
+      }]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let entities = try await client.listCustomPropertyTreeEntities(propertyId: 42)
+    #expect(entities.count == 1)
+    #expect(entities[0].uid == "11111111-2222-3333-4444-555555555555")
+    #expect(entities[0].access == "by_invite")
+    #expect(entities[0].for_everyone_access_role_id == "66666666-7777-8888-9999-aaaaaaaaaaaa")
+    #expect(entities[0].entity_type == "space")
+    #expect(entities[0].path == "10.abc123.def456")
+    #expect(entities[0].sort_order == 1.4588347597716682)
+    #expect(entities[0].parent_entity_uid == "bbbbbbbb-cccc-dddd-eeee-ffffffffffff")
+    #expect(entities[0].company_id == 10)
+    #expect(entities[0].protected == false)
+    #expect(entities[0].archived == false)
+    #expect(entities[0].title == "Product space")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    #expect(recorded.request.path == "/company/custom-properties/42/tree-entities")
+  }
+
+  /// The live API returns an empty array for a property with no usage paths.
+  @Test("200 with empty array returns empty array")
+  func listEmpty() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: "[]"))
+    let entities = try await client.listCustomPropertyTreeEntities(propertyId: 42)
+    #expect(entities.isEmpty)
+  }
+
+  @Test("401 throws unauthorized")
+  func listUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listCustomPropertyTreeEntities(propertyId: 42)
+    }
+  }
+
+  @Test("402 unsupported tariff throws unexpectedResponse")
+  func listPaymentRequired() async throws {
+    let client = try makeClient(.returning(statusCode: 402))
+    await expectUnexpectedResponse(statusCode: 402) {
+      _ = try await client.listCustomPropertyTreeEntities(propertyId: 42)
+    }
+  }
+
+  @Test("403 throws unexpectedResponse")
+  func listForbidden() async throws {
+    let client = try makeClient(.returning(statusCode: 403))
+    await expectUnexpectedResponse(statusCode: 403) {
+      _ = try await client.listCustomPropertyTreeEntities(propertyId: 42)
+    }
+  }
+
+  // MARK: - Add
+
+  /// Fixture follows the documented example response: an object with the custom property id.
+  @Test("add sends tree_entity_uid and returns the custom property id")
+  func addSuccess() async throws {
+    let json = """
+      {"id": 42}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let result = try await client.addCustomPropertyTreeEntity(
+      propertyId: 42, treeEntityUid: "11111111-2222-3333-4444-555555555555")
+    #expect(result.id == 42)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .post)
+    #expect(recorded.request.path == "/company/custom-properties/42/tree-entities")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["tree_entity_uid"] as? String == "11111111-2222-3333-4444-555555555555")
+  }
+
+  @Test("add 400 throws unexpectedResponse")
+  func addBadRequest() async throws {
+    let client = try makeClient(.returning(statusCode: 400))
+    await expectUnexpectedResponse(statusCode: 400) {
+      _ = try await client.addCustomPropertyTreeEntity(propertyId: 42, treeEntityUid: "missing-uid")
+    }
+  }
+
+  @Test("add 402 unsupported tariff throws unexpectedResponse")
+  func addPaymentRequired() async throws {
+    let client = try makeClient(.returning(statusCode: 402))
+    await expectUnexpectedResponse(statusCode: 402) {
+      _ = try await client.addCustomPropertyTreeEntity(propertyId: 42, treeEntityUid: "some-uid")
+    }
+  }
+
+  // MARK: - Delete
+
+  /// Fixture follows the documented response schema: an object with the custom property id.
+  @Test("delete targets the tree entity UID and returns the custom property id")
+  func deleteSuccess() async throws {
+    let json = """
+      {"id": 42}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let result = try await client.deleteCustomPropertyTreeEntity(
+      propertyId: 42, uid: "11111111-2222-3333-4444-555555555555")
+    #expect(result.id == 42)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .delete)
+    #expect(
+      recorded.request.path
+        == "/company/custom-properties/42/tree-entities/11111111-2222-3333-4444-555555555555")
+  }
+
+  @Test("delete 403 throws unexpectedResponse")
+  func deleteForbidden() async throws {
+    let client = try makeClient(.returning(statusCode: 403))
+    await expectUnexpectedResponse(statusCode: 403) {
+      _ = try await client.deleteCustomPropertyTreeEntity(propertyId: 42, uid: "some-uid")
+    }
+  }
+
+  @Test("delete 401 throws unauthorized")
+  func deleteUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.deleteCustomPropertyTreeEntity(propertyId: 42, uid: "some-uid")
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -1833,6 +1833,93 @@ paths:
           description: Invalid token
         '404':
           description: Not found
+  /company/custom-properties/{property_id}/tree-entities:
+    get:
+      summary: Get list of custom property tree entities
+      operationId: list_custom_property_tree_entities
+      parameters:
+      - name: property_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Custom property ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CustomPropertyTreeEntity'
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
+    post:
+      summary: Add tree entity to custom property
+      operationId: add_custom_property_tree_entity
+      parameters:
+      - name: property_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Custom property ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddCustomPropertyTreeEntityRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPropertyIdResponse'
+        '400':
+          description: Bad request
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
+  /company/custom-properties/{property_id}/tree-entities/{uid}:
+    delete:
+      summary: Delete tree entity from custom property
+      operationId: delete_custom_property_tree_entity
+      parameters:
+      - name: property_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Custom property ID
+      - name: uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Tree entity uid
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPropertyIdResponse'
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
   /spaces:
     post:
       summary: Create new space
@@ -5050,6 +5137,56 @@ components:
         company_id:
           type: integer
           description: Company id
+    CustomPropertyTreeEntity:
+      type: object
+      properties:
+        uid:
+          type: string
+          description: Entity uid
+        title:
+          type: string
+          description: Entity title
+        sort_order:
+          type: number
+          description: Entity sort order
+        archived:
+          type: boolean
+          description: Archived flag
+        access:
+          type: string
+          description: Entity access
+        for_everyone_access_role_id:
+          type: string
+          description: Role id for when access is for_everyone
+        entity_type:
+          type: string
+          description: Entity type
+        path:
+          type: string
+          description: Inner path to entity
+        parent_entity_uid:
+          type: string
+          description: Parent entity uid
+        company_id:
+          type: integer
+          description: Company id
+        protected:
+          type: boolean
+          description: Flag that disables the display of an element in the sidebar
+    AddCustomPropertyTreeEntityRequest:
+      type: object
+      required:
+      - tree_entity_uid
+      properties:
+        tree_entity_uid:
+          type: string
+          description: Tree entity uuid
+    CustomPropertyIdResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Custom property id
     UpdateChecklistRequest:
       type: object
       properties:

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -303,6 +303,17 @@ let sections: [Section] = [
     Operation(
       name: "list_custom_directory_record_cards", errors: [.badRequest, .unauthorized, .notFound]),
   ]),
+  Section(mark: "Custom Property Tree Entities", operations: [
+    Operation(
+      name: "list_custom_property_tree_entities",
+      errors: [.unauthorized, .paymentRequired, .forbidden]),
+    Operation(
+      name: "add_custom_property_tree_entity",
+      errors: [.badRequest, .unauthorized, .paymentRequired, .forbidden]),
+    Operation(
+      name: "delete_custom_property_tree_entity",
+      errors: [.unauthorized, .paymentRequired, .forbidden]),
+  ]),
 ]
 
 // MARK: - Generator


### PR DESCRIPTION
Implements the three documented `custom-property-tree-entities` endpoints.

## Endpoints

- [x] `GET /company/custom-properties/{property_id}/tree-entities` — `listCustomPropertyTreeEntities(propertyId:)` / `list-custom-property-tree-entities`
- [x] `POST /company/custom-properties/{property_id}/tree-entities` — `addCustomPropertyTreeEntity(propertyId:treeEntityUid:)` / `add-custom-property-tree-entity`
- [x] `DELETE /company/custom-properties/{property_id}/tree-entities/{uid}` — `deleteCustomPropertyTreeEntity(propertyId:uid:)` / `delete-custom-property-tree-entity`

## Verification

- **Live-verified:** the GET endpoint was fetched against a live instance (both empty and non-empty responses). Every documented field came back with the documented type and nullability — no divergence, so **no DOC_MISMATCH annotations were needed**. The list-test fixture is a sanitized live response.
- **Docs-only:** POST and DELETE are mutating and were not sent to the live API; their schemas and test fixtures follow the documentation.
- No query parameters are documented for any of the three endpoints.

## Changes

- `openapi/kaiten.yaml` — paths plus `CustomPropertyTreeEntity`, `AddCustomPropertyTreeEntityRequest`, `CustomPropertyIdResponse` schemas
- `Sources/KaitenSDK/KaitenClient+CustomPropertyTreeEntities.swift` — DocC-documented wrappers
- `scripts/generate-response-mapping.swift` + regenerated `ResponseMapping.swift`
- `Sources/kaiten/CustomPropertyTreeEntities/CustomPropertyTreeEntitieCommands.swift`, registered in `Kaiten.swift`
- README "API Reference" — Custom Properties table rows
- `Tests/KaitenSDKTests/CustomPropertyTreeEntitiesTests.swift` — 11 tests (success, empty list, 400/401/402/403 error paths)

`swift format lint --strict` clean; full `swift test` suite green (398 tests).

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)
