### PR TITLE
feat(groups): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,6 +784,39 @@ let created = try await client.createDocumentGroup(title: "Handbook", key: "HB")
 CLI: `list-document-groups`, `search-document-groups`, `get-document-group`,
 `create-document-group`, `update-document-group`, `delete-document-group`.
 
+### Groups
+
+| Method | Description |
+|--------|-------------|
+| `listGroups(withTreeEntities:withUsersCount:withSyncGroupAttribute:condition:query:limit:offset:)` | List user groups in the company |
+| `createGroup(name:permissions:addToCardsAndSpacesEnabled:)` | Create a user group |
+| `getGroup(uid:)` | Get a user group |
+| `updateGroup(uid:name:permissions:addToCardsAndSpacesEnabled:)` | Update a user group |
+| `removeGroup(uid:)` | Remove a user group; returns the removed group |
+
+Requires an API token of a user with access to the administrative section
+"Members" — other tokens get HTTP 403. Kaiten documents the groups endpoints as
+under active development, so attributes are subject to change. The `condition`
+filter is exposed as the `GroupCondition` enum (`.active`, `.inactive`) with an
+`unknown(Int)` case that preserves undocumented values. The `permissions` field
+is a bit mask; sum the documented values to combine permissions.
+
+```swift
+let groups = try await client.listGroups(condition: .active)
+
+let created = try await client.createGroup(
+  name: "QA engineers",
+  permissions: 3  // administrative sections "Members" + "Billing"
+)
+```
+
+CLI: `list-groups` with `--with-tree-entities`, `--with-users-count`,
+`--with-sync-group-attribute`, `--condition`, `--query`, `--limit`, `--offset`;
+`create-group --name <name>` with `--permissions`,
+`--add-to-cards-and-spaces-enabled`; `get-group --uid <uid>`;
+`update-group --uid <uid>` with `--name`, `--permissions`,
+`--add-to-cards-and-spaces-enabled`; `remove-group --uid <uid>`.
+
 ## Pagination
 
 Most list endpoints accept `offset` and `limit` parameters and return a `Page<T>`:

--- a/Sources/KaitenSDK/Enums.swift
+++ b/Sources/KaitenSDK/Enums.swift
@@ -2051,3 +2051,44 @@ public enum DocumentGroupAccess: Sendable, Equatable, CaseIterable, Codable {
     try container.encode(rawValue)
   }
 }
+
+/// Group condition filter.
+///
+/// Used in ``KaitenClient/listGroups(withTreeEntities:withUsersCount:withSyncGroupAttribute:condition:query:limit:offset:)``.
+/// - SeeAlso: [Kaiten API – Groups](https://developers.kaiten.ru/groups/get-list-of-groups)
+public enum GroupCondition: Sendable, Equatable, CaseIterable, Codable {
+  /// Group is active.
+  case active
+  /// Group is inactive.
+  case inactive
+  /// Unknown value returned by the API (forward compatibility).
+  case unknown(Int)
+
+  public static var allCases: [GroupCondition] { [.active, .inactive] }
+
+  public init(rawValue: Int) {
+    switch rawValue {
+    case 1: self = .active
+    case 2: self = .inactive
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: Int {
+    switch self {
+    case .active: 1
+    case .inactive: 2
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(Int.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}

--- a/Sources/KaitenSDK/KaitenClient+Groups.swift
+++ b/Sources/KaitenSDK/KaitenClient+Groups.swift
@@ -1,0 +1,163 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - Groups
+
+extension KaitenClient {
+  /// Lists user groups in the company.
+  ///
+  /// The result is paginated only when `limit` or `offset` is present and
+  /// `withTreeEntities` is `false`.
+  ///
+  /// - Parameters:
+  ///   - withTreeEntities: Add tree entities for each group.
+  ///   - withUsersCount: Add users count for each group.
+  ///   - withSyncGroupAttribute: Add sync attribute for each group.
+  ///   - condition: Optional group condition filter.
+  ///   - query: Search query.
+  ///   - limit: Maximum amount of records (default `100` on the server).
+  ///   - offset: Number of records to skip.
+  /// - Returns: An array of groups. Returns an empty array if the company has no groups.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for forbidden (403, the token lacks
+  ///     access to the administrative section "Members"), not found (404) or other undocumented
+  ///     HTTP status codes.
+  public func listGroups(
+    withTreeEntities: Bool? = nil,
+    withUsersCount: Bool? = nil,
+    withSyncGroupAttribute: Bool? = nil,
+    condition: GroupCondition? = nil,
+    query: String? = nil,
+    limit: Int? = nil,
+    offset: Int? = nil
+  ) async throws(KaitenError) -> [Components.Schemas.Group] {
+    guard
+      let response = try await callList({
+        try await client.list_groups(
+          query: .init(
+            with_tree_entities: withTreeEntities,
+            with_users_count: withUsersCount,
+            with_sync_group_attribute: withSyncGroupAttribute,
+            condition: condition?.rawValue,
+            query: query,
+            limit: limit,
+            offset: offset
+          )
+        )
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Creates a user group in the company.
+  ///
+  /// - Parameters:
+  ///   - name: The group name (1 to 512 characters).
+  ///   - permissions: The group permissions bit mask. To set several permissions, sum their
+  ///     documented values.
+  ///   - addToCardsAndSpacesEnabled: Ability to add all users of the group to cards placed in
+  ///     group spaces.
+  /// - Returns: The created group.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for bad request (400), unsupported
+  ///     tariff (402), forbidden (403), not found (404) or other undocumented HTTP status codes.
+  public func createGroup(
+    name: String,
+    permissions: Int? = nil,
+    addToCardsAndSpacesEnabled: Bool? = nil
+  ) async throws(KaitenError) -> Components.Schemas.Group {
+    let response = try await call {
+      try await client.create_group(
+        body: .json(
+          .init(
+            name: name,
+            permissions: permissions,
+            add_to_cards_and_spaces_enabled: addToCardsAndSpacesEnabled
+          ))
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Retrieves a user group.
+  ///
+  /// - Parameter uid: The group UID.
+  /// - Returns: The group.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for forbidden (403), not found (404)
+  ///     or other undocumented HTTP status codes. A 404 is reported as `unexpectedResponse` rather
+  ///     than ``KaitenError/notFound(resource:id:)`` because groups are addressed by string UID.
+  public func getGroup(uid: String) async throws(KaitenError) -> Components.Schemas.Group {
+    let response = try await call {
+      try await client.get_group(path: .init(uid: uid))
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Updates a user group.
+  ///
+  /// - Parameters:
+  ///   - uid: The group UID.
+  ///   - name: The updated group name (1 to 512 characters).
+  ///   - permissions: The updated group permissions bit mask. To set several permissions, sum
+  ///     their documented values.
+  ///   - addToCardsAndSpacesEnabled: Ability to add all users of the group to cards placed in
+  ///     group spaces.
+  /// - Returns: The updated group.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for bad request (400), unsupported
+  ///     tariff (402), forbidden (403), not found (404) or other undocumented HTTP status codes.
+  ///     A 404 is reported as `unexpectedResponse` rather than
+  ///     ``KaitenError/notFound(resource:id:)`` because groups are addressed by string UID.
+  public func updateGroup(
+    uid: String,
+    name: String? = nil,
+    permissions: Int? = nil,
+    addToCardsAndSpacesEnabled: Bool? = nil
+  ) async throws(KaitenError) -> Components.Schemas.Group {
+    let response = try await call {
+      try await client.update_group(
+        path: .init(uid: uid),
+        body: .json(
+          .init(
+            name: name,
+            permissions: permissions,
+            add_to_cards_and_spaces_enabled: addToCardsAndSpacesEnabled
+          ))
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Removes a user group.
+  ///
+  /// - Parameter uid: The group UID.
+  /// - Returns: The removed group.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for forbidden (403), not found (404)
+  ///     or other undocumented HTTP status codes. A 404 is reported as `unexpectedResponse` rather
+  ///     than ``KaitenError/notFound(resource:id:)`` because groups are addressed by string UID.
+  public func removeGroup(uid: String) async throws(KaitenError) -> Components.Schemas.Group {
+    let response = try await call {
+      try await client.remove_group(path: .init(uid: uid))
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -2107,3 +2107,69 @@ extension Operations.delete_document_group.Output {
     }
   }
 }
+
+// MARK: - Groups
+
+extension Operations.list_groups.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_groups.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.create_group.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.create_group.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.get_group.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_group.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.update_group.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.update_group.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .code402: .undocumented(statusCode: 402)
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.remove_group.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.remove_group.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/Groups/GroupCommands.swift
+++ b/Sources/kaiten/Groups/GroupCommands.swift
@@ -1,0 +1,169 @@
+import ArgumentParser
+import KaitenSDK
+
+// MARK: - Groups
+
+func parseGroupCondition(_ rawValue: Int?) throws -> GroupCondition? {
+  guard let rawValue else { return nil }
+  let condition = GroupCondition(rawValue: rawValue)
+  guard GroupCondition.allCases.contains(condition) else {
+    throw ValidationError(
+      "Invalid group condition: \(rawValue). Allowed values: 1 (active), 2 (inactive)")
+  }
+  return condition
+}
+
+// MARK: - List Groups
+
+struct ListGroups: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-groups",
+    abstract: "List user groups in the company",
+    discussion: """
+      The result is paginated only when --limit or --offset is present and \
+      --with-tree-entities is not.
+      """
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Flag(name: .long, help: "Add tree entities for each group")
+  var withTreeEntities: Bool = false
+
+  @Flag(name: .long, help: "Add users count for each group")
+  var withUsersCount: Bool = false
+
+  @Flag(name: .long, help: "Add sync attribute for each group")
+  var withSyncGroupAttribute: Bool = false
+
+  @Option(name: .long, help: "Group condition: 1 = active, 2 = inactive")
+  var condition: Int?
+
+  @Option(name: .long, help: "Search query")
+  var query: String?
+
+  @Option(name: .long, help: "Maximum amount of records (default 100)")
+  var limit: Int?
+
+  @Option(name: .long, help: "Number of records to skip")
+  var offset: Int?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let groups = try await client.listGroups(
+      withTreeEntities: withTreeEntities ? true : nil,
+      withUsersCount: withUsersCount ? true : nil,
+      withSyncGroupAttribute: withSyncGroupAttribute ? true : nil,
+      condition: try parseGroupCondition(condition),
+      query: query,
+      limit: limit,
+      offset: offset
+    )
+    try printJSON(groups, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Create Group
+
+struct CreateGroup: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "create-group",
+    abstract: "Create a user group in the company"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Group name (1 to 512 characters)")
+  var name: String
+
+  @Option(name: .long, help: "Group permissions bit mask; sum the documented values to combine")
+  var permissions: Int?
+
+  @Flag(name: .long, help: "Allow adding all users of the group to cards in group spaces")
+  var addToCardsAndSpacesEnabled: Bool = false
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let group = try await client.createGroup(
+      name: name,
+      permissions: permissions,
+      addToCardsAndSpacesEnabled: addToCardsAndSpacesEnabled ? true : nil
+    )
+    try printJSON(group, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Get Group
+
+struct GetGroup: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "get-group",
+    abstract: "Get a user group"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Group UID")
+  var uid: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let group = try await client.getGroup(uid: uid)
+    try printJSON(group, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Update Group
+
+struct UpdateGroup: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "update-group",
+    abstract: "Update a user group"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Group UID")
+  var uid: String
+
+  @Option(name: .long, help: "Group name (1 to 512 characters)")
+  var name: String?
+
+  @Option(name: .long, help: "Group permissions bit mask; sum the documented values to combine")
+  var permissions: Int?
+
+  @Option(name: .long, help: "Allow adding all users of the group to cards in group spaces")
+  var addToCardsAndSpacesEnabled: Bool?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let group = try await client.updateGroup(
+      uid: uid,
+      name: name,
+      permissions: permissions,
+      addToCardsAndSpacesEnabled: addToCardsAndSpacesEnabled
+    )
+    try printJSON(group, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Remove Group
+
+struct RemoveGroup: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "remove-group",
+    abstract: "Remove a user group",
+    discussion: "Prints the removed group."
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Group UID")
+  var uid: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let group = try await client.removeGroup(uid: uid)
+    try printJSON(group, expand: global.expandedFields)
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -173,6 +173,11 @@ struct Kaiten: AsyncParsableCommand {
       CreateDocumentGroup.self,
       UpdateDocumentGroup.self,
       DeleteDocumentGroup.self,
+      ListGroups.self,
+      CreateGroup.self,
+      GetGroup.self,
+      UpdateGroup.self,
+      RemoveGroup.self,
     ]
   )
 }

--- a/Tests/KaitenSDKTests/GroupsTests.swift
+++ b/Tests/KaitenSDKTests/GroupsTests.swift
@@ -1,0 +1,244 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Groups")
+struct GroupsTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// A group object matching the documentation example. Live verification is unavailable —
+  /// the endpoints answer 403 to tokens without access to the administrative section "Members".
+  private static let groupJSON = """
+    {
+      "name": "QA engineers",
+      "permissions": 3,
+      "add_to_cards_and_spaces_enabled": false,
+      "updated": "2024-08-29T13:16:19.886Z",
+      "created": "2024-08-29T13:16:19.886Z",
+      "id": 11,
+      "uid": "00000000-0000-4000-8000-000000000001"
+    }
+    """
+
+  /// `KaitenError` is not `Equatable`, so the status code is matched by pattern.
+  private func expectUnexpectedResponse(
+    statusCode: Int,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      Issue.record(
+        "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), no error thrown",
+        sourceLocation: sourceLocation)
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == statusCode else {
+        Issue.record(
+          "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), got \(error)",
+          sourceLocation: sourceLocation)
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)", sourceLocation: sourceLocation)
+    }
+  }
+
+  // MARK: - List
+
+  @Test("200 returns array of Group")
+  func listSuccess() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: "[\(Self.groupJSON)]"))
+
+    let groups = try await client.listGroups()
+    #expect(groups.count == 1)
+    #expect(groups[0].id == 11)
+    #expect(groups[0].uid == "00000000-0000-4000-8000-000000000001")
+    #expect(groups[0].name == "QA engineers")
+    #expect(groups[0].permissions == 3)
+    #expect(groups[0].add_to_cards_and_spaces_enabled == false)
+    #expect(groups[0].created == "2024-08-29T13:16:19.886Z")
+    #expect(groups[0].updated == "2024-08-29T13:16:19.886Z")
+  }
+
+  @Test("200 with empty body returns empty array")
+  func listEmptyBody() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: ""))
+    let groups = try await client.listGroups()
+    #expect(groups.isEmpty)
+  }
+
+  @Test("query parameters are sent")
+  func listSendsQueryParameters() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
+    let client = try makeClient(transport)
+
+    _ = try await client.listGroups(
+      withTreeEntities: true,
+      withUsersCount: true,
+      withSyncGroupAttribute: true,
+      condition: .inactive,
+      query: "designers",
+      limit: 50,
+      offset: 100
+    )
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    let path = try #require(recorded.request.path)
+    #expect(path.hasPrefix("/company/groups?"))
+    #expect(path.contains("with_tree_entities=true"))
+    #expect(path.contains("with_users_count=true"))
+    #expect(path.contains("with_sync_group_attribute=true"))
+    #expect(path.contains("condition=2"))
+    #expect(path.contains("query=designers"))
+    #expect(path.contains("limit=50"))
+    #expect(path.contains("offset=100"))
+  }
+
+  @Test("401 throws unauthorized")
+  func listUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listGroups()
+    }
+  }
+
+  /// The endpoint answers 403 with an empty body when the token's user has no access to the
+  /// administrative section "Members" (verified live).
+  @Test("403 throws unexpectedResponse")
+  func listForbidden() async throws {
+    let client = try makeClient(.returning(statusCode: 403))
+    await expectUnexpectedResponse(statusCode: 403) {
+      _ = try await client.listGroups()
+    }
+  }
+
+  // MARK: - Create
+
+  @Test("create sends the body and parses the group")
+  func createSendsBody() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: Self.groupJSON)
+    let client = try makeClient(transport)
+
+    let group = try await client.createGroup(
+      name: "QA engineers",
+      permissions: 3,
+      addToCardsAndSpacesEnabled: false
+    )
+
+    #expect(group.id == 11)
+    #expect(group.name == "QA engineers")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .post)
+    #expect(recorded.request.path == "/company/groups")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["name"] as? String == "QA engineers")
+    #expect(sent["permissions"] as? Int == 3)
+    #expect(sent["add_to_cards_and_spaces_enabled"] as? Bool == false)
+  }
+
+  @Test("402 unsupported tariff throws unexpectedResponse")
+  func createPaymentRequired() async throws {
+    let client = try makeClient(.returning(statusCode: 402))
+    await expectUnexpectedResponse(statusCode: 402) {
+      _ = try await client.createGroup(name: "QA engineers")
+    }
+  }
+
+  // MARK: - Get
+
+  @Test("200 returns the group")
+  func getSuccess() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: Self.groupJSON)
+    let client = try makeClient(transport)
+
+    let group = try await client.getGroup(uid: "00000000-0000-4000-8000-000000000001")
+
+    #expect(group.id == 11)
+    #expect(group.name == "QA engineers")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    #expect(recorded.request.path == "/company/groups/00000000-0000-4000-8000-000000000001")
+  }
+
+  /// Groups are addressed by string UID, which ``KaitenError/notFound(resource:id:)``
+  /// cannot represent, so a 404 surfaces as `unexpectedResponse`.
+  @Test("404 throws unexpectedResponse")
+  func getNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await expectUnexpectedResponse(statusCode: 404) {
+      _ = try await client.getGroup(uid: "missing")
+    }
+  }
+
+  // MARK: - Update
+
+  @Test("update targets the group UID")
+  func updateSuccess() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: Self.groupJSON)
+    let client = try makeClient(transport)
+
+    let group = try await client.updateGroup(
+      uid: "00000000-0000-4000-8000-000000000001", name: "QA engineers", permissions: 3)
+
+    #expect(group.name == "QA engineers")
+    #expect(group.permissions == 3)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .patch)
+    #expect(recorded.request.path == "/company/groups/00000000-0000-4000-8000-000000000001")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["name"] as? String == "QA engineers")
+    #expect(sent["permissions"] as? Int == 3)
+  }
+
+  @Test("update 400 throws unexpectedResponse")
+  func updateBadRequest() async throws {
+    let client = try makeClient(.returning(statusCode: 400))
+    await expectUnexpectedResponse(statusCode: 400) {
+      _ = try await client.updateGroup(uid: "uid-1", name: "")
+    }
+  }
+
+  // MARK: - Remove
+
+  @Test("remove returns the removed group")
+  func removeSuccess() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: Self.groupJSON)
+    let client = try makeClient(transport)
+
+    let group = try await client.removeGroup(uid: "00000000-0000-4000-8000-000000000001")
+
+    #expect(group.id == 11)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .delete)
+    #expect(recorded.request.path == "/company/groups/00000000-0000-4000-8000-000000000001")
+  }
+
+  @Test("remove 403 throws unexpectedResponse")
+  func removeForbidden() async throws {
+    let client = try makeClient(.returning(statusCode: 403))
+    await expectUnexpectedResponse(statusCode: 403) {
+      _ = try await client.removeGroup(uid: "uid-1")
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -5062,6 +5062,170 @@ paths:
           description: Unsupported schema format
         '404':
           description: Schema version not found
+  /company/groups:
+    get:
+      summary: Get list of groups
+      operationId: list_groups
+      parameters:
+      - name: with_tree_entities
+        in: query
+        schema:
+          type: boolean
+        description: Add tree entities for each group
+      - name: with_users_count
+        in: query
+        schema:
+          type: boolean
+        description: Add users count for each group
+      - name: with_sync_group_attribute
+        in: query
+        schema:
+          type: boolean
+        description: Add sync attribute for each group
+      - name: condition
+        in: query
+        schema:
+          type: integer
+        description: 'Group condition filter: 1 = active, 2 = inactive'
+      - name: query
+        in: query
+        schema:
+          type: string
+        description: Search query
+      - name: limit
+        in: query
+        schema:
+          type: integer
+        description: 'Maximum amount of records. Default: 100. The result is paginated only when limit or offset is present and with_tree_entities is false'
+      - name: offset
+        in: query
+        schema:
+          type: integer
+        description: Number of records to skip
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Group'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    post:
+      summary: Create group
+      operationId: create_group
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateGroupRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+        '400':
+          description: Bad request
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+  /company/groups/{uid}:
+    get:
+      summary: Get group
+      operationId: get_group
+      parameters:
+      - name: uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Group UID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                # NOTE: the docs' response-type column says `Array of objects`, but the docs' own
+                # example is a single object; live verification is unavailable (the endpoint answers
+                # 403 to non-admin tokens) — https://developers.kaiten.ru/groups/get-group
+                $ref: '#/components/schemas/Group'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    patch:
+      summary: Update group
+      operationId: update_group
+      parameters:
+      - name: uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Group UID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateGroupRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+        '400':
+          description: Bad request
+        '401':
+          description: Invalid token
+        '402':
+          description: Feature is not supported by tariff
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    delete:
+      summary: Remove group
+      operationId: remove_group
+      parameters:
+      - name: uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Group UID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
   /company/groups/{group_uid}/entities:
     get:
       summary: Get list of group entities
@@ -12129,3 +12293,58 @@ components:
           - string
           - 'null'
           description: UID of the document to use as the home page for this folder. Requires hostname to be set on this folder. Document must be within the document group tree, not archived and not hidden on public site
+    Group:
+      type: object
+      description: A company user group. The groups endpoints are documented as under active development, so attributes are subject to change
+      properties:
+        id:
+          type: integer
+          description: Group id
+        uid:
+          type: string
+          description: Group uid
+        name:
+          type: string
+          description: Group name
+        permissions:
+          type: integer
+          description: Group permissions bit mask
+        add_to_cards_and_spaces_enabled:
+          type: boolean
+          description: Ability to add all users of the group to cards placed in group spaces, and to filter logs by group in Timesheets
+        created:
+          type: string
+          description: Create date
+        updated:
+          type: string
+          description: Last update timestamp
+    CreateGroupRequest:
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 512
+          description: Group name
+        permissions:
+          type: integer
+          description: Group permissions bit mask
+        add_to_cards_and_spaces_enabled:
+          type: boolean
+          description: Ability to add all users of the group to cards placed in group spaces
+    UpdateGroupRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 512
+          description: Group name
+        permissions:
+          type: integer
+          description: Group permissions bit mask. To set several permissions, sum their documented values
+        add_to_cards_and_spaces_enabled:
+          type: boolean
+          description: Ability to add all users of the group to cards placed in group spaces, and to filter logs by group in Timesheets

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -405,6 +405,17 @@ let sections: [Section] = [
       name: "delete_document_group",
       errors: [.badRequest, .unauthorized, .forbidden, .notFound]),
   ]),
+  Section(mark: "Groups", operations: [
+    Operation(name: "list_groups", errors: [.unauthorized, .forbidden, .notFound]),
+    Operation(
+      name: "create_group",
+      errors: [.badRequest, .unauthorized, .paymentRequired, .forbidden, .notFound]),
+    Operation(name: "get_group", errors: [.unauthorized, .forbidden, .notFound]),
+    Operation(
+      name: "update_group",
+      errors: [.badRequest, .unauthorized, .paymentRequired, .forbidden, .notFound]),
+    Operation(name: "remove_group", errors: [.unauthorized, .forbidden, .notFound]),
+  ]),
 ]
 
 // MARK: - Generator


### PR DESCRIPTION
## Endpoints

- [x] `GET /company/groups` — Get list of groups (`listGroups`, `kaiten list-groups`)
- [x] `POST /company/groups` — Create group (`createGroup`, `kaiten create-group`)
- [x] `GET /company/groups/{uid}` — Get group (`getGroup`, `kaiten get-group`)
- [x] `PATCH /company/groups/{uid}` — Update group (`updateGroup`, `kaiten update-group`)
- [x] `DELETE /company/groups/{uid}` — Remove Group (`removeGroup`, `kaiten remove-group`)

## Live verification

Both GET endpoints answer **HTTP 403 with an empty body** to the available token — the groups endpoints require access to the administrative section "Members". The 403-with-no-body behaviour matches the docs and was verified live; response field types could not be live-verified, so every schema comes strictly from the documentation and test fixtures are based on the docs' example responses (sanitized).

## DOC_MISMATCH

None added — no live responses were available to diverge from the docs. One docs-internal inconsistency is annotated with a plain `# NOTE:` in the spec: the get-group 200 response is labelled "Array of objects" in the docs' response-type column while the docs' own example is a single object; the spec follows the example.

## Notes

- All documented query parameters of the list endpoint are exposed (`with_tree_entities`, `with_users_count`, `with_sync_group_attribute`, `condition`, `query`, `limit`, `offset`) per FR-010.
- `condition` is exposed as the hand-written `GroupCondition` enum with an `unknown(Int)` case per FR-020a.
- Groups are addressed by string UID, so a 404 surfaces as `unexpectedResponse` per FR-021.
- `DELETE` is documented as returning the removed group object, so `removeGroup` returns it (FR-022 does not apply).
- 13 tests added; `swift format lint --strict` clean; full suite (400 tests) green.

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)