### PR TITLE
feat(document-groups): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,6 +755,35 @@ CLI: `list-group-entities --group-uid <uid>`,
 `update-group-entity --group-uid <uid> --uid <uid> --role-ids <uids>`,
 `remove-group-entity --group-uid <uid> --uid <uid>`.
 
+### Document Groups
+
+| Method | Description |
+|--------|-------------|
+| `listDocumentGroups(query:role:offset:limit:)` | List document groups |
+| `searchDocumentGroups(query:condition:startPosition:role:offset:limit:)` | Search document groups via OpenSearch (`version=2`), with a cursor for pagination |
+| `getDocumentGroup(uid:relations:)` | Get a document group |
+| `createDocumentGroup(title:parentEntityUid:forEveryoneAccessRoleId:sortOrder:key:)` | Create a document group |
+| `updateDocumentGroup(uid:title:parentEntityUid:sortOrder:access:...)` | Update a document group |
+| `deleteDocumentGroup(uid:)` | Remove a document group |
+
+The access discriminator is exposed as the `DocumentGroupAccess` Swift enum
+(`.forEveryone`, `.byInvite`) with an `unknown(String)` case that preserves
+values the documentation does not list. `deleteDocumentGroup` returns the
+removed group stub with `archived` set to `true`, and answers HTTP 400 while
+the group still has child tree entities.
+
+```swift
+let groups = try await client.listDocumentGroups(query: "handbook")
+for group in groups where group.documentGroupAccess == .forEveryone {
+  print(group.title ?? "")
+}
+
+let created = try await client.createDocumentGroup(title: "Handbook", key: "HB")
+```
+
+CLI: `list-document-groups`, `search-document-groups`, `get-document-group`,
+`create-document-group`, `update-document-group`, `delete-document-group`.
+
 ## Pagination
 
 Most list endpoints accept `offset` and `limit` parameters and return a `Page<T>`:

--- a/Sources/KaitenSDK/Enums.swift
+++ b/Sources/KaitenSDK/Enums.swift
@@ -2005,3 +2005,49 @@ public enum GroupEntityType: Sendable, Equatable, CaseIterable, Codable {
     try container.encode(rawValue)
   }
 }
+
+// MARK: - Document Groups
+
+/// Document group access type.
+///
+/// Used in the ``KaitenClient`` document group methods, and exposed on decoded
+/// document groups through the `documentGroupAccess` accessor.
+/// - SeeAlso: [Kaiten API – Document groups](https://developers.kaiten.ru/document-groups/retrieve-document-group)
+public enum DocumentGroupAccess: Sendable, Equatable, CaseIterable, Codable {
+  /// Accessible to all company members.
+  case forEveryone
+  /// Accessible only to invited members.
+  case byInvite
+  /// Unknown value returned by the API (forward compatibility).
+  case unknown(String)
+
+  public static var allCases: [DocumentGroupAccess] {
+    [.forEveryone, .byInvite]
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "for_everyone": self = .forEveryone
+    case "by_invite": self = .byInvite
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: String {
+    switch self {
+    case .forEveryone: "for_everyone"
+    case .byInvite: "by_invite"
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(String.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}

--- a/Sources/KaitenSDK/KaitenClient+DocumentGroups.swift
+++ b/Sources/KaitenSDK/KaitenClient+DocumentGroups.swift
@@ -1,0 +1,269 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - Typed Discriminators
+
+// The document group access discriminator travels as a plain string (see the
+// comment above `DocumentGroupAccess` in `Enums.swift`). This accessor gives the
+// generated payload a typed surface without losing undocumented values.
+
+extension Components.Schemas.DocumentGroup {
+  /// The document group access type, or `nil` if the API omitted the field.
+  public var documentGroupAccess: DocumentGroupAccess? {
+    access.map(DocumentGroupAccess.init(rawValue:))
+  }
+}
+
+/// The document group list endpoint answered with the shape belonging to the
+/// other `version` of the request — an object where an array was expected, or
+/// the other way around.
+private struct UnexpectedDocumentGroupListShape: Error {}
+
+// MARK: - Document Groups
+
+extension KaitenClient {
+  /// Lists document groups in the company.
+  ///
+  /// Calls the list endpoint without a `version`, which returns a plain array.
+  /// Use ``searchDocumentGroups(query:condition:startPosition:role:offset:limit:)``
+  /// for the `version=2` cursor-based search format.
+  ///
+  /// - Parameters:
+  ///   - query: Search query string.
+  ///   - role: Filter by minimum user role: 1 — reader, 2 — writer, 3 — admin.
+  ///   - offset: Number of records to skip (default `0` on the API side).
+  ///   - limit: Maximum number of records to return (default `100` on the API side).
+  /// - Returns: An array of document groups. Returns an empty array when nothing matches.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for undocumented HTTP status codes.
+  public func listDocumentGroups(
+    query: String? = nil,
+    role: Int? = nil,
+    offset: Int? = nil,
+    limit: Int? = nil
+  ) async throws(KaitenError) -> [Components.Schemas.DocumentGroup] {
+    guard
+      let response = try await callList({
+        try await client.list_document_groups(
+          query: .init(query: query, offset: offset, limit: limit, role: role))
+      })
+    else {
+      return []
+    }
+    let payload = try decodeResponse(response.toCase()) { try $0.json }
+    guard let groups = payload.value1 else {
+      throw .decodingError(underlying: UnexpectedDocumentGroupListShape())
+    }
+    return groups
+  }
+
+  /// Searches document groups via OpenSearch (the `version=2` list format).
+  ///
+  /// The response carries the matching groups in `result` and an opaque cursor
+  /// in `position`; pass that cursor as `startPosition` to fetch the next page.
+  ///
+  /// - Parameters:
+  ///   - query: Search query string.
+  ///   - condition: Filter condition.
+  ///   - startPosition: Search cursor — the `position` value from the previous response.
+  ///   - role: Filter by minimum user role: 1 — reader, 2 — writer, 3 — admin.
+  ///   - offset: Number of records to skip (default `0` on the API side).
+  ///   - limit: Maximum number of records to return (default `100` on the API side).
+  /// - Returns: The search response with matching document groups and the pagination cursor.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for undocumented HTTP status codes.
+  public func searchDocumentGroups(
+    query: String? = nil,
+    condition: Int? = nil,
+    startPosition: String? = nil,
+    role: Int? = nil,
+    offset: Int? = nil,
+    limit: Int? = nil
+  ) async throws(KaitenError) -> Components.Schemas.DocumentGroupSearchResponse {
+    let response = try await call {
+      try await client.list_document_groups(
+        query: .init(
+          query: query,
+          offset: offset,
+          limit: limit,
+          version: 2,
+          condition: condition,
+          start_position: startPosition,
+          role: role))
+    }
+    let payload = try decodeResponse(response.toCase()) { try $0.json }
+    guard let result = payload.value2 else {
+      throw .decodingError(underlying: UnexpectedDocumentGroupListShape())
+    }
+    return result
+  }
+
+  /// Retrieves a document group.
+  ///
+  /// - Parameters:
+  ///   - uid: The document group UID.
+  ///   - relations: Relations to include in the response. The API accepts
+  ///     `documents`, `groups`, `parent` and `author`; the matching response
+  ///     fields stay `nil` when their relation is not requested.
+  /// - Returns: The document group.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for forbidden (403), not found (404)
+  ///     or other undocumented HTTP status codes. A 404 is reported as `unexpectedResponse`
+  ///     rather than ``KaitenError/notFound(resource:id:)`` because document groups are
+  ///     addressed by string UID.
+  public func getDocumentGroup(
+    uid: String,
+    relations: [String]? = nil
+  ) async throws(KaitenError) -> Components.Schemas.DocumentGroup {
+    let response = try await call {
+      try await client.get_document_group(
+        path: .init(document_group_uid: uid),
+        query: .init(relations: relations.map { $0.joined(separator: ",") }))
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Creates a document group.
+  ///
+  /// - Parameters:
+  ///   - title: The document group title (1–256 characters).
+  ///   - parentEntityUid: The parent tree entity UID.
+  ///   - forEveryoneAccessRoleId: The role id for everyone access.
+  ///   - sortOrder: The sort order (must be greater than 0).
+  ///   - key: A unique document group key within the company.
+  /// - Returns: The created document group.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for validation errors (400),
+  ///     unsupported tariff (402), forbidden (403), key conflicts (409) or other undocumented
+  ///     HTTP status codes.
+  public func createDocumentGroup(
+    title: String,
+    parentEntityUid: String? = nil,
+    forEveryoneAccessRoleId: String? = nil,
+    sortOrder: Double? = nil,
+    key: String? = nil
+  ) async throws(KaitenError) -> Components.Schemas.DocumentGroup {
+    let response = try await call {
+      try await client.create_document_group(
+        body: .json(
+          .init(
+            title: title,
+            parent_entity_uid: parentEntityUid,
+            for_everyone_access_role_id: forEveryoneAccessRoleId,
+            sort_order: sortOrder,
+            key: key
+          ))
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Updates a document group.
+  ///
+  /// - Parameters:
+  ///   - uid: The document group UID.
+  ///   - title: The updated title (1–256 characters).
+  ///   - parentEntityUid: The parent tree entity UID. Moves the group in the tree.
+  ///   - sortOrder: The sort order (must be greater than 0).
+  ///   - access: The access type.
+  ///   - forEveryoneAccessRoleId: The role id for everyone access.
+  ///   - hostname: A custom hostname for the public site.
+  ///   - redirectUrl: The redirect URL.
+  ///   - key: A unique document group key within the company. Cannot be changed once set.
+  ///   - iconType: The icon type.
+  ///   - iconValue: The icon value (icon name for the `material_icon` type).
+  ///   - iconColor: The icon color.
+  ///   - hiddenOnPublicSite: Whether the group is hidden on the public site.
+  ///   - newsFeed: Whether the group is marked as a news feed. Requires a hostname on
+  ///     this folder or one of its parents.
+  ///   - indexDocumentUid: UID of the document used as the home page for this folder.
+  ///     Requires a hostname on this folder.
+  /// - Returns: The updated document group.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for validation errors (400),
+  ///     unsupported tariff (402), forbidden (403), not found (404), key or hostname conflicts
+  ///     (409) or other undocumented HTTP status codes. A 404 is reported as
+  ///     `unexpectedResponse` rather than ``KaitenError/notFound(resource:id:)`` because
+  ///     document groups are addressed by string UID.
+  public func updateDocumentGroup(
+    uid: String,
+    title: String? = nil,
+    parentEntityUid: String? = nil,
+    sortOrder: Double? = nil,
+    access: DocumentGroupAccess? = nil,
+    forEveryoneAccessRoleId: String? = nil,
+    hostname: String? = nil,
+    redirectUrl: String? = nil,
+    key: String? = nil,
+    iconType: String? = nil,
+    iconValue: String? = nil,
+    iconColor: Int? = nil,
+    hiddenOnPublicSite: Bool? = nil,
+    newsFeed: Bool? = nil,
+    indexDocumentUid: String? = nil
+  ) async throws(KaitenError) -> Components.Schemas.DocumentGroup {
+    let response = try await call {
+      try await client.update_document_group(
+        path: .init(document_group_uid: uid),
+        body: .json(
+          .init(
+            title: title,
+            parent_entity_uid: parentEntityUid,
+            sort_order: sortOrder,
+            access: access?.rawValue,
+            for_everyone_access_role_id: forEveryoneAccessRoleId,
+            hostname: hostname,
+            redirect_url: redirectUrl,
+            key: key,
+            icon_type: iconType,
+            icon_value: iconValue,
+            icon_color: iconColor,
+            hidden_on_public_site: hiddenOnPublicSite,
+            news_feed: newsFeed,
+            index_document_uid: indexDocumentUid
+          ))
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Removes a document group.
+  ///
+  /// The endpoint answers HTTP 400 while the group still has child tree
+  /// entities — remove or move them first.
+  ///
+  /// - Parameter uid: The document group UID.
+  /// - Returns: The removed document group stub, with `archived` set to `true`.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for child entities still present
+  ///     (400), forbidden (403), not found (404) or other undocumented HTTP status codes.
+  ///     A 404 is reported as `unexpectedResponse` rather than
+  ///     ``KaitenError/notFound(resource:id:)`` because document groups are addressed by
+  ///     string UID.
+  public func deleteDocumentGroup(
+    uid: String
+  ) async throws(KaitenError) -> Components.Schemas.RemovedDocumentGroupResponse {
+    let response = try await call {
+      try await client.delete_document_group(path: .init(document_group_uid: uid))
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -2041,3 +2041,69 @@ extension Operations.remove_user_from_group.Output {
     }
   }
 }
+
+// MARK: - Document Groups
+
+extension Operations.list_document_groups.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_document_groups.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.create_document_group.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.create_document_group.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .conflict: .undocumented(statusCode: 409)
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.get_document_group.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_document_group.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.update_document_group.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.update_document_group.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .conflict: .undocumented(statusCode: 409)
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.delete_document_group.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.delete_document_group.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/DocumentGroups/DocumentGroupCommands.swift
+++ b/Sources/kaiten/DocumentGroups/DocumentGroupCommands.swift
@@ -1,0 +1,263 @@
+import ArgumentParser
+import Foundation
+import KaitenSDK
+
+// MARK: - Document Groups
+
+func parseDocumentGroupAccess(_ rawValue: String) throws -> DocumentGroupAccess {
+  let access = DocumentGroupAccess(rawValue: rawValue)
+  guard DocumentGroupAccess.allCases.contains(access) else {
+    let allowed = DocumentGroupAccess.allCases.map(\.rawValue).joined(separator: ", ")
+    throw ValidationError("Invalid access type: '\(rawValue)'. Allowed values: \(allowed)")
+  }
+  return access
+}
+
+// MARK: - List Document Groups
+
+struct ListDocumentGroups: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-document-groups",
+    abstract: "List document groups"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Search query string")
+  var query: String?
+
+  @Option(name: .long, help: "Minimum user role: 1 - reader, 2 - writer, 3 - admin")
+  var role: Int?
+
+  @Option(name: .long, help: "Number of records to skip")
+  var offset: Int?
+
+  @Option(name: .long, help: "Maximum number of records to return")
+  var limit: Int?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let groups = try await client.listDocumentGroups(
+      query: query, role: role, offset: offset, limit: limit)
+    try printJSON(groups, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Search Document Groups
+
+struct SearchDocumentGroups: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "search-document-groups",
+    abstract: "Search document groups via OpenSearch",
+    discussion: """
+      Returns matching groups under `result` and an opaque cursor under `position`; \
+      pass that cursor as --start-position to fetch the next page.
+      """
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Search query string")
+  var query: String?
+
+  @Option(name: .long, help: "Filter condition")
+  var condition: Int?
+
+  @Option(name: .long, help: "Search cursor - the position value from the previous response")
+  var startPosition: String?
+
+  @Option(name: .long, help: "Minimum user role: 1 - reader, 2 - writer, 3 - admin")
+  var role: Int?
+
+  @Option(name: .long, help: "Number of records to skip")
+  var offset: Int?
+
+  @Option(name: .long, help: "Maximum number of records to return")
+  var limit: Int?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let result = try await client.searchDocumentGroups(
+      query: query,
+      condition: condition,
+      startPosition: startPosition,
+      role: role,
+      offset: offset,
+      limit: limit
+    )
+    try printJSON(result, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Get Document Group
+
+struct GetDocumentGroup: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "get-document-group",
+    abstract: "Get a document group"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Document group UID")
+  var documentGroupUid: String
+
+  @Option(
+    name: .long,
+    help: "Comma-separated relations to include: documents, groups, parent, author"
+  )
+  var relations: String?
+
+  func run() async throws {
+    let parsedRelations = try parseStringCSV(relations, fieldName: "--relations")
+    let client = try await global.makeClient()
+    let group = try await client.getDocumentGroup(
+      uid: documentGroupUid, relations: parsedRelations)
+    try printJSON(group, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Create Document Group
+
+struct CreateDocumentGroup: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "create-document-group",
+    abstract: "Create a document group"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Document group title")
+  var title: String
+
+  @Option(name: .long, help: "Parent tree entity UID")
+  var parentEntityUid: String?
+
+  @Option(name: .long, help: "Role id for everyone access")
+  var forEveryoneAccessRoleId: String?
+
+  @Option(name: .long, help: "Sort order (greater than 0)")
+  var sortOrder: Double?
+
+  @Option(name: .long, help: "Unique document group key within the company")
+  var key: String?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let group = try await client.createDocumentGroup(
+      title: title,
+      parentEntityUid: parentEntityUid,
+      forEveryoneAccessRoleId: forEveryoneAccessRoleId,
+      sortOrder: sortOrder,
+      key: key
+    )
+    try printJSON(group, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Update Document Group
+
+struct UpdateDocumentGroup: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "update-document-group",
+    abstract: "Update a document group"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Document group UID")
+  var documentGroupUid: String
+
+  @Option(name: .long, help: "Document group title")
+  var title: String?
+
+  @Option(name: .long, help: "Parent tree entity UID; moves the group in the tree")
+  var parentEntityUid: String?
+
+  @Option(name: .long, help: "Sort order (greater than 0)")
+  var sortOrder: Double?
+
+  @Option(name: .long, help: "Access type: for_everyone, by_invite")
+  var access: String?
+
+  @Option(name: .long, help: "Role id for everyone access")
+  var forEveryoneAccessRoleId: String?
+
+  @Option(name: .long, help: "Custom hostname for the public site")
+  var hostname: String?
+
+  @Option(name: .long, help: "Redirect URL")
+  var redirectUrl: String?
+
+  @Option(name: .long, help: "Unique document group key; cannot be changed once set")
+  var key: String?
+
+  @Option(name: .long, help: "Icon type")
+  var iconType: String?
+
+  @Option(name: .long, help: "Icon value (icon name for the material_icon type)")
+  var iconValue: String?
+
+  @Option(name: .long, help: "Icon color")
+  var iconColor: Int?
+
+  @Option(name: .long, help: "Hide the group on the public site (true/false)")
+  var hiddenOnPublicSite: Bool?
+
+  @Option(
+    name: .long,
+    help:
+      "Mark the group as a news feed (true/false); requires a hostname on this folder or a parent"
+  )
+  var newsFeed: Bool?
+
+  @Option(name: .long, help: "UID of the document used as the folder home page")
+  var indexDocumentUid: String?
+
+  func run() async throws {
+    let parsedAccess = try access.map(parseDocumentGroupAccess)
+    let client = try await global.makeClient()
+    let group = try await client.updateDocumentGroup(
+      uid: documentGroupUid,
+      title: title,
+      parentEntityUid: parentEntityUid,
+      sortOrder: sortOrder,
+      access: parsedAccess,
+      forEveryoneAccessRoleId: forEveryoneAccessRoleId,
+      hostname: hostname,
+      redirectUrl: redirectUrl,
+      key: key,
+      iconType: iconType,
+      iconValue: iconValue,
+      iconColor: iconColor,
+      hiddenOnPublicSite: hiddenOnPublicSite,
+      newsFeed: newsFeed,
+      indexDocumentUid: indexDocumentUid
+    )
+    try printJSON(group, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Delete Document Group
+
+struct DeleteDocumentGroup: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "delete-document-group",
+    abstract: "Remove a document group",
+    discussion: """
+      The API answers HTTP 400 while the group still has child tree entities - \
+      remove or move them first.
+      """
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Document group UID")
+  var documentGroupUid: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let removed = try await client.deleteDocumentGroup(uid: documentGroupUid)
+    try printJSON(removed, expand: global.expandedFields)
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -167,6 +167,12 @@ struct Kaiten: AsyncParsableCommand {
       ListGroupUsers.self,
       AddGroupUser.self,
       RemoveGroupUser.self,
+      ListDocumentGroups.self,
+      SearchDocumentGroups.self,
+      GetDocumentGroup.self,
+      CreateDocumentGroup.self,
+      UpdateDocumentGroup.self,
+      DeleteDocumentGroup.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/DocumentGroupsTests.swift
+++ b/Tests/KaitenSDKTests/DocumentGroupsTests.swift
@@ -1,0 +1,417 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("DocumentGroups")
+struct DocumentGroupsTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// `KaitenError` is not `Equatable`, so the status code is matched by pattern.
+  private func expectUnexpectedResponse(
+    statusCode: Int,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      Issue.record(
+        "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), no error thrown",
+        sourceLocation: sourceLocation)
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == statusCode else {
+        Issue.record(
+          "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), got \(error)",
+          sourceLocation: sourceLocation)
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)", sourceLocation: sourceLocation)
+    }
+  }
+
+  /// Sanitized from a live version-1 list response. The list shape omits `created`, `updated`,
+  /// `redirect_url` and `hidden_on_public_site` even though the documentation lists them, `id`
+  /// is a string equal to `uid`, and `access_record` / `updater_id` are present although
+  /// undocumented.
+  private static let listItemJSON = """
+    {
+      "uid": "dg-uid-1",
+      "path": "100",
+      "access": "for_everyone",
+      "title": "Handbook",
+      "public": false,
+      "parent_entity_uid": null,
+      "entity_type": "document_group",
+      "sort_order": 1.1483993608289147,
+      "author_id": 7,
+      "updater_id": 7,
+      "news_feed": false,
+      "hostname": null,
+      "index_document_uid": null,
+      "archived": false,
+      "for_everyone_access_role_id": "role-uid-1",
+      "company_id": 100,
+      "icon_type": null,
+      "icon_value": null,
+      "icon_color": null,
+      "key": null,
+      "id": "dg-uid-1",
+      "parent_group_id": null,
+      "access_record": {
+        "access_mod": "all",
+        "entity_uid": "dg-uid-1",
+        "user_id": 7,
+        "own_role_ids": null,
+        "own_groups_role_ids": null,
+        "own_access_mod": null,
+        "role_ids": ["role-uid-1"],
+        "groups_role_ids": null,
+        "role": 1,
+        "own_role": null,
+        "role_permissions": {"document": {"read": true, "create": false}}
+      }
+    }
+    """
+
+  // MARK: - List
+
+  @Test("200 returns array of DocumentGroup")
+  func listSuccess() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: "[\(Self.listItemJSON)]"))
+
+    let groups = try await client.listDocumentGroups()
+    #expect(groups.count == 1)
+    #expect(groups[0].uid == "dg-uid-1")
+    #expect(groups[0].id == "dg-uid-1")
+    #expect(groups[0].documentGroupAccess == .forEveryone)
+    #expect(groups[0].sort_order == 1.1483993608289147)
+    #expect(groups[0].parent_entity_uid == nil)
+    #expect(groups[0].updater_id == 7)
+    #expect(groups[0].access_record?.role == 1)
+    #expect(groups[0].access_record?.role_ids == ["role-uid-1"])
+    #expect(groups[0].access_record?.own_role == nil)
+  }
+
+  @Test("list sends the documented query parameters")
+  func listSendsQuery() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
+    let client = try makeClient(transport)
+
+    _ = try await client.listDocumentGroups(query: "handbook", role: 2, offset: 10, limit: 50)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    let path = try #require(recorded.request.path)
+    #expect(path.hasPrefix("/document-groups"))
+    #expect(path.contains("query=handbook"))
+    #expect(path.contains("role=2"))
+    #expect(path.contains("offset=10"))
+    #expect(path.contains("limit=50"))
+    #expect(!path.contains("version="))
+  }
+
+  @Test("200 with empty body returns empty array")
+  func listEmptyBody() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: ""))
+    let groups = try await client.listDocumentGroups()
+    #expect(groups.isEmpty)
+  }
+
+  /// The access discriminator is a plain string in the spec, so a value the documentation does
+  /// not list must survive as `.unknown` instead of failing the response.
+  @Test("undocumented access decodes as unknown")
+  func listUnknownAccess() async throws {
+    let json = """
+      [{"uid": "dg-uid-2", "id": "dg-uid-2", "title": "Restricted", "access": "secret"}]
+      """
+    let client = try makeClient(.returning(statusCode: 200, body: json))
+
+    let groups = try await client.listDocumentGroups()
+    #expect(groups[0].documentGroupAccess == .unknown("secret"))
+  }
+
+  @Test("401 throws unauthorized")
+  func listUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listDocumentGroups()
+    }
+  }
+
+  // MARK: - Search (version=2)
+
+  /// Sanitized from a live version=2 response: an object with `result` and `position`, whose
+  /// items additionally carry the undocumented `mQueries` and `ftsVersion` fields.
+  @Test("search returns result and position")
+  func searchSuccess() async throws {
+    let json = """
+      {
+        "result": [{
+          "id": "dg-uid-3",
+          "mQueries": ["document_group_title_0"],
+          "ftsVersion": "123456",
+          "uid": "dg-uid-3",
+          "path": "100.aaaa.bbbb",
+          "access": "by_invite",
+          "title": "Recipes",
+          "public": false,
+          "parent_entity_uid": "dg-uid-2",
+          "entity_type": "document_group",
+          "sort_order": 1.5,
+          "author_id": 8,
+          "updater_id": 8,
+          "news_feed": false,
+          "hostname": null,
+          "index_document_uid": null,
+          "archived": false,
+          "for_everyone_access_role_id": "role-uid-1",
+          "company_id": 100,
+          "icon_type": "emoji",
+          "icon_value": "X",
+          "icon_color": null,
+          "key": null,
+          "parent_group_id": "dg-uid-2"
+        }],
+        "position": "cursor-1"
+      }
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let response = try await client.searchDocumentGroups(query: "recipes", limit: 1)
+    #expect(response.position == "cursor-1")
+    #expect(response.result?.count == 1)
+    #expect(response.result?.first?.uid == "dg-uid-3")
+    #expect(response.result?.first?.documentGroupAccess == .byInvite)
+    #expect(response.result?.first?.ftsVersion == "123456")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    let path = try #require(recorded.request.path)
+    #expect(path.contains("version=2"))
+    #expect(path.contains("query=recipes"))
+  }
+
+  // MARK: - Get
+
+  /// Sanitized from a live single-group response, which carries the undocumented `updater_id`,
+  /// `protected`, `import_uid`, `description`, `public_id`, `fts_version`, `slug` and `branding`
+  /// fields, and requested with `relations=author` so the author object is present.
+  @Test("200 returns DocumentGroup")
+  func getSuccess() async throws {
+    let json = """
+      {
+        "created": "2024-02-06T05:51:53.337Z",
+        "updated": "2024-02-06T05:57:41.826Z",
+        "archived": false,
+        "uid": "dg-uid-1",
+        "access": "for_everyone",
+        "entity_type": "document_group",
+        "path": "100",
+        "sort_order": 1.1483993608289147,
+        "parent_entity_uid": null,
+        "for_everyone_access_role_id": "role-uid-1",
+        "icon_type": null,
+        "icon_value": null,
+        "icon_color": null,
+        "company_id": 100,
+        "protected": false,
+        "import_uid": null,
+        "title": "Handbook",
+        "description": null,
+        "public": false,
+        "author_id": 7,
+        "updater_id": 7,
+        "id": "dg-uid-1",
+        "parent_group_id": null,
+        "public_id": "pub-uid-1",
+        "hostname": null,
+        "news_feed": false,
+        "redirect_url": null,
+        "hidden_on_public_site": false,
+        "fts_version": "123456",
+        "index_document_uid": null,
+        "slug": null,
+        "branding": null,
+        "key": null,
+        "documents": null,
+        "groups": null,
+        "parent": null,
+        "author": {"id": 7, "username": "jdoe", "full_name": "Jane Doe", "email": "jdoe@example.com"},
+        "access_record": {"role": 3, "role_permissions": {"document": {"read": true}}}
+      }
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let group = try await client.getDocumentGroup(uid: "dg-uid-1", relations: ["author"])
+    #expect(group.uid == "dg-uid-1")
+    #expect(group.created == "2024-02-06T05:51:53.337Z")
+    #expect(group.hidden_on_public_site == false)
+    #expect(group.protected == false)
+    #expect(group.public_id == "pub-uid-1")
+    #expect(group.description == nil)
+    #expect(group.author != nil)
+    #expect(group.parent == nil)
+    #expect(group.access_record?.role == 3)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    let path = try #require(recorded.request.path)
+    #expect(path.hasPrefix("/document-groups/dg-uid-1"))
+    #expect(path.contains("relations=author"))
+  }
+
+  /// Document groups are addressed by string UID, which ``KaitenError/notFound(resource:id:)``
+  /// cannot represent, so a 404 surfaces as `unexpectedResponse`.
+  @Test("get 404 throws unexpectedResponse")
+  func getNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await expectUnexpectedResponse(statusCode: 404) {
+      _ = try await client.getDocumentGroup(uid: "missing")
+    }
+  }
+
+  // MARK: - Create
+
+  @Test("create sends title and key in the body")
+  func createSendsBody() async throws {
+    let json = """
+      {
+        "uid": "dg-uid-9",
+        "id": "dg-uid-9",
+        "title": "New group",
+        "created": "2026-01-01T00:00:00.000Z",
+        "updated": "2026-01-01T00:00:00.000Z",
+        "archived": false,
+        "company_id": 100,
+        "author_id": 7,
+        "parent_entity_uid": null,
+        "parent_group_id": null,
+        "entity_type": "document_group",
+        "sort_order": 2.5,
+        "access": "for_everyone",
+        "for_everyone_access_role_id": null,
+        "hostname": null,
+        "redirect_url": null,
+        "key": "NEWGROUP",
+        "icon_type": null,
+        "icon_value": null,
+        "icon_color": null,
+        "public": false,
+        "news_feed": false,
+        "hidden_on_public_site": false,
+        "path": "100",
+        "index_document_uid": null,
+        "access_record": {"role": 3, "role_permissions": {}}
+      }
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let group = try await client.createDocumentGroup(
+      title: "New group", sortOrder: 2.5, key: "NEWGROUP")
+
+    #expect(group.uid == "dg-uid-9")
+    #expect(group.key == "NEWGROUP")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .post)
+    #expect(recorded.request.path == "/document-groups")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["title"] as? String == "New group")
+    #expect(sent["sort_order"] as? Double == 2.5)
+    #expect(sent["key"] as? String == "NEWGROUP")
+  }
+
+  @Test("create 409 key conflict throws unexpectedResponse")
+  func createConflict() async throws {
+    let client = try makeClient(.returning(statusCode: 409))
+    await expectUnexpectedResponse(statusCode: 409) {
+      _ = try await client.createDocumentGroup(title: "Duplicate key")
+    }
+  }
+
+  @Test("create 402 unsupported tariff throws unexpectedResponse")
+  func createPaymentRequired() async throws {
+    let client = try makeClient(.returning(statusCode: 402))
+    await expectUnexpectedResponse(statusCode: 402) {
+      _ = try await client.createDocumentGroup(title: "No tariff")
+    }
+  }
+
+  // MARK: - Update
+
+  @Test("update targets the document group UID")
+  func updateSuccess() async throws {
+    let json = """
+      {"uid": "dg-uid-1", "id": "dg-uid-1", "title": "Renamed", "access": "by_invite"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let group = try await client.updateDocumentGroup(
+      uid: "dg-uid-1", title: "Renamed", access: .byInvite)
+
+    #expect(group.title == "Renamed")
+    #expect(group.documentGroupAccess == .byInvite)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .patch)
+    #expect(recorded.request.path == "/document-groups/dg-uid-1")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["title"] as? String == "Renamed")
+    #expect(sent["access"] as? String == "by_invite")
+  }
+
+  @Test("update 404 throws unexpectedResponse")
+  func updateNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await expectUnexpectedResponse(statusCode: 404) {
+      _ = try await client.updateDocumentGroup(uid: "missing", title: "Renamed")
+    }
+  }
+
+  // MARK: - Delete
+
+  @Test("delete returns the removed stub")
+  func deleteSuccess() async throws {
+    let json = """
+      {"uid": "dg-uid-1", "id": "dg-uid-1", "title": "Handbook", "archived": true}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let removed = try await client.deleteDocumentGroup(uid: "dg-uid-1")
+
+    #expect(removed.uid == "dg-uid-1")
+    #expect(removed.archived == true)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .delete)
+    #expect(recorded.request.path == "/document-groups/dg-uid-1")
+  }
+
+  /// The API answers HTTP 400 while the group still has child tree entities.
+  @Test("delete 400 throws unexpectedResponse")
+  func deleteWithChildren() async throws {
+    let client = try makeClient(.returning(statusCode: 400))
+    await expectUnexpectedResponse(statusCode: 400) {
+      _ = try await client.deleteDocumentGroup(uid: "dg-uid-1")
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -5281,6 +5281,171 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /document-groups:
+    get:
+      summary: Retrieve list of document groups
+      operationId: list_document_groups
+      parameters:
+      - name: query
+        in: query
+        schema:
+          type: string
+        description: Search query string
+      - name: offset
+        in: query
+        schema:
+          type: integer
+        description: 'Number of records to skip for pagination. Default: 0'
+      - name: limit
+        in: query
+        schema:
+          type: integer
+        description: 'Maximum number of records to return. Default: 100'
+      - name: version
+        in: query
+        schema:
+          type: integer
+        description: 'Search version. Default: 1. Use version=2 to search via OpenSearch and enable the response format with result and position fields'
+      - name: condition
+        in: query
+        schema:
+          type: integer
+        description: Filter condition. Used with version=2
+      - name: start_position
+        in: query
+        schema:
+          type: string
+        description: Search cursor for version=2 pagination. Pass the position value from the previous version=2 response
+      - name: role
+        in: query
+        schema:
+          type: integer
+        description: 'Filter by minimum user role: 1 - reader, 2 - writer, 3 - admin'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentGroupListResponse'
+        '401':
+          description: Invalid token
+    post:
+      summary: Create new document group
+      operationId: create_document_group
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDocumentGroupRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentGroup'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
+        '409':
+          description: Conflict - the key is already in use in the company
+  /document-groups/{document_group_uid}:
+    get:
+      summary: Retrieve document group
+      operationId: get_document_group
+      parameters:
+      - name: document_group_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Document group UID
+      # DOC_MISMATCH: not in docs, accepted by actual API; the documented response fields documents/groups/parent/author are described as included "when relations contains" the matching name — https://developers.kaiten.ru/document-groups/retrieve-document-group
+      - name: relations
+        in: query
+        schema:
+          type: string
+        description: 'Comma-separated relations to include in the response: documents, groups, parent, author'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentGroup'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    patch:
+      summary: Update document group
+      operationId: update_document_group
+      parameters:
+      - name: document_group_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Document group UID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateDocumentGroupRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentGroup'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+        '409':
+          description: Conflict - key already in use, hostname already in use, or unfinished key operations
+    delete:
+      summary: Remove document group
+      operationId: delete_document_group
+      parameters:
+      - name: document_group_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Document group UID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemovedDocumentGroupResponse'
+        '400':
+          description: Document group has child tree entities - remove or move them first
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
 components:
   securitySchemes:
     bearerAuth:
@@ -11578,3 +11743,389 @@ components:
           minLength: 1
           maxLength: 1024
           description: Operator's comment if addition to the group is an answer to an access request
+    DocumentGroup:
+      type: object
+      properties:
+        uid:
+          type: string
+          description: Document group uid
+        # DOC_MISMATCH: docs=`integer`, actual=`string` (same value as `uid`) — https://developers.kaiten.ru/document-groups/retrieve-document-group
+        id:
+          type: string
+          description: Document group id
+        title:
+          type: string
+          description: Document group title
+        # DOC_MISMATCH: docs=`string` in the list response, absent from actual list responses (present when retrieving a single group) — https://developers.kaiten.ru/document-groups/retrieve-list-of-document-groups
+        created:
+          type: string
+          description: Create date
+        # DOC_MISMATCH: docs=`string` in the list response, absent from actual list responses (present when retrieving a single group) — https://developers.kaiten.ru/document-groups/retrieve-list-of-document-groups
+        updated:
+          type: string
+          description: Last update timestamp
+        archived:
+          type: boolean
+          description: Document group archived flag
+        company_id:
+          type: integer
+          description: Company id
+        author_id:
+          type: integer
+          description: Author user id
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/document-groups/retrieve-list-of-document-groups
+        updater_id:
+          type: integer
+          description: Last updater user id
+        parent_entity_uid:
+          type:
+          - string
+          - 'null'
+          description: Parent tree entity uid
+        parent_group_id:
+          type:
+          - string
+          - 'null'
+          description: Deprecated alias for parent_entity_uid
+        entity_type:
+          type: string
+          description: Entity type. Always "document_group"
+        sort_order:
+          type: number
+          description: Document group sort order
+        # DOC_MISMATCH: docs=`enum` (for_everyone, by_invite), actual=`string` — modelled as a plain string so undocumented values cannot break decoding — https://developers.kaiten.ru/document-groups/retrieve-document-group
+        access:
+          type: string
+          description: 'Document group access type. Documented values: for_everyone (accessible to all company members), by_invite (only invited members). Map to the DocumentGroupAccess Swift enum, which preserves unknown values.'
+        for_everyone_access_role_id:
+          type:
+          - string
+          - 'null'
+          description: Role id for everyone access
+        hostname:
+          type:
+          - string
+          - 'null'
+          description: Custom hostname for public site
+        # DOC_MISMATCH: docs=`null | string` in the list response, absent from actual list responses (present when retrieving a single group) — https://developers.kaiten.ru/document-groups/retrieve-list-of-document-groups
+        redirect_url:
+          type:
+          - string
+          - 'null'
+          description: Redirect URL
+        key:
+          type:
+          - string
+          - 'null'
+          description: Unique document group key within company
+        # DOC_MISMATCH: docs=`"material_icon" or null`, actual includes other values; observed: "emoji" — https://developers.kaiten.ru/document-groups/retrieve-list-of-document-groups
+        icon_type:
+          type:
+          - string
+          - 'null'
+          description: Icon type
+        icon_value:
+          type:
+          - string
+          - 'null'
+          description: Icon value (icon name for material_icon type)
+        icon_color:
+          type:
+          - integer
+          - 'null'
+          description: Icon color
+        public:
+          type: boolean
+          description: Is document group publicly available (legacy field)
+        news_feed:
+          type: boolean
+          description: Is document group marked as news feed
+        # DOC_MISMATCH: docs=`boolean` in the list response, absent from actual list responses (present when retrieving a single group) — https://developers.kaiten.ru/document-groups/retrieve-list-of-document-groups
+        hidden_on_public_site:
+          type: boolean
+          description: Document group is hidden on public site
+        path:
+          type: string
+          description: Inner path to entity in tree
+        index_document_uid:
+          type:
+          - string
+          - 'null'
+          description: UID of the document used as the home page for this folder
+        documents:
+          type:
+          - array
+          - 'null'
+          items:
+            type: object
+            additionalProperties: true
+          description: Child documents. Included when relations contains "documents". Item shape is not described in the Kaiten documentation
+        groups:
+          type:
+          - array
+          - 'null'
+          items:
+            type: object
+            additionalProperties: true
+          description: Child document groups. Included when relations contains "groups". Item shape is not described in the Kaiten documentation
+        parent:
+          type:
+          - object
+          - 'null'
+          additionalProperties: true
+          description: Parent document group. Included when relations contains "parent". Shape is not described in the Kaiten documentation
+        author:
+          type:
+          - object
+          - 'null'
+          additionalProperties: true
+          description: Author user object. Included when relations contains "author". Shape is not described in the Kaiten documentation
+        # DOC_MISMATCH: not in docs for the list response, present in actual list responses — https://developers.kaiten.ru/document-groups/retrieve-list-of-document-groups
+        access_record:
+          $ref: '#/components/schemas/DocumentGroupAccessRecord'
+          description: Current user access record to this document group
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/document-groups/retrieve-document-group
+        description:
+          type:
+          - string
+          - 'null'
+          description: Document group description
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/document-groups/retrieve-document-group
+        protected:
+          type: boolean
+          description: Document group protected flag
+        # DOC_MISMATCH: not in docs, present in actual API responses; observed only null — https://developers.kaiten.ru/document-groups/retrieve-document-group
+        import_uid:
+          type:
+          - string
+          - 'null'
+          description: Import uid
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/document-groups/retrieve-document-group
+        public_id:
+          type: string
+          description: Public id
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/document-groups/retrieve-document-group
+        fts_version:
+          type: string
+          description: Full-text search index version
+        # DOC_MISMATCH: not in docs, present in actual API responses; observed only null — https://developers.kaiten.ru/document-groups/retrieve-document-group
+        slug:
+          type:
+          - string
+          - 'null'
+          description: Public site slug
+        # DOC_MISMATCH: not in docs, present in actual API responses; observed only null, so no type is imposed — https://developers.kaiten.ru/document-groups/retrieve-document-group
+        branding:
+          description: Public site branding. Shape is not described in the Kaiten documentation
+        # DOC_MISMATCH: not in docs, present in actual version=2 search results — https://developers.kaiten.ru/document-groups/retrieve-list-of-document-groups
+        mQueries:
+          type: array
+          items:
+            type: string
+          description: Matched search sub-queries in version=2 search results
+        # DOC_MISMATCH: not in docs, present in actual version=2 search results — https://developers.kaiten.ru/document-groups/retrieve-list-of-document-groups
+        ftsVersion:
+          type: string
+          description: Full-text search index version in version=2 search results
+    DocumentGroupAccessRecord:
+      type: object
+      description: Current user access record to a document group
+      properties:
+        role:
+          type: integer
+          description: User role id
+        role_permissions:
+          type: object
+          additionalProperties: true
+          description: User permissions for this document group. Shape is not described in the Kaiten documentation
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/document-groups/retrieve-document-group
+        access_mod:
+          type: string
+          description: Access mode
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/document-groups/retrieve-document-group
+        entity_uid:
+          type: string
+          description: Uid of the entity the record belongs to
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/document-groups/retrieve-document-group
+        user_id:
+          type: integer
+          description: User id
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/document-groups/retrieve-document-group
+        role_ids:
+          type:
+          - array
+          - 'null'
+          items:
+            type: string
+          description: Role ids granted to the user
+        # DOC_MISMATCH: not in docs, present in actual API responses; observed only null, type inferred from `role` — https://developers.kaiten.ru/document-groups/retrieve-document-group
+        own_role:
+          type:
+          - integer
+          - 'null'
+          description: Role id granted to the user directly
+        # DOC_MISMATCH: not in docs, present in actual API responses; observed only null, type inferred from `role_ids` — https://developers.kaiten.ru/document-groups/retrieve-document-group
+        own_role_ids:
+          type:
+          - array
+          - 'null'
+          items:
+            type: string
+          description: Role ids granted to the user directly
+        # DOC_MISMATCH: not in docs, present in actual API responses; observed only null, type inferred from `role_ids` — https://developers.kaiten.ru/document-groups/retrieve-document-group
+        groups_role_ids:
+          type:
+          - array
+          - 'null'
+          items:
+            type: string
+          description: Role ids granted via user groups
+        # DOC_MISMATCH: not in docs, present in actual API responses; observed only null, type inferred from `role_ids` — https://developers.kaiten.ru/document-groups/retrieve-document-group
+        own_groups_role_ids:
+          type:
+          - array
+          - 'null'
+          items:
+            type: string
+          description: Role ids granted via user groups directly
+        # DOC_MISMATCH: not in docs, present in actual API responses; observed only null, type inferred from `access_mod` — https://developers.kaiten.ru/document-groups/retrieve-document-group
+        own_access_mod:
+          type:
+          - string
+          - 'null'
+          description: Access mode granted to the user directly
+    DocumentGroupSearchResponse:
+      type: object
+      description: Response of the document group list endpoint when version=2 is passed
+      properties:
+        result:
+          type: array
+          items:
+            $ref: '#/components/schemas/DocumentGroup'
+          description: Search results
+        position:
+          type: string
+          description: Opaque cursor for pagination. Pass this value as start_position in the next request
+    # The list endpoint returns two shapes keyed off the `version` query parameter: a plain array
+    # (version omitted or 1) or an object with `result` and `position` (version=2). Modelled as
+    # `anyOf` — OpenAPI cannot select a response schema by query parameter, and the shapes are
+    # unambiguous (array vs object), so a payload decodes as exactly one of them.
+    DocumentGroupListResponse:
+      anyOf:
+      - type: array
+        items:
+          $ref: '#/components/schemas/DocumentGroup'
+      - $ref: '#/components/schemas/DocumentGroupSearchResponse'
+      description: Document group list - a plain array (version 1) or a version=2 search response
+    RemovedDocumentGroupResponse:
+      type: object
+      properties:
+        uid:
+          type: string
+          description: Document group uid
+        # DOC_MISMATCH: docs=`integer`, actual=`string` (same value as `uid`) on the live GET document-group endpoints for the same field — https://developers.kaiten.ru/document-groups/remove-document-group
+        id:
+          type: string
+          description: Document group id
+        title:
+          type: string
+          description: Document group title
+        archived:
+          type: boolean
+          description: Document group archived flag. Always true after removal
+    CreateDocumentGroupRequest:
+      type: object
+      required:
+      - title
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Document group title
+        parent_entity_uid:
+          type:
+          - string
+          - 'null'
+          description: Parent tree entity uid
+        for_everyone_access_role_id:
+          type:
+          - string
+          - 'null'
+          description: Role id for everyone access
+        sort_order:
+          type: number
+          exclusiveMinimum: 0
+          description: Sort order
+        key:
+          type:
+          - string
+          - 'null'
+          maxLength: 256
+          description: Unique document group key within company
+    UpdateDocumentGroupRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Document group title
+        parent_entity_uid:
+          type:
+          - string
+          - 'null'
+          description: Parent tree entity uid. Used to move document group in the tree
+        sort_order:
+          type: number
+          exclusiveMinimum: 0
+          description: Sort order
+        access:
+          type: string
+          description: 'Document group access type. Documented values: for_everyone, by_invite. Map to the DocumentGroupAccess Swift enum, which preserves unknown values.'
+        for_everyone_access_role_id:
+          type:
+          - string
+          - 'null'
+          description: Role id for everyone access
+        hostname:
+          type:
+          - string
+          - 'null'
+          description: Custom hostname for public site. Can contain only letters, numbers and "-", length 2-30 symbols, cannot end with "-"
+        redirect_url:
+          type:
+          - string
+          - 'null'
+          description: Redirect URL
+        key:
+          type:
+          - string
+          - 'null'
+          description: Unique document group key within company. Cannot be changed once set
+        icon_type:
+          type:
+          - string
+          - 'null'
+          description: Icon type
+        icon_value:
+          type:
+          - string
+          - 'null'
+          description: Icon value (icon name for material_icon type)
+        icon_color:
+          type:
+          - integer
+          - 'null'
+          description: Icon color
+        hidden_on_public_site:
+          type: boolean
+          description: Hide document group on public site
+        news_feed:
+          type: boolean
+          description: Mark document group as news feed. Requires hostname to be set on this folder or one of its parent folders
+        index_document_uid:
+          type:
+          - string
+          - 'null'
+          description: UID of the document to use as the home page for this folder. Requires hostname to be set on this folder. Document must be within the document group tree, not archived and not hidden on public site

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -392,6 +392,19 @@ let sections: [Section] = [
       name: "remove_user_from_group",
       errors: [.unauthorized, .paymentRequired, .forbidden, .notFound]),
   ]),
+  Section(mark: "Document Groups", operations: [
+    Operation(name: "list_document_groups", errors: [.unauthorized]),
+    Operation(
+      name: "create_document_group",
+      errors: [.badRequest, .unauthorized, .paymentRequired, .forbidden, .conflict]),
+    Operation(name: "get_document_group", errors: [.unauthorized, .forbidden, .notFound]),
+    Operation(
+      name: "update_document_group",
+      errors: [.badRequest, .unauthorized, .paymentRequired, .forbidden, .notFound, .conflict]),
+    Operation(
+      name: "delete_document_group",
+      errors: [.badRequest, .unauthorized, .forbidden, .notFound]),
+  ]),
 ]
 
 // MARK: - Generator


### PR DESCRIPTION
## Endpoints

- [x] `GET /document-groups` — `listDocumentGroups` (version 1) and `searchDocumentGroups` (version=2 OpenSearch format); all documented query parameters exposed (`query`, `offset`, `limit`, `version`, `condition`, `start_position`, `role`)
- [x] `POST /document-groups` — `createDocumentGroup`
- [x] `GET /document-groups/{document_group_uid}` — `getDocumentGroup(uid:relations:)`
- [x] `PATCH /document-groups/{document_group_uid}` — `updateDocumentGroup` (all documented body fields)
- [x] `DELETE /document-groups/{document_group_uid}` — `deleteDocumentGroup` (returns the removed stub)

CLI: `list-document-groups`, `search-document-groups`, `get-document-group`, `create-document-group`, `update-document-group`, `delete-document-group`, registered in `Kaiten.swift`. README API Reference updated.

## Live verification

- `GET /document-groups` (version 1 and version=2) and `GET /document-groups/{uid}` (with and without `relations`) verified against the live API; every field compared for type and nullability, and the test fixtures are sanitized real responses. All three shapes also smoke-tested end-to-end through the built CLI.
- `POST`, `PATCH`, `DELETE` are mutating and were **not** sent to the live instance; their schemas follow the documentation, with the `id` type carried over from the live GET evidence.

## DOC_MISMATCH added (29 lines)

- `id` — docs say `integer`, actual is a `string` equal to `uid` (also applied to the delete response stub)
- `created`, `updated`, `redirect_url`, `hidden_on_public_site` — documented in the list response but absent from actual list responses (present on single-group retrieval)
- `access` — documented as a closed enum, modelled as plain string + `DocumentGroupAccess` Swift enum with `unknown(String)` (FR-020a)
- `icon_type` — docs say `"material_icon" or null`, actual also returns other values (observed `"emoji"`)
- `access_record` — undocumented in the list response but always present; its actual shape carries many undocumented fields (`access_mod`, `entity_uid`, `user_id`, `role_ids`, `own_*`, `groups_role_ids`)
- Undocumented single-group fields: `updater_id`, `description`, `protected`, `import_uid`, `public_id`, `fts_version`, `slug`, `branding`
- Undocumented version=2 result fields: `mQueries`, `ftsVersion`
- `relations` query parameter on the retrieve endpoint — not documented as a parameter, but accepted by the actual API and referenced by the documented response fields

## Notes

- The dual list response is modelled as `anyOf` (array vs `result`/`position` object) — OpenAPI cannot select a response schema by query parameter, and the shapes are unambiguous.
- `scripts/generate-response-mapping.swift` gained a `conflict` (409) error case; `ResponseMapping.swift` regenerated.
- `swift format lint --strict` clean; full suite green (402 tests, including 15 new DocumentGroups tests).

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)