### PR TITLE
feat(service-desk-services): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,16 @@ CLI: `add-item-to-checklist --checklist-id <id> --text <text>`,
 | `addServiceDeskExternalRecipient(cardId:email:)` | Add an external recipient to a card's service desk request |
 | `removeServiceDeskExternalRecipient(cardId:email:)` | Remove an external recipient from a card's service desk request |
 
+### Service Desk Services
+
+| Method | Description |
+|--------|-------------|
+| `listServiceDeskServices()` | List service desk services in the company |
+
+The API answers HTTP 403 for tokens without access to the service desk.
+
+CLI: `list-service-desk-services`.
+
 ### Card Files
 
 | Method | Description |

--- a/Sources/KaitenSDK/KaitenClient+ServiceDeskServices.swift
+++ b/Sources/KaitenSDK/KaitenClient+ServiceDeskServices.swift
@@ -1,0 +1,29 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - Service Desk Services
+
+extension KaitenClient {
+  /// Lists all service desk services in the company.
+  ///
+  /// Requires a token with access to the service desk; without it the API answers HTTP 403.
+  ///
+  /// - Returns: An array of services. Returns an empty array if the company has no services.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for forbidden (403) or other undocumented HTTP status codes.
+  public func listServiceDeskServices() async throws(KaitenError) -> [Components.Schemas
+    .ServiceDeskService]
+  {
+    guard
+      let response = try await callList({
+        try await client.list_service_desk_services()
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -1024,6 +1024,19 @@ extension Operations.remove_sd_external_recipient.Output {
   }
 }
 
+// MARK: - Service Desk Services
+
+extension Operations.list_service_desk_services.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_service_desk_services.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
 // MARK: - Blocker Categories
 
 extension Operations.list_blocker_categories.Output {

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -90,6 +90,7 @@ struct Kaiten: AsyncParsableCommand {
       DeleteAutomation.self,
       AddServiceDeskExternalRecipient.self,
       RemoveServiceDeskExternalRecipient.self,
+      ListServiceDeskServices.self,
       ListBlockerCategories.self,
       AddBlockerCategory.self,
       RemoveBlockerCategory.self,

--- a/Sources/kaiten/ServiceDeskServices/ServiceDeskServiceCommands.swift
+++ b/Sources/kaiten/ServiceDeskServices/ServiceDeskServiceCommands.swift
@@ -1,0 +1,21 @@
+import ArgumentParser
+import Foundation
+import KaitenSDK
+
+// MARK: - List Service Desk Services
+
+struct ListServiceDeskServices: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-service-desk-services",
+    abstract: "List service desk services in the company",
+    discussion: "The API answers HTTP 403 for tokens without access to the service desk."
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let services = try await client.listServiceDeskServices()
+    try printJSON(services, expand: global.expandedFields)
+  }
+}

--- a/Tests/KaitenSDKTests/ServiceDeskServicesTests.swift
+++ b/Tests/KaitenSDKTests/ServiceDeskServicesTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Service Desk Services")
+struct ServiceDeskServicesTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// `KaitenError` is not `Equatable`, so the status code is matched by pattern.
+  private func expectUnexpectedResponse(
+    statusCode: Int,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      Issue.record(
+        "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), no error thrown",
+        sourceLocation: sourceLocation)
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == statusCode else {
+        Issue.record(
+          "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), got \(error)",
+          sourceLocation: sourceLocation)
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)", sourceLocation: sourceLocation)
+    }
+  }
+
+  // MARK: - List
+
+  /// Fixture built from the documented response schema: the live endpoint answers HTTP 403
+  /// for tokens without service desk access, so no real response was available.
+  @Test("200 returns array of ServiceDeskService")
+  func listSuccess() async throws {
+    let json = """
+      [{
+        "id": 11,
+        "name": "Support requests",
+        "fields_settings": {
+          "commentDescription": {"required": false},
+          "size": {"required": false},
+          "dueDate": {"required": false},
+          "id_12": {"required": true}
+        },
+        "archived": false,
+        "lng": "en",
+        "email_settings": 3,
+        "type_id": null,
+        "email_key": 101,
+        "board_id": 21,
+        "column_id": 31,
+        "lane_id": 41,
+        "display_status": "default",
+        "template_description": "Describe the request",
+        "settings": {"allowed_email_masks": ["*@example.com"]},
+        "allow_to_add_external_recipients": true,
+        "column": {
+          "id": 31, "title": "Queue", "sort_order": 1, "col_count": 1, "type": 1,
+          "board_id": 21, "column_id": null, "external_id": null, "rules": 0
+        },
+        "board": {"id": 21, "title": "Requests board", "external_id": null, "card_properties": null},
+        "lane": {
+          "id": 41, "title": "Default", "sort_order": 1, "board_id": 21,
+          "condition": 1, "external_id": null
+        },
+        "voteCustomProperty": {
+          "updated": "2024-01-02T03:04:05.000Z", "created": "2024-01-01T00:00:00.000Z",
+          "service_id": 11, "custom_property_id": 12, "author_id": 7
+        }
+      }]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let services = try await client.listServiceDeskServices()
+    #expect(services.count == 1)
+    let service = try #require(services.first)
+    #expect(service.id == 11)
+    #expect(service.name == "Support requests")
+    #expect(service.archived == false)
+    #expect(service.lng == "en")
+    #expect(service.email_settings == 3)
+    #expect(service.type_id == .none)
+    #expect(service.email_key == 101)
+    #expect(service.board_id == 21)
+    #expect(service.column_id == 31)
+    #expect(service.lane_id == 41)
+    #expect(service.display_status == "default")
+    #expect(service.allow_to_add_external_recipients == true)
+    #expect(service.settings?.allowed_email_masks?.count == 1)
+    #expect(service.column?.id == 31)
+    #expect(service.column?._type == 1)
+    #expect(service.column?.column_id == nil)
+    #expect(service.board?.title == "Requests board")
+    #expect(service.lane?.condition == 1)
+    #expect(service.voteCustomProperty?.custom_property_id == 12)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    #expect(recorded.request.path == "/service-desk/services")
+  }
+
+  /// `fields_settings` and `type_id` are documented as nullable; explicit JSON null must
+  /// decode to nil rather than fail the response.
+  @Test("null nullable fields decode to nil")
+  func listNullableFields() async throws {
+    let json = """
+      [{
+        "id": 12,
+        "name": "Archived service",
+        "fields_settings": null,
+        "archived": true,
+        "type_id": null
+      }]
+      """
+    let client = try makeClient(.returning(statusCode: 200, body: json))
+
+    let services = try await client.listServiceDeskServices()
+    let service = try #require(services.first)
+    #expect(service.fields_settings == nil)
+    #expect(service.type_id == .none)
+    #expect(service.archived == true)
+  }
+
+  @Test("200 with empty body returns empty array")
+  func listEmptyBody() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: ""))
+    let services = try await client.listServiceDeskServices()
+    #expect(services.isEmpty)
+  }
+
+  @Test("401 throws unauthorized")
+  func listUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listServiceDeskServices()
+    }
+  }
+
+  /// Observed live: a token without service desk access gets HTTP 403.
+  @Test("403 throws unexpectedResponse")
+  func listForbidden() async throws {
+    let client = try makeClient(.returning(statusCode: 403))
+    await expectUnexpectedResponse(statusCode: 403) {
+      _ = try await client.listServiceDeskServices()
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -1976,6 +1976,23 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /service-desk/services:
+    get:
+      summary: Retrieve services list
+      operationId: list_service_desk_services
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ServiceDeskService'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
   /cards/{card_id}/files:
     put:
       summary: Attach file to card
@@ -5669,6 +5686,177 @@ components:
           description: Recipient email
           minLength: 1
           maxLength: 128
+    ServiceDeskService:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Service id
+        name:
+          type: string
+          description: Service name
+        fields_settings:
+          type:
+          - object
+          - 'null'
+          additionalProperties: true
+          description: 'Service fields. Documented keys: commentDescription, size, dueDate and id_{custom_property_id}; each value is a field setting object whose fields the documentation does not describe.'
+        archived:
+          type: boolean
+          description: Archived flag
+        lng:
+          type: string
+          description: Language
+        email_settings:
+          type: integer
+          description: Bitmap of email settings
+        type_id:
+          type:
+          - integer
+          - 'null'
+          description: Request (card) type ID
+        email_key:
+          type: integer
+          description: Email key
+        board_id:
+          type: integer
+          description: Board id
+        column_id:
+          type: integer
+          description: Column id
+        lane_id:
+          type: integer
+          description: Lane id
+        display_status:
+          type: string
+          description: Request's status display type
+        template_description:
+          type: string
+          description: Template request description
+        settings:
+          $ref: '#/components/schemas/ServiceDeskServiceSettings'
+          description: Service settings
+        allow_to_add_external_recipients:
+          type: boolean
+          description: Allow to add external recipients
+        column:
+          $ref: '#/components/schemas/ServiceDeskServiceColumn'
+          description: Column info
+        board:
+          $ref: '#/components/schemas/ServiceDeskServiceBoard'
+          description: Board info
+        lane:
+          $ref: '#/components/schemas/ServiceDeskServiceLane'
+          description: Lane info
+        voteCustomProperty:
+          $ref: '#/components/schemas/ServiceDeskServiceVoteCustomProperty'
+          description: Vote custom property info
+    ServiceDeskServiceSettings:
+      type: object
+      properties:
+        allowed_email_masks:
+          type: array
+          items: {}
+          description: Allowed email masks. The documentation does not state the item type.
+    ServiceDeskServiceColumn:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Column id
+        title:
+          type: string
+          description: Column title
+        sort_order:
+          type: number
+          description: Position
+        col_count:
+          type: integer
+          description: Width
+        type:
+          type: integer
+          description: 1 - queue, 2 – in progress, 3 – done
+        board_id:
+          type: integer
+          description: Board id
+        # NOTE: the service docs list the type as bare `null`; declared nullable integer to match the Column schema documented for /boards/{board_id}/columns.
+        column_id:
+          type:
+          - integer
+          - 'null'
+          description: Parent column id
+        external_id:
+          type:
+          - string
+          - 'null'
+          description: External id
+        rules:
+          type: integer
+          description: 'Bit mask for column rules. Rules: 1 - checklists must be checked, 2 - display FIFO order'
+    ServiceDeskServiceBoard:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Board id
+        title:
+          type: string
+          description: Board title
+        external_id:
+          type:
+          - string
+          - 'null'
+          description: External id
+        card_properties:
+          type:
+          - array
+          - 'null'
+          items:
+            type:
+            - object
+            - 'null'
+          description: Properties of the board cards suggested for filling
+    ServiceDeskServiceLane:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Lane id
+        title:
+          type: string
+          description: Lane title
+        sort_order:
+          type: number
+          description: Position
+        board_id:
+          type: integer
+          description: Board id
+        condition:
+          type: integer
+          description: 1 - live, 2 - archived, 3 - deleted
+        external_id:
+          type:
+          - string
+          - 'null'
+          description: External id
+    ServiceDeskServiceVoteCustomProperty:
+      type: object
+      properties:
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        service_id:
+          type: integer
+          description: Service id
+        custom_property_id:
+          type: integer
+          description: Custom property id
+        author_id:
+          type: integer
+          description: Author id
     UpdateCardFileRequest:
       type: object
       properties:

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -207,6 +207,9 @@ let sections: [Section] = [
       name: "remove_sd_external_recipient",
       errors: [.badRequest, .unauthorized, .forbidden, .notFound]),
   ]),
+  Section(mark: "Service Desk Services", operations: [
+    Operation(name: "list_service_desk_services", errors: [.unauthorized, .forbidden])
+  ]),
   Section(mark: "Blocker Categories", operations: [
     Operation(name: "list_blocker_categories", errors: [.unauthorized, .forbidden]),
     Operation(name: "add_blocker_category", errors: [.unauthorized, .forbidden, .notFound]),


### PR DESCRIPTION
## Endpoints

- [x] `GET /service-desk/services` — Retrieve services list ([docs](https://developers.kaiten.ru/service-desk-services/retrieve-services-list))

## Verification

- **Docs-only.** Live verification was not possible: the endpoint answers HTTP 403 with an empty body (the documented Forbidden response) for the verification token, which lacks service desk access. The token itself is valid — other endpoints answer 200. The spec, the SDK and the test fixture therefore follow the documentation strictly, including the Schema dialogs for `fields_settings`, `settings`, `column`, `board`, `lane` and `voteCustomProperty`.
- No `DOC_MISMATCH` annotations — with no live response there is nothing to diverge from. A `# NOTE:` comment records the one docs-only judgement call: `column.column_id`, whose documented type is plain `null`, is modeled as a nullable integer to match the standalone Column schema documented for board columns.
- No query or path parameters are documented for this endpoint, so none are exposed (FR-010 satisfied).
- No string discriminators with documented values, so no new enums; `display_status` stays a plain string as its values are not documented. The integer enums `column.type` and `lane.condition` are declared as plain integers, matching the existing Column and Lane schemas.

## Changes

- `openapi/kaiten.yaml` — `/service-desk/services` path, `ServiceDeskService` plus nested `ServiceDeskServiceSettings`, `ServiceDeskServiceColumn`, `ServiceDeskServiceBoard`, `ServiceDeskServiceLane`, `ServiceDeskServiceVoteCustomProperty` schemas
- `Sources/KaitenSDK/KaitenClient+ServiceDeskServices.swift` — `listServiceDeskServices()` with DocC comments
- `Sources/kaiten/ServiceDeskServices/ServiceDeskServiceCommands.swift` — `list-service-desk-services`, registered in `Kaiten.swift`
- `scripts/generate-response-mapping.swift` + regenerated `ResponseMapping.swift`
- `Tests/KaitenSDKTests/ServiceDeskServicesTests.swift` — 5 tests: 200 with a docs-based fixture, nullable fields, empty body, 401, 403
- `README.md` — Service Desk Services section in the API Reference

`swift format lint --strict` clean; `swift test` green (418 tests).

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)
