### PR TITLE
feat(group-admins): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,21 @@ CLI: `list-custom-directory-records`, `create-custom-directory-record`,
 `delete-custom-directory-record`, `list-custom-directory-record-cards` — all
 take `--directory-id`, the record-scoped ones also `--record-id`.
 
+### Group Admins
+
+| Method | Description |
+|--------|-------------|
+| `listGroupAdmins(groupUid:)` | List admins of a group |
+| `addGroupAdmin(groupUid:userId:)` | Add a user as an admin of a group |
+| `removeGroupAdmin(groupUid:userId:)` | Remove an admin from a group |
+
+Groups are addressed by string UID. Adding and removing an admin both return
+the affected user.
+
+CLI: `list-group-admins --group-uid <uid>`,
+`add-group-admin --group-uid <uid> --user-id <id>`,
+`remove-group-admin --group-uid <uid> --user-id <id>`.
+
 ## Pagination
 
 Most list endpoints accept `offset` and `limit` parameters and return a `Page<T>`:

--- a/Sources/KaitenSDK/KaitenClient+GroupAdmins.swift
+++ b/Sources/KaitenSDK/KaitenClient+GroupAdmins.swift
@@ -1,0 +1,85 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - Group Admins
+
+extension KaitenClient {
+  /// Lists the admins of a group.
+  ///
+  /// - Parameter groupUid: The group UID.
+  /// - Returns: An array of group admins. Returns an empty array if the group has no admins.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for forbidden (403), not found (404)
+  ///     or other undocumented HTTP status codes. A 404 is reported as `unexpectedResponse` rather
+  ///     than ``KaitenError/notFound(resource:id:)`` because groups are addressed by string UID,
+  ///     which that case cannot represent.
+  public func listGroupAdmins(groupUid: String) async throws(KaitenError) -> [Components.Schemas
+    .GroupAdmin]
+  {
+    guard
+      let response = try await callList({
+        try await client.list_group_admins(path: .init(group_uid: groupUid))
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Adds a user as an admin of a group.
+  ///
+  /// - Parameters:
+  ///   - groupUid: The group UID.
+  ///   - userId: The identifier of the user to make a group admin.
+  /// - Returns: The added group admin.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for validation errors (400),
+  ///     unsupported tariff (402), forbidden (403), not found (404) or other undocumented HTTP
+  ///     status codes. A 404 is reported as `unexpectedResponse` rather than
+  ///     ``KaitenError/notFound(resource:id:)`` because groups are addressed by string UID,
+  ///     which that case cannot represent.
+  public func addGroupAdmin(groupUid: String, userId: Int) async throws(KaitenError)
+    -> Components
+    .Schemas.GroupAdmin
+  {
+    let response = try await call {
+      try await client.add_group_admin(
+        path: .init(group_uid: groupUid),
+        body: .json(.init(user_id: userId))
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Removes an admin from a group.
+  ///
+  /// - Parameters:
+  ///   - groupUid: The group UID.
+  ///   - userId: The identifier of the admin to remove.
+  /// - Returns: The removed group admin.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for unsupported tariff (402),
+  ///     forbidden (403), not found (404) or other undocumented HTTP status codes. A 404 is
+  ///     reported as `unexpectedResponse` rather than ``KaitenError/notFound(resource:id:)``
+  ///     because the group is addressed by string UID and the response does not say whether the
+  ///     group or the user is missing.
+  public func removeGroupAdmin(groupUid: String, userId: Int) async throws(KaitenError)
+    -> Components.Schemas.GroupAdmin
+  {
+    let response = try await call {
+      try await client.remove_group_admin(
+        path: .init(group_uid: groupUid, user_id: userId)
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -1715,3 +1715,44 @@ extension Operations.delete_custom_property_tree_entity.Output {
     }
   }
 }
+
+// MARK: - Group Admins
+
+extension Operations.list_group_admins.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_group_admins.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.add_group_admin.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.add_group_admin.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.remove_group_admin.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.remove_group_admin.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/GroupAdmins/GroupAdminCommands.swift
+++ b/Sources/kaiten/GroupAdmins/GroupAdminCommands.swift
@@ -1,0 +1,68 @@
+import ArgumentParser
+import KaitenSDK
+
+// MARK: - List Group Admins
+
+struct ListGroupAdmins: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-group-admins",
+    abstract: "List admins of a group"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Group UID")
+  var groupUid: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let admins = try await client.listGroupAdmins(groupUid: groupUid)
+    try printJSON(admins, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Add Group Admin
+
+struct AddGroupAdmin: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "add-group-admin",
+    abstract: "Add a user as an admin of a group"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Group UID")
+  var groupUid: String
+
+  @Option(name: .long, help: "User ID")
+  var userId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let admin = try await client.addGroupAdmin(groupUid: groupUid, userId: userId)
+    try printJSON(admin, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Remove Group Admin
+
+struct RemoveGroupAdmin: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "remove-group-admin",
+    abstract: "Remove an admin from a group"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Group UID")
+  var groupUid: String
+
+  @Option(name: .long, help: "User ID")
+  var userId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let admin = try await client.removeGroupAdmin(groupUid: groupUid, userId: userId)
+    try printJSON(admin, expand: global.expandedFields)
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -143,6 +143,9 @@ struct Kaiten: AsyncParsableCommand {
       ListCustomPropertyTreeEntities.self,
       AddCustomPropertyTreeEntity.self,
       DeleteCustomPropertyTreeEntity.self,
+      ListGroupAdmins.self,
+      AddGroupAdmin.self,
+      RemoveGroupAdmin.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/GroupAdminsTests.swift
+++ b/Tests/KaitenSDKTests/GroupAdminsTests.swift
@@ -1,0 +1,239 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Group Admins")
+struct GroupAdminsTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// `KaitenError` is not `Equatable`, so the status code is matched by pattern.
+  private func expectUnexpectedResponse(
+    statusCode: Int,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      Issue.record(
+        "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), no error thrown",
+        sourceLocation: sourceLocation)
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == statusCode else {
+        Issue.record(
+          "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), got \(error)",
+          sourceLocation: sourceLocation)
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)", sourceLocation: sourceLocation)
+    }
+  }
+
+  // MARK: - List
+
+  /// Fixture follows the documented example response of the list endpoint, which carries
+  /// `sd_telegram_id`, `news_subscription` and `delete_confirmation_sent_at` on top of the
+  /// fields the add/remove responses document.
+  @Test("200 returns array of GroupAdmin")
+  func listSuccess() async throws {
+    let json = """
+      [{
+        "created": "2024-08-06T06:30:38.514Z",
+        "updated": "2024-08-06T06:30:38.514Z",
+        "id": 272,
+        "uid": "1cd74db5-7c62-4a9a-9c19-053f583c4008",
+        "full_name": "Clara Walker",
+        "username": "Abbie60262",
+        "email": "clara@example.com",
+        "activated": true,
+        "avatar_initials_url": "data:image/png;base64,abc",
+        "avatar_uploaded_url": null,
+        "initials": "CW",
+        "avatar_type": 2,
+        "lng": "en",
+        "sd_telegram_id": null,
+        "timezone": "UTC",
+        "news_subscription": false,
+        "theme": "auto",
+        "ui_version": 2,
+        "virtual": false,
+        "email_blocked": null,
+        "email_blocked_reason": null,
+        "delete_requested_at": null,
+        "delete_confirmation_sent_at": null
+      }]
+      """
+    let client = try makeClient(.returning(statusCode: 200, body: json))
+
+    let admins = try await client.listGroupAdmins(groupUid: "group-uid-1")
+    #expect(admins.count == 1)
+    #expect(admins[0].id == 272)
+    #expect(admins[0].uid == "1cd74db5-7c62-4a9a-9c19-053f583c4008")
+    #expect(admins[0].full_name == "Clara Walker")
+    #expect(admins[0].avatar_uploaded_url == nil)
+    #expect(admins[0].avatar_type == 2)
+    #expect(admins[0].sd_telegram_id == nil)
+    #expect(admins[0].news_subscription == false)
+    #expect(admins[0].delete_confirmation_sent_at == nil)
+  }
+
+  @Test("list targets the group UID")
+  func listRequestPath() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
+    let client = try makeClient(transport)
+
+    _ = try await client.listGroupAdmins(groupUid: "group-uid-1")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    #expect(recorded.request.path == "/groups/group-uid-1/admins")
+  }
+
+  @Test("200 with empty body returns empty array")
+  func listEmptyBody() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: ""))
+    let admins = try await client.listGroupAdmins(groupUid: "group-uid-1")
+    #expect(admins.isEmpty)
+  }
+
+  @Test("401 throws unauthorized")
+  func listUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listGroupAdmins(groupUid: "group-uid-1")
+    }
+  }
+
+  /// Groups are addressed by string UID, which ``KaitenError/notFound(resource:id:)``
+  /// cannot represent, so a 404 surfaces as `unexpectedResponse`.
+  @Test("list 404 throws unexpectedResponse")
+  func listNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await expectUnexpectedResponse(statusCode: 404) {
+      _ = try await client.listGroupAdmins(groupUid: "missing")
+    }
+  }
+
+  // MARK: - Add
+
+  /// Fixture follows the documented example response of the add endpoint.
+  @Test("add sends user_id in the body")
+  func addSendsBody() async throws {
+    let json = """
+      {
+        "id": 1,
+        "uid": "20072568-2bb5-4c48-94ba-ee7986e4ac83",
+        "full_name": "Johnny Doe",
+        "email": "admin@example.com",
+        "username": "admin",
+        "avatar_initials_url": "data:image/png;base64,abc",
+        "avatar_uploaded_url": null,
+        "initials": "JD",
+        "avatar_type": 2,
+        "lng": "en",
+        "timezone": "UTC",
+        "theme": "auto",
+        "created": "2024-08-06T06:30:37.802Z",
+        "updated": "2024-09-06T13:48:40.670Z",
+        "activated": true,
+        "ui_version": 2,
+        "virtual": false,
+        "email_blocked": null,
+        "email_blocked_reason": null,
+        "delete_requested_at": null
+      }
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let admin = try await client.addGroupAdmin(groupUid: "group-uid-1", userId: 1)
+
+    #expect(admin.id == 1)
+    #expect(admin.username == "admin")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .post)
+    #expect(recorded.request.path == "/groups/group-uid-1/admins")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["user_id"] as? Int == 1)
+  }
+
+  @Test("add 400 validation error throws unexpectedResponse")
+  func addBadRequest() async throws {
+    let client = try makeClient(.returning(statusCode: 400))
+    await expectUnexpectedResponse(statusCode: 400) {
+      _ = try await client.addGroupAdmin(groupUid: "group-uid-1", userId: 1)
+    }
+  }
+
+  @Test("add 402 unsupported tariff throws unexpectedResponse")
+  func addPaymentRequired() async throws {
+    let client = try makeClient(.returning(statusCode: 402))
+    await expectUnexpectedResponse(statusCode: 402) {
+      _ = try await client.addGroupAdmin(groupUid: "group-uid-1", userId: 1)
+    }
+  }
+
+  // MARK: - Remove
+
+  /// Fixture follows the documented example response of the remove endpoint.
+  @Test("remove targets the group UID and user ID and returns the removed admin")
+  func removeSuccess() async throws {
+    let json = """
+      {
+        "id": 1,
+        "uid": "20072568-2bb5-4c48-94ba-ee7986e4ac83",
+        "full_name": "Johnny Doe",
+        "email": "admin@example.com",
+        "username": "admin",
+        "avatar_initials_url": "data:image/png;base64,abc",
+        "avatar_uploaded_url": null,
+        "initials": "JD",
+        "avatar_type": 2,
+        "lng": "en",
+        "timezone": "UTC",
+        "theme": "auto",
+        "created": "2024-08-06T06:30:37.802Z",
+        "updated": "2024-09-06T13:48:40.670Z",
+        "activated": true,
+        "ui_version": 2,
+        "virtual": false,
+        "email_blocked": null,
+        "email_blocked_reason": null,
+        "delete_requested_at": null
+      }
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let admin = try await client.removeGroupAdmin(groupUid: "group-uid-1", userId: 1)
+
+    #expect(admin.id == 1)
+    #expect(admin.full_name == "Johnny Doe")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .delete)
+    #expect(recorded.request.path == "/groups/group-uid-1/admins/1")
+  }
+
+  /// The group is addressed by string UID and the response does not say whether the group or
+  /// the user is missing, so a 404 surfaces as `unexpectedResponse`.
+  @Test("remove 404 throws unexpectedResponse")
+  func removeNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await expectUnexpectedResponse(statusCode: 404) {
+      _ = try await client.removeGroupAdmin(groupUid: "missing", userId: 1)
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -4490,6 +4490,97 @@ paths:
           description: Invalid token
         '404':
           description: Not found
+  /groups/{group_uid}/admins:
+    get:
+      summary: Get list of group admins
+      operationId: list_group_admins
+      parameters:
+      - name: group_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Group UID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GroupAdmin'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    post:
+      summary: Add admin to group
+      operationId: add_group_admin
+      parameters:
+      - name: group_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Group UID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddGroupAdminRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupAdmin'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+  /groups/{group_uid}/admins/{user_id}:
+    delete:
+      summary: Remove admin from group
+      operationId: remove_group_admin
+      parameters:
+      - name: group_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Group UID
+      - name: user_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: User ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupAdmin'
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
 components:
   securitySchemes:
     bearerAuth:
@@ -9761,3 +9852,98 @@ components:
           type: object
           additionalProperties: true
           description: Values map where keys are custom directory field IDs. Each value is either an object (single-value) or an array of objects (multi-select)
+    GroupAdmin:
+      type: object
+      description: A company user who administers a group. The Kaiten documentation lists `sd_telegram_id` and `news_subscription` only for the list endpoint, and `delete_confirmation_sent_at` is present only in the list endpoint response
+      properties:
+        id:
+          type: integer
+          description: User id
+        # DOC_MISMATCH: not in docs attribute tables, present in every documented example response — https://developers.kaiten.ru/group-admins/get-list-of-group-admins
+        uid:
+          type: string
+          description: User uid
+        full_name:
+          type: string
+          description: User full name
+        email:
+          type: string
+          description: User email
+        username:
+          type: string
+          description: Username for mentions and login
+        avatar_initials_url:
+          type: string
+          description: Default user avatar
+        avatar_uploaded_url:
+          type:
+          - string
+          - 'null'
+          description: User uploaded avatar url
+        initials:
+          type: string
+          description: User initials
+        avatar_type:
+          type: integer
+          description: 1 - gravatar, 2 - initials, 3 - uploaded
+        lng:
+          type: string
+          description: Language
+        timezone:
+          type: string
+          description: Time zone
+        theme:
+          type: string
+          description: light - light color theme, dark - dark color theme, auto - color theme based on OS settings
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        activated:
+          type: boolean
+          description: User activated flag
+        ui_version:
+          type: integer
+          description: 1 - old ui, 2 - new ui
+        virtual:
+          type: boolean
+          description: Is user virtual
+        email_blocked:
+          type:
+          - string
+          - 'null'
+          description: Email blocked timestamp
+        email_blocked_reason:
+          type:
+          - string
+          - 'null'
+          description: Email blocked reason
+        delete_requested_at:
+          type:
+          - string
+          - 'null'
+          description: Timestamp of delete request
+        delete_confirmation_sent_at:
+          type:
+          - string
+          - 'null'
+          description: Timestamp of sending confirmation of deletion
+        # DOC_MISMATCH: docs=`integer`, documented example response=`null` — https://developers.kaiten.ru/group-admins/get-list-of-group-admins
+        sd_telegram_id:
+          type:
+          - integer
+          - 'null'
+          description: Service desk telegram id
+        news_subscription:
+          type: boolean
+          description: News subscription flag
+    AddGroupAdminRequest:
+      type: object
+      required:
+      - user_id
+      properties:
+        user_id:
+          type: integer
+          description: User Id

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -326,6 +326,15 @@ let sections: [Section] = [
       name: "delete_custom_property_tree_entity",
       errors: [.unauthorized, .paymentRequired, .forbidden]),
   ]),
+  Section(mark: "Group Admins", operations: [
+    Operation(name: "list_group_admins", errors: [.unauthorized, .forbidden, .notFound]),
+    Operation(
+      name: "add_group_admin",
+      errors: [.badRequest, .unauthorized, .paymentRequired, .forbidden, .notFound]),
+    Operation(
+      name: "remove_group_admin",
+      errors: [.unauthorized, .paymentRequired, .forbidden, .notFound]),
+  ]),
 ]
 
 // MARK: - Generator


### PR DESCRIPTION
## Endpoints

- [x] `GET /groups/{group_uid}/admins` — list group admins ([docs](https://developers.kaiten.ru/group-admins/get-list-of-group-admins))
- [x] `POST /groups/{group_uid}/admins` — add admin to group ([docs](https://developers.kaiten.ru/group-admins/add-admin-to-group))
- [x] `DELETE /groups/{group_uid}/admins/{user_id}` — remove admin from group ([docs](https://developers.kaiten.ru/group-admins/remove-admin-from-group))

## What was added

- `openapi/kaiten.yaml`: the three paths plus `GroupAdmin` and `AddGroupAdminRequest` schemas, built from the official documentation pages (attribute tables and example responses). Nullable fields use the `type: [T, 'null']` pattern; no `anyOf: [$ref, 'null']`.
- `Sources/KaitenSDK/KaitenClient+GroupAdmins.swift`: `listGroupAdmins(groupUid:)`, `addGroupAdmin(groupUid:userId:)`, `removeGroupAdmin(groupUid:userId:)` with DocC comments. Groups are addressed by string UID, so a 404 surfaces as `unexpectedResponse` (the `notFound(resource:id:)` case cannot represent a string id), matching the automations precedent.
- `scripts/generate-response-mapping.swift` + regenerated `ResponseMapping.swift`.
- `Sources/kaiten/GroupAdmins/GroupAdminCommands.swift`: `list-group-admins`, `add-group-admin`, `remove-group-admin`, registered in `Kaiten.swift`.
- README: "Group Admins" API Reference section with SDK methods and CLI commands.
- `Tests/KaitenSDKTests/GroupAdminsTests.swift`: 10 tests — success parse per endpoint (fixtures follow the documented example responses), request method/path/body assertions, and error paths (400, 401, 402, 404).

## Live verification

Not possible for this resource: the available API token cannot access group endpoints — `GET /company/groups` returns 403, so no group UID could be obtained, and `GET /groups/{uid}/admins` with an unknown UID returns 404. All schemas therefore come strictly from the documentation, and no docs-vs-live `DOC_MISMATCH` could be recorded.

Two docs-internal divergences are annotated in the spec with `DOC_MISMATCH` comments:
- `uid` is absent from every response attribute table but present in every documented example response.
- `sd_telegram_id` is declared `integer` in the list endpoint's attribute table but is `null` in its documented example, so it is modeled as nullable.

## Checks

- `swift format lint --strict --recursive Sources/ Tests/` clean
- `swift test` green (397 tests)

Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)