### PR TITLE
feat(document-schemas): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,33 @@ CLI: `list-group-admins --group-uid <uid>`,
 `add-group-admin --group-uid <uid> --user-id <id>`,
 `remove-group-admin --group-uid <uid> --user-id <id>`.
 
+### Document Schemas
+
+| Method | Description |
+|--------|-------------|
+| `getDocumentSchema(id:format:)` | Get the document data schema |
+
+Returns the schema used to validate and describe document data in ProseMirror
+JSON format. Pass `latest` as the `id` for the latest available schema, or a
+concrete version such as `v25`; the response `version` field always carries the
+resolved `v{number}` version.
+
+The response shape follows the requested `DocumentSchemaFormat`: `.draft06`
+(the API default) returns a JSON Schema draft-06 document, `.proseMirror`
+returns sanitized ProseMirror node and mark specs. Exactly one of the
+`draft06` and `proseMirror` accessors on the result is populated:
+
+```swift
+let schema = try await client.getDocumentSchema(id: "latest")
+print(schema.draft06?.version ?? "")
+
+let specs = try await client.getDocumentSchema(id: "latest", format: .proseMirror)
+print(specs.proseMirror?.topNode ?? "")
+```
+
+CLI: `kaiten get-document-schema --id latest` with optional `--format`
+(`draft-06` or `prosemirror`).
+
 ## Pagination
 
 Most list endpoints accept `offset` and `limit` parameters and return a `Page<T>`:

--- a/Sources/KaitenSDK/Enums.swift
+++ b/Sources/KaitenSDK/Enums.swift
@@ -1904,3 +1904,48 @@ public enum CustomPropertySelectValueCondition: Sendable, Equatable, CaseIterabl
     try container.encode(rawValue)
   }
 }
+
+// MARK: - Document Schemas
+
+/// Document data schema response format.
+///
+/// Used in ``KaitenClient/getDocumentSchema(id:format:)``.
+/// - SeeAlso: [Kaiten API – Document schemas](https://developers.kaiten.ru/document-schemas/get-document-data-schema)
+public enum DocumentSchemaFormat: Sendable, Equatable, CaseIterable, Codable {
+  /// JSON Schema draft-06 representation (the API default).
+  case draft06
+  /// Sanitized ProseMirror node and mark specs.
+  case proseMirror
+  /// Unknown value returned by the API (forward compatibility).
+  case unknown(String)
+
+  public static var allCases: [DocumentSchemaFormat] {
+    [.draft06, .proseMirror]
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "draft-06": self = .draft06
+    case "prosemirror": self = .proseMirror
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: String {
+    switch self {
+    case .draft06: "draft-06"
+    case .proseMirror: "prosemirror"
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(String.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}

--- a/Sources/KaitenSDK/KaitenClient+DocumentSchemas.swift
+++ b/Sources/KaitenSDK/KaitenClient+DocumentSchemas.swift
@@ -1,0 +1,61 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - Typed Variants
+
+// GET /document-schemas/{id} returns one of two structurally different objects,
+// selected by the request's `format` query parameter. The generated `anyOf`
+// surface exposes them as `value1`/`value2`; these accessors give the variants
+// readable names.
+
+extension Components.Schemas.DocumentSchema {
+  /// The JSON Schema draft-06 variant, or `nil` when the response carries the
+  /// ProseMirror variant.
+  public var draft06: Components.Schemas.DocumentSchemaDraft06? {
+    value1
+  }
+
+  /// The sanitized ProseMirror variant, or `nil` when the response carries the
+  /// JSON Schema draft-06 variant.
+  public var proseMirror: Components.Schemas.DocumentSchemaProseMirror? {
+    value2
+  }
+}
+
+// MARK: - Document Schemas
+
+extension KaitenClient {
+  /// Gets the schema used to validate and describe document data in ProseMirror JSON format.
+  ///
+  /// - Parameters:
+  ///   - id: The document schema version. Pass `latest` for the latest available schema, or a
+  ///     concrete version in `v{number}` format, for example `v25`. When `latest` is passed, the
+  ///     response `version` field contains the resolved `v{number}` version.
+  ///   - format: The response format. The API defaults to ``DocumentSchemaFormat/draft06``, which
+  ///     returns a JSON Schema draft-06 document; ``DocumentSchemaFormat/proseMirror`` returns
+  ///     sanitized ProseMirror node and mark specs.
+  /// - Returns: The document data schema. Exactly one of
+  ///   ``Components/Schemas/DocumentSchema/draft06`` and
+  ///   ``Components/Schemas/DocumentSchema/proseMirror`` is populated, matching the requested
+  ///   format.
+  /// - Throws:
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for unsupported format (400),
+  ///     schema version not found (404) or other undocumented HTTP status codes. A 404 is
+  ///     reported as `unexpectedResponse` rather than ``KaitenError/notFound(resource:id:)``
+  ///     because document schemas are addressed by string version, which that case cannot
+  ///     represent.
+  public func getDocumentSchema(
+    id: String,
+    format: DocumentSchemaFormat? = nil
+  ) async throws(KaitenError) -> Components.Schemas.DocumentSchema {
+    let response = try await call {
+      try await client.get_document_schema(
+        path: .init(id: id),
+        query: .init(format: format?.rawValue)
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -1756,3 +1756,16 @@ extension Operations.remove_group_admin.Output {
     }
   }
 }
+
+// MARK: - Document Schemas
+
+extension Operations.get_document_schema.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_document_schema.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/DocumentSchemas/DocumentSchemaCommands.swift
+++ b/Sources/kaiten/DocumentSchemas/DocumentSchemaCommands.swift
@@ -1,0 +1,41 @@
+import ArgumentParser
+import Foundation
+import KaitenSDK
+
+// MARK: - Get Document Schema
+
+struct GetDocumentSchema: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "get-document-schema",
+    abstract: "Get the document data schema",
+    discussion: """
+      Returns the schema used to validate and describe document data in ProseMirror JSON \
+      format. The response shape follows --format: a JSON Schema draft-06 document by default, \
+      or sanitized ProseMirror node and mark specs with runtime-only fields omitted.
+      """
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(
+    name: .long,
+    help: "Document schema version: 'latest', or a concrete version such as 'v25'")
+  var id: String
+
+  @Option(name: .long, help: "Response format: draft-06 (default), prosemirror")
+  var format: String?
+
+  func run() async throws {
+    let parsedFormat = try format.map { rawValue in
+      let format = DocumentSchemaFormat(rawValue: rawValue)
+      guard DocumentSchemaFormat.allCases.contains(format) else {
+        let allowed = DocumentSchemaFormat.allCases.map(\.rawValue).joined(separator: ", ")
+        throw ValidationError("Invalid format: '\(rawValue)'. Allowed values: \(allowed)")
+      }
+      return format
+    }
+    let client = try await global.makeClient()
+    let schema = try await client.getDocumentSchema(id: id, format: parsedFormat)
+    try printJSON(schema, expand: global.expandedFields)
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -146,6 +146,7 @@ struct Kaiten: AsyncParsableCommand {
       ListGroupAdmins.self,
       AddGroupAdmin.self,
       RemoveGroupAdmin.self,
+      GetDocumentSchema.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/DocumentSchemasTests.swift
+++ b/Tests/KaitenSDKTests/DocumentSchemasTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Document Schemas")
+struct DocumentSchemasTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// `KaitenError` is not `Equatable`, so the status code is matched by pattern.
+  private func expectUnexpectedResponse(
+    statusCode: Int,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      Issue.record(
+        "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), no error thrown",
+        sourceLocation: sourceLocation)
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == statusCode else {
+        Issue.record(
+          "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), got \(error)",
+          sourceLocation: sourceLocation)
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)", sourceLocation: sourceLocation)
+    }
+  }
+
+  /// Trimmed from a live response: full top-level shape, `definitions` cut down to a
+  /// representative node and mark.
+  private static let draft06JSON = """
+    {
+      "$schema": "http://json-schema.org/draft-06/schema",
+      "$id": "kaiten://document-schemas/v25",
+      "title": "Kaiten document data ProseMirror schema v25",
+      "description": "JSON Schema representation for ProseMirror document data.",
+      "allOf": [{"$ref": "#/definitions/nodes/doc"}],
+      "version": "v25",
+      "definitions": {
+        "nodes": {
+          "doc": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type", "content"],
+            "properties": {
+              "type": {"const": "doc"},
+              "content": {
+                "type": "array",
+                "items": {"anyOf": [{"$ref": "#/definitions/nodes/paragraph"}]},
+                "minItems": 1
+              }
+            },
+            "x-prosemirror": {"content": "block+"}
+          },
+          "paragraph": {"type": "object"}
+        },
+        "marks": {
+          "strong": {"type": "object"}
+        }
+      }
+    }
+    """
+
+  /// Trimmed from a live response: full top-level shape, `nodes` and `marks` cut down to
+  /// representative specs.
+  private static let proseMirrorJSON = """
+    {
+      "type": "prosemirror-document-data-schema",
+      "version": "v25",
+      "topNode": "doc",
+      "data": {"type": "doc", "content": "block+"},
+      "nodes": {
+        "doc": {"content": "block+"},
+        "text": {"group": "inline"},
+        "paragraph": {
+          "content": "inline*",
+          "attrs": {"textAlign": {"default": "left"}},
+          "group": "block"
+        }
+      },
+      "marks": {
+        "strong": {},
+        "em": {}
+      }
+    }
+    """
+
+  // MARK: - Get
+
+  @Test("200 with the default format decodes the draft-06 variant")
+  func getDraft06() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: Self.draft06JSON)
+    let client = try makeClient(transport)
+
+    let schema = try await client.getDocumentSchema(id: "latest")
+
+    let draft06 = try #require(schema.draft06)
+    #expect(schema.proseMirror == nil)
+    #expect(draft06._dollar_schema == "http://json-schema.org/draft-06/schema")
+    #expect(draft06._dollar_id == "kaiten://document-schemas/v25")
+    #expect(draft06.version == "v25")
+    #expect(draft06.allOf?.count == 1)
+    let nodes = try #require(draft06.definitions?.nodes)
+    #expect(nodes.additionalProperties.value.keys.contains("doc"))
+    let marks = try #require(draft06.definitions?.marks)
+    #expect(marks.additionalProperties.value.keys.contains("strong"))
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    #expect(recorded.request.path == "/document-schemas/latest")
+  }
+
+  @Test("200 with format=prosemirror decodes the ProseMirror variant")
+  func getProseMirror() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: Self.proseMirrorJSON)
+    let client = try makeClient(transport)
+
+    let schema = try await client.getDocumentSchema(id: "v25", format: .proseMirror)
+
+    let proseMirror = try #require(schema.proseMirror)
+    #expect(schema.draft06 == nil)
+    #expect(proseMirror._type == "prosemirror-document-data-schema")
+    #expect(proseMirror.version == "v25")
+    #expect(proseMirror.topNode == "doc")
+    let nodes = try #require(proseMirror.nodes)
+    #expect(nodes.additionalProperties.value.keys.contains("paragraph"))
+    let marks = try #require(proseMirror.marks)
+    #expect(marks.additionalProperties.value.keys.contains("em"))
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    #expect(recorded.request.path == "/document-schemas/v25?format=prosemirror")
+  }
+
+  @Test("format is omitted from the query when not passed")
+  func getOmitsFormat() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: Self.draft06JSON)
+    let client = try makeClient(transport)
+
+    _ = try await client.getDocumentSchema(id: "v25")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.path == "/document-schemas/v25")
+  }
+
+  @Test("400 unsupported format throws unexpectedResponse")
+  func getBadRequest() async throws {
+    let client = try makeClient(.returning(statusCode: 400))
+    await expectUnexpectedResponse(statusCode: 400) {
+      _ = try await client.getDocumentSchema(id: "latest", format: .unknown("bogus"))
+    }
+  }
+
+  /// Document schemas are addressed by string version, which
+  /// ``KaitenError/notFound(resource:id:)`` cannot represent, so a 404 surfaces as
+  /// `unexpectedResponse`.
+  @Test("404 throws unexpectedResponse")
+  func getNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await expectUnexpectedResponse(statusCode: 404) {
+      _ = try await client.getDocumentSchema(id: "v99999")
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -4581,6 +4581,33 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /document-schemas/{id}:
+    get:
+      summary: Get document data schema
+      operationId: get_document_schema
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Document schema version. Use `latest` for the latest available schema, or a version in `v{number}` format, for example `v25`. When `latest` is used, the response `version` field contains the resolved `v{number}` version
+      - name: format
+        in: query
+        schema:
+          type: string
+        description: 'Response format. Documented values: draft-06 (default), prosemirror. Map to the DocumentSchemaFormat Swift enum, which preserves unknown values'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentSchema'
+        '400':
+          description: Unsupported schema format
+        '404':
+          description: Schema version not found
 components:
   securitySchemes:
     bearerAuth:
@@ -9947,3 +9974,89 @@ components:
         user_id:
           type: integer
           description: User Id
+    # GET /document-schemas/{id} returns one of two structurally different objects, selected by
+    # the request's `format` query parameter: JSON Schema draft-06 (the default) or sanitized
+    # ProseMirror specs. Modelled as `anyOf` like CardFileEntry: an OpenAPI discriminator cannot
+    # key off a field that exists in only one variant. The variants are unambiguous regardless —
+    # `$schema` is required in one and `type` in the other (both always present in live
+    # responses) — so a payload decodes as exactly one of them.
+    #
+    # Guarded by Tests/KaitenSDKTests/DocumentSchemasTests.swift.
+    DocumentSchema:
+      anyOf:
+        - $ref: '#/components/schemas/DocumentSchemaDraft06'
+        - $ref: '#/components/schemas/DocumentSchemaProseMirror'
+      description: Document data schema - a JSON Schema draft-06 document or sanitized ProseMirror specs, depending on the requested format
+    DocumentSchemaDraft06:
+      type: object
+      description: JSON Schema draft-06 representation of the Kaiten document data schema
+      # NOTE: `$schema` is listed as required so the DocumentSchema `anyOf` stays unambiguous —
+      # the ProseMirror variant never carries it. Confirmed always present in live responses.
+      required:
+      - $schema
+      properties:
+        $schema:
+          type: string
+          description: JSON Schema dialect URI. Always http://json-schema.org/draft-06/schema for this format
+        $id:
+          type: string
+          description: Schema identifier in kaiten://document-schemas/{version} format
+        title:
+          type: string
+          description: Schema title
+        description:
+          type: string
+          description: Schema description
+        allOf:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+          description: Root schema references. Points to the top ProseMirror node definition
+        version:
+          type: string
+          description: Resolved document schema version. If latest was requested, this field contains the actual v{number} version
+        definitions:
+          $ref: '#/components/schemas/DocumentSchemaDefinitions'
+          description: JSON Schema definitions for document nodes and marks
+    DocumentSchemaDefinitions:
+      type: object
+      description: JSON Schema definitions for document nodes and marks
+      properties:
+        nodes:
+          type: object
+          additionalProperties: true
+          description: Map of ProseMirror node names to JSON Schema definitions
+        marks:
+          type: object
+          additionalProperties: true
+          description: Map of ProseMirror mark names to JSON Schema definitions
+    DocumentSchemaProseMirror:
+      type: object
+      description: Sanitized ProseMirror node and mark specs of the Kaiten document data schema
+      # NOTE: `type` is listed as required so the DocumentSchema `anyOf` stays unambiguous —
+      # the draft-06 variant never carries it. Confirmed always present in live responses.
+      required:
+      - type
+      properties:
+        type:
+          type: string
+          description: Schema response type. Always prosemirror-document-data-schema
+        version:
+          type: string
+          description: Resolved document schema version. If latest was requested, this field contains the actual v{number} version
+        topNode:
+          type: string
+          description: Name of the top ProseMirror node
+        data:
+          type: object
+          additionalProperties: true
+          description: Top-level document data descriptor
+        nodes:
+          type: object
+          additionalProperties: true
+          description: Map of sanitized ProseMirror node specs. Runtime-only fields such as parseDOM and toDOM are omitted
+        marks:
+          type: object
+          additionalProperties: true
+          description: Map of sanitized ProseMirror mark specs. Runtime-only fields such as parseDOM and toDOM are omitted


### PR DESCRIPTION
## Endpoints

- [x] `GET /document-schemas/{id}` — Get document data schema ([docs](https://developers.kaiten.ru/document-schemas/get-document-data-schema))

## What was done

- `openapi/kaiten.yaml`: new path plus `DocumentSchema`, `DocumentSchemaDraft06`, `DocumentSchemaDefinitions` and `DocumentSchemaProseMirror` schemas. The endpoint returns one of two structurally different objects selected by the `format` query parameter, so the 200 response is an `anyOf` of the two variants (CardFileEntry precedent), disambiguated by their required `$schema` / `type` fields — no `anyOf: [$ref, 'null']` anywhere, `OpenAPISpecIntegrityTests` stays green.
- All documented query parameters exposed (`format`); the enum-valued parameter is a plain `string` in the spec mapped to a new hand-written `DocumentSchemaFormat` Swift enum with an `unknown(String)` case (FR-020a).
- `Sources/KaitenSDK/KaitenClient+DocumentSchemas.swift`: `getDocumentSchema(id:format:)` with DocC comments, plus named `draft06` / `proseMirror` accessors on the generated union.
- `Sources/kaiten/DocumentSchemas/DocumentSchemaCommands.swift`: `get-document-schema --id <version> [--format <format>]`, registered in `Kaiten.swift`; invalid formats fail locally with the allowed values.
- README "API Reference" gained a Document Schemas section with the method table, usage example and the CLI command.
- `Tests/KaitenSDKTests/DocumentSchemasTests.swift`: 5 tests — both 200 variants (fixtures trimmed from live responses), query-parameter encoding, and 400/404 error paths.

## Live verification

Verified against a live Kaiten instance (read-only GETs only):

- 200 with the default format (JSON Schema draft-06) — every field matches the docs in name, type and presence.
- 200 with `format=prosemirror` — matches the docs.
- 400 for an unsupported format (`message`, `allowedFormats`) — matches the docs.
- 404 for an unknown version (`message`) — matches the docs.

No `DOC_MISMATCH` annotations were needed: documentation and live behaviour agree on every field.

`swift format lint --strict` clean; full `swift test` suite green (392 tests).

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)