### PR TITLE
feat(group-users): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,22 @@ CLI: `kaiten list-company-users` (with the same filters as the SDK method),
 `kaiten update-company-user` with `--id`, `--apps-permissions`,
 `--temporarily-inactive`, and `kaiten remove-virtual-user` with `--id`.
 
+### Group Users
+
+| Method | Description |
+|--------|-------------|
+| `listGroupUsers(groupUid:)` | List users in a company group |
+| `addUserToGroup(groupUid:userId:requestId:operatorComment:)` | Add a user to a company group |
+| `removeUserFromGroup(groupUid:userId:)` | Remove a user from a company group |
+
+Groups are addressed by string UID. Kaiten marks the group-users endpoints as
+under active development, so their responses may change.
+
+CLI: `list-group-users --group-uid <uid>`,
+`add-group-user --group-uid <uid> --user-id <id>` with optional `--request-id`
+and `--operator-comment`,
+`remove-group-user --group-uid <uid> --user-id <id>`.
+
 ### Card Types & Sprints
 
 | Method | Description |

--- a/Sources/KaitenSDK/KaitenClient+GroupUsers.swift
+++ b/Sources/KaitenSDK/KaitenClient+GroupUsers.swift
@@ -1,0 +1,94 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - Group Users
+
+extension KaitenClient {
+  /// Lists users that belong to a company group.
+  ///
+  /// - Parameter groupUid: The group UID.
+  /// - Returns: An array of group users. Returns an empty array if the group has no users.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for forbidden (403), not found (404)
+  ///     or other undocumented HTTP status codes. A 404 is reported as `unexpectedResponse` rather
+  ///     than ``KaitenError/notFound(resource:id:)`` because groups are addressed by string UID.
+  public func listGroupUsers(groupUid: String) async throws(KaitenError) -> [Components.Schemas
+    .GroupUser]
+  {
+    guard
+      let response = try await callList({
+        try await client.list_group_users(path: .init(group_uid: groupUid))
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Adds a user to a company group.
+  ///
+  /// - Parameters:
+  ///   - groupUid: The group UID.
+  ///   - userId: The identifier of the user to add.
+  ///   - requestId: Request id if the addition to the group is an answer to an access request.
+  ///   - operatorComment: Operator's comment if the addition to the group is an answer to an
+  ///     access request. Kaiten accepts 1 to 1024 characters.
+  /// - Returns: The added user.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for validation error (400),
+  ///     unsupported tariff (402), forbidden (403), not found (404) or other undocumented HTTP
+  ///     status codes. A 404 is reported as `unexpectedResponse` rather than
+  ///     ``KaitenError/notFound(resource:id:)`` because groups are addressed by string UID.
+  public func addUserToGroup(
+    groupUid: String,
+    userId: Int,
+    requestId: String? = nil,
+    operatorComment: String? = nil
+  ) async throws(KaitenError) -> Components.Schemas.GroupUser {
+    let response = try await call {
+      try await client.add_user_to_group(
+        path: .init(group_uid: groupUid),
+        body: .json(
+          .init(
+            user_id: userId,
+            request_id: requestId,
+            operator_comment: operatorComment
+          ))
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Removes a user from a company group.
+  ///
+  /// - Parameters:
+  ///   - groupUid: The group UID.
+  ///   - userId: The identifier of the user to remove.
+  /// - Returns: The removed user.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for unsupported tariff (402),
+  ///     forbidden (403), not found (404) or other undocumented HTTP status codes. A 404 is
+  ///     reported as `unexpectedResponse` rather than ``KaitenError/notFound(resource:id:)``
+  ///     because groups are addressed by string UID and the response does not say whether the
+  ///     group or the user is missing.
+  public func removeUserFromGroup(
+    groupUid: String,
+    userId: Int
+  ) async throws(KaitenError) -> Components.Schemas.GroupUser {
+    let response = try await call {
+      try await client.remove_user_from_group(
+        path: .init(group_uid: groupUid, user_id: userId)
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -1922,3 +1922,44 @@ extension Operations.update_collective_score_value.Output {
     }
   }
 }
+
+// MARK: - Group Users
+
+extension Operations.list_group_users.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_group_users.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.add_user_to_group.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.add_user_to_group.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.remove_user_from_group.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.remove_user_from_group.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/GroupUsers/GroupUserCommands.swift
+++ b/Sources/kaiten/GroupUsers/GroupUserCommands.swift
@@ -1,0 +1,82 @@
+import ArgumentParser
+import KaitenSDK
+
+// MARK: - List Group Users
+
+struct ListGroupUsers: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-group-users",
+    abstract: "List users in a company group"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Group UID")
+  var groupUid: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let users = try await client.listGroupUsers(groupUid: groupUid)
+    try printJSON(users, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Add Group User
+
+struct AddGroupUser: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "add-group-user",
+    abstract: "Add a user to a company group"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Group UID")
+  var groupUid: String
+
+  @Option(name: .long, help: "User ID")
+  var userId: Int
+
+  @Option(name: .long, help: "Request id if the addition is an answer to an access request")
+  var requestId: String?
+
+  @Option(
+    name: .long,
+    help: "Operator's comment if the addition is an answer to an access request (1-1024 characters)"
+  )
+  var operatorComment: String?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let user = try await client.addUserToGroup(
+      groupUid: groupUid,
+      userId: userId,
+      requestId: requestId,
+      operatorComment: operatorComment
+    )
+    try printJSON(user, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Remove Group User
+
+struct RemoveGroupUser: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "remove-group-user",
+    abstract: "Remove a user from a company group"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Group UID")
+  var groupUid: String
+
+  @Option(name: .long, help: "User ID")
+  var userId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let user = try await client.removeUserFromGroup(groupUid: groupUid, userId: userId)
+    try printJSON(user, expand: global.expandedFields)
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -158,6 +158,9 @@ struct Kaiten: AsyncParsableCommand {
       ListCollectiveScoreValues.self,
       CreateCollectiveScoreValue.self,
       UpdateCollectiveScoreValue.self,
+      ListGroupUsers.self,
+      AddGroupUser.self,
+      RemoveGroupUser.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/GroupUsersTests.swift
+++ b/Tests/KaitenSDKTests/GroupUsersTests.swift
@@ -1,0 +1,221 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Group Users")
+struct GroupUsersTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// `KaitenError` is not `Equatable`, so the status code is matched by pattern.
+  private func expectUnexpectedResponse(
+    statusCode: Int,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      Issue.record(
+        "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), no error thrown",
+        sourceLocation: sourceLocation)
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == statusCode else {
+        Issue.record(
+          "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), got \(error)",
+          sourceLocation: sourceLocation)
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)", sourceLocation: sourceLocation)
+    }
+  }
+
+  /// Fixture built from the documented response attributes of the group-users endpoints.
+  /// The live GET could not be exercised: listing company groups requires an administrative
+  /// permission the verification token does not have, so no real group UID was obtainable.
+  private static let groupUserJSON = """
+    {
+      "id": 123,
+      "full_name": "Jane Doe",
+      "email": "jane.doe@example.com",
+      "username": "jane.doe",
+      "avatar_initials_url": "https://example.kaiten.ru/avatars/initials/jd.png",
+      "avatar_uploaded_url": null,
+      "initials": "JD",
+      "avatar_type": 2,
+      "lng": "en",
+      "timezone": "Europe/Amsterdam",
+      "theme": "auto",
+      "updated": "2026-01-02T03:04:05.678Z",
+      "created": "2025-01-02T03:04:05.678Z",
+      "activated": true,
+      "ui_version": 2,
+      "virtual": false,
+      "email_blocked": null,
+      "email_blocked_reason": null,
+      "delete_requested_at": null,
+      "delete_confirmation_sent_at": null,
+      "sd_telegram_id": 456,
+      "news_subscription": true
+    }
+    """
+
+  // MARK: - List
+
+  @Test("200 returns array of GroupUser")
+  func listSuccess() async throws {
+    let transport = MockClientTransport.returning(
+      statusCode: 200, body: "[\(Self.groupUserJSON)]")
+    let client = try makeClient(transport)
+
+    let users = try await client.listGroupUsers(groupUid: "group-uid-1")
+    #expect(users.count == 1)
+    #expect(users[0].id == 123)
+    #expect(users[0].full_name == "Jane Doe")
+    #expect(users[0].email == "jane.doe@example.com")
+    #expect(users[0].avatar_uploaded_url == nil)
+    #expect(users[0].avatar_type == 2)
+    #expect(users[0].activated == true)
+    #expect(users[0].virtual == false)
+    #expect(users[0].sd_telegram_id == 456)
+    #expect(users[0].news_subscription == true)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    #expect(recorded.request.path == "/groups/group-uid-1/users")
+  }
+
+  @Test("200 with empty body returns empty array")
+  func listEmptyBody() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: ""))
+    let users = try await client.listGroupUsers(groupUid: "group-uid-1")
+    #expect(users.isEmpty)
+  }
+
+  /// Groups are addressed by string UID, which ``KaitenError/notFound(resource:id:)``
+  /// cannot represent, so a 404 surfaces as `unexpectedResponse`.
+  @Test("list 404 throws unexpectedResponse")
+  func listNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await expectUnexpectedResponse(statusCode: 404) {
+      _ = try await client.listGroupUsers(groupUid: "missing")
+    }
+  }
+
+  @Test("list 401 throws unauthorized")
+  func listUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listGroupUsers(groupUid: "group-uid-1")
+    }
+  }
+
+  @Test("list 403 throws unexpectedResponse")
+  func listForbidden() async throws {
+    let client = try makeClient(.returning(statusCode: 403))
+    await expectUnexpectedResponse(statusCode: 403) {
+      _ = try await client.listGroupUsers(groupUid: "group-uid-1")
+    }
+  }
+
+  // MARK: - Add
+
+  @Test("add sends user_id in the body and parses the added user")
+  func addSendsBody() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: Self.groupUserJSON)
+    let client = try makeClient(transport)
+
+    let user = try await client.addUserToGroup(
+      groupUid: "group-uid-1",
+      userId: 123,
+      requestId: "request-uid-1",
+      operatorComment: "Access approved"
+    )
+
+    #expect(user.id == 123)
+    #expect(user.username == "jane.doe")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .post)
+    #expect(recorded.request.path == "/groups/group-uid-1/users")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["user_id"] as? Int == 123)
+    #expect(sent["request_id"] as? String == "request-uid-1")
+    #expect(sent["operator_comment"] as? String == "Access approved")
+  }
+
+  @Test("add 400 validation error throws unexpectedResponse")
+  func addBadRequest() async throws {
+    let client = try makeClient(.returning(statusCode: 400))
+    await expectUnexpectedResponse(statusCode: 400) {
+      _ = try await client.addUserToGroup(groupUid: "group-uid-1", userId: 123)
+    }
+  }
+
+  @Test("add 402 unsupported tariff throws unexpectedResponse")
+  func addPaymentRequired() async throws {
+    let client = try makeClient(.returning(statusCode: 402))
+    await expectUnexpectedResponse(statusCode: 402) {
+      _ = try await client.addUserToGroup(groupUid: "group-uid-1", userId: 123)
+    }
+  }
+
+  @Test("add 404 throws unexpectedResponse")
+  func addNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await expectUnexpectedResponse(statusCode: 404) {
+      _ = try await client.addUserToGroup(groupUid: "missing", userId: 123)
+    }
+  }
+
+  // MARK: - Remove
+
+  @Test("remove targets the user ID and parses the removed user")
+  func removeSuccess() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: Self.groupUserJSON)
+    let client = try makeClient(transport)
+
+    let user = try await client.removeUserFromGroup(groupUid: "group-uid-1", userId: 123)
+
+    #expect(user.id == 123)
+    #expect(user.email == "jane.doe@example.com")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .delete)
+    #expect(recorded.request.path == "/groups/group-uid-1/users/123")
+  }
+
+  @Test("remove 402 unsupported tariff throws unexpectedResponse")
+  func removePaymentRequired() async throws {
+    let client = try makeClient(.returning(statusCode: 402))
+    await expectUnexpectedResponse(statusCode: 402) {
+      _ = try await client.removeUserFromGroup(groupUid: "group-uid-1", userId: 123)
+    }
+  }
+
+  @Test("remove 403 throws unexpectedResponse")
+  func removeForbidden() async throws {
+    let client = try makeClient(.returning(statusCode: 403))
+    await expectUnexpectedResponse(statusCode: 403) {
+      _ = try await client.removeUserFromGroup(groupUid: "group-uid-1", userId: 123)
+    }
+  }
+
+  @Test("remove 404 throws unexpectedResponse")
+  func removeNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await expectUnexpectedResponse(statusCode: 404) {
+      _ = try await client.removeUserFromGroup(groupUid: "group-uid-1", userId: 456)
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -5008,6 +5008,97 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /groups/{group_uid}/users:
+    get:
+      summary: Get list of group users
+      operationId: list_group_users
+      parameters:
+      - name: group_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Group UID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GroupUser'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    post:
+      summary: Add user to group
+      operationId: add_user_to_group
+      parameters:
+      - name: group_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Group UID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddGroupUserRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupUser'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+  /groups/{group_uid}/users/{user_id}:
+    delete:
+      summary: Remove user from group
+      operationId: remove_user_from_group
+      parameters:
+      - name: group_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Group UID
+      - name: user_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: User ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupUser'
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
 components:
   securitySchemes:
     bearerAuth:
@@ -10677,3 +10768,102 @@ components:
           items:
             type: string
           description: Entity role UIDs for the group
+    GroupUser:
+      type: object
+      description: A user that belongs to a company group. The Kaiten documentation marks the group-users endpoints as under active development, so fields may change
+      properties:
+        id:
+          type: integer
+          description: User id
+        full_name:
+          type: string
+          description: User full name
+        email:
+          type: string
+          description: User email
+        username:
+          type: string
+          description: Username for mentions and login
+        avatar_initials_url:
+          type: string
+          description: Default user avatar
+        avatar_uploaded_url:
+          type:
+          - string
+          - 'null'
+          description: User uploaded avatar url
+        initials:
+          type: string
+          description: User initials
+        avatar_type:
+          type: integer
+          description: 1 - gravatar, 2 - initials, 3 - uploaded
+        lng:
+          type: string
+          description: Language
+        timezone:
+          type: string
+          description: Time zone
+        theme:
+          type: string
+          description: light - light color theme, dark - dark color theme, auto - color theme based on OS settings
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        activated:
+          type: boolean
+          description: User activated flag
+        ui_version:
+          type: integer
+          description: 1 - old ui, 2 - new ui
+        virtual:
+          type: boolean
+          description: Is user virtual
+        email_blocked:
+          type:
+          - string
+          - 'null'
+          description: Email blocked timestamp
+        email_blocked_reason:
+          type:
+          - string
+          - 'null'
+          description: Email blocked reason
+        delete_requested_at:
+          type:
+          - string
+          - 'null'
+          description: Timestamp of delete request
+        # NOTE: documented only in the GET response; the POST and DELETE response docs omit it — https://developers.kaiten.ru/group-users/get-list-of-group-users
+        delete_confirmation_sent_at:
+          type:
+          - string
+          - 'null'
+          description: Timestamp of sending confirmation of deletion
+        # NOTE: documented only in the GET response; the POST and DELETE response docs omit it — https://developers.kaiten.ru/group-users/get-list-of-group-users
+        sd_telegram_id:
+          type: integer
+          description: Service desk telegram id
+        # NOTE: documented only in the GET response; the POST and DELETE response docs omit it — https://developers.kaiten.ru/group-users/get-list-of-group-users
+        news_subscription:
+          type: boolean
+          description: News subscription flag
+    AddGroupUserRequest:
+      type: object
+      required:
+      - user_id
+      properties:
+        user_id:
+          type: integer
+          description: User id
+        request_id:
+          type: string
+          description: Request id if addition to the group is an answer to an access request
+        operator_comment:
+          type: string
+          minLength: 1
+          maxLength: 1024
+          description: Operator's comment if addition to the group is an answer to an access request

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -366,6 +366,15 @@ let sections: [Section] = [
       name: "update_collective_score_value",
       errors: [.badRequest, .unauthorized, .paymentRequired, .forbidden, .notFound]),
   ]),
+  Section(mark: "Group Users", operations: [
+    Operation(name: "list_group_users", errors: [.unauthorized, .forbidden, .notFound]),
+    Operation(
+      name: "add_user_to_group",
+      errors: [.badRequest, .unauthorized, .paymentRequired, .forbidden, .notFound]),
+    Operation(
+      name: "remove_user_from_group",
+      errors: [.unauthorized, .paymentRequired, .forbidden, .notFound]),
+  ]),
 ]
 
 // MARK: - Generator


### PR DESCRIPTION
## Endpoints

- [x] `GET /groups/{group_uid}/users` — Get list of group users ([docs](https://developers.kaiten.ru/group-users/get-list-of-group-users))
- [x] `POST /groups/{group_uid}/users` — Add user to group ([docs](https://developers.kaiten.ru/group-users/add-user-to-group))
- [x] `DELETE /groups/{group_uid}/users/{user_id}` — Remove user from group ([docs](https://developers.kaiten.ru/group-users/remove-user-from-group))

## What was verified how

- **Docs**: all three endpoint pages were scraped from the official documentation — path parameters, request attributes (`user_id`, `request_id`, `operator_comment` with its 1–1024 length constraints) and the response attributes of each endpoint. The endpoints document no query parameters.
- **Live**: only read-only GETs were attempted. Listing company groups (`GET /company/groups`) answered **403** — the verification token lacks the group-management administrative permission — so no real group UID was obtainable and the 200 body of `GET /groups/{group_uid}/users` could not be live-verified. The `GroupUser` schema and the test fixture come strictly from the documented response attributes. No mutating requests were sent.
- **DOC_MISMATCH annotations**: none — no divergence between docs and observable API behaviour could be established. Three fields (`delete_confirmation_sent_at`, `sd_telegram_id`, `news_subscription`) are documented only in the GET response and are annotated with `NOTE` comments in the spec.

## Implementation

- `openapi/kaiten.yaml`: `/groups/{group_uid}/users` (GET, POST) and `/groups/{group_uid}/users/{user_id}` (DELETE) paths, `GroupUser` and `AddGroupUserRequest` schemas. All properties optional, nullability per docs; no `anyOf: [$ref, 'null']`.
- `Sources/KaitenSDK/KaitenClient+GroupUsers.swift`: `listGroupUsers(groupUid:)`, `addUserToGroup(groupUid:userId:requestId:operatorComment:)`, `removeUserFromGroup(groupUid:userId:)` with DocC on every public symbol. Groups are addressed by string UID, so a 404 surfaces as `unexpectedResponse` per FR-021.
- `Sources/kaiten/GroupUsers/GroupUserCommands.swift`: `list-group-users`, `add-group-user`, `remove-group-user`, registered in `Kaiten.swift`.
- `scripts/generate-response-mapping.swift` + regenerated `ResponseMapping.swift`.
- README: Group Users section in the API Reference with the CLI commands.
- `Tests/KaitenSDKTests/GroupUsersTests.swift`: 13 tests — 200 parsing for each endpoint (docs-based fixture, invented IDs and fake user data), empty-body list fallback, request method/path/body assertions, and 400/401/402/403/404 error paths.

`swift format lint --strict` clean, `swift test` green (400 tests).

Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)