### PR TITLE
feat(space-template-checklist): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,24 @@ CLI: `list-space-users --space-id <id>`,
 `get-space-user --space-id <id> --user-id <id>`,
 `update-space-user --space-id <id> --user-id <id>`,
 `remove-space-user --space-id <id> --user-id <id>`.
+### Space Template Checklists
+
+| Method | Description |
+|--------|-------------|
+| `listSpaceTemplateChecklists(spaceUid:)` | List template checklists in a space |
+| `createSpaceTemplateChecklist(spaceUid:name:sortOrder:)` | Create a template checklist in a space |
+| `updateSpaceTemplateChecklist(spaceUid:templateChecklistUid:name:sortOrder:newSpaceUid:)` | Update a space template checklist |
+| `removeSpaceTemplateChecklist(spaceUid:templateChecklistUid:)` | Remove a template checklist from a space |
+
+Spaces and template checklists are addressed by string UIDs here, not integer
+IDs. The list response embeds the checklist items; the documented create and
+update responses return the checklist without them. Remove answers with an
+object carrying only the deleted checklist UID.
+
+CLI: `list-space-template-checklists --space-uid <uid>`,
+`create-space-template-checklist --space-uid <uid> [--name <name>] [--sort-order <n>]`,
+`update-space-template-checklist --space-uid <uid> --template-checklist-uid <uid> [--name <name>] [--sort-order <n>] [--new-space-uid <uid>]`,
+`remove-space-template-checklist --space-uid <uid> --template-checklist-uid <uid>`.
 
 ### Blocker Categories
 

--- a/Sources/KaitenSDK/KaitenClient+SpaceTemplateChecklist.swift
+++ b/Sources/KaitenSDK/KaitenClient+SpaceTemplateChecklist.swift
@@ -1,0 +1,121 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - Space Template Checklists
+
+extension KaitenClient {
+  /// Lists all template checklists in a space.
+  ///
+  /// - Parameter spaceUid: The space UID.
+  /// - Returns: An array of template checklists. Returns an empty array if the space has no
+  ///   template checklists.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for not found (404) or other
+  ///     undocumented HTTP status codes. A 404 is reported as `unexpectedResponse` rather than
+  ///     ``KaitenError/notFound(resource:id:)`` because spaces are addressed here by string UID,
+  ///     which that case cannot represent.
+  public func listSpaceTemplateChecklists(spaceUid: String) async throws(KaitenError)
+    -> [Components.Schemas.SpaceTemplateChecklist]
+  {
+    guard
+      let response = try await callList({
+        try await client.list_space_template_checklists(path: .init(space_uid: spaceUid))
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Creates a template checklist in a space.
+  ///
+  /// - Parameters:
+  ///   - spaceUid: The space UID.
+  ///   - name: The template checklist name. Kaiten accepts 1 to 512 characters.
+  ///   - sortOrder: The template checklist position. Must be greater than 0.
+  /// - Returns: The created template checklist.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for not found (404) or other
+  ///     undocumented HTTP status codes. A 404 is reported as `unexpectedResponse` rather than
+  ///     ``KaitenError/notFound(resource:id:)`` because spaces are addressed here by string UID,
+  ///     which that case cannot represent.
+  public func createSpaceTemplateChecklist(
+    spaceUid: String,
+    name: String? = nil,
+    sortOrder: Double? = nil
+  ) async throws(KaitenError) -> Components.Schemas.SpaceTemplateChecklist {
+    let response = try await call {
+      try await client.create_space_template_checklist(
+        path: .init(space_uid: spaceUid),
+        body: .json(.init(name: name, sort_order: sortOrder))
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Updates a template checklist.
+  ///
+  /// - Parameters:
+  ///   - spaceUid: The space UID.
+  ///   - templateChecklistUid: The template checklist UID.
+  ///   - name: The updated template checklist name. Kaiten accepts 1 to 512 characters.
+  ///   - sortOrder: The updated template checklist position. Must be greater than 0.
+  ///   - newSpaceUid: The `space_uid` request attribute. The documentation does not describe
+  ///     its effect.
+  /// - Returns: The updated template checklist.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for not found (404) or other
+  ///     undocumented HTTP status codes. A 404 is reported as `unexpectedResponse` rather than
+  ///     ``KaitenError/notFound(resource:id:)`` because both the space and the template checklist
+  ///     are addressed by string UID, which that case cannot represent.
+  public func updateSpaceTemplateChecklist(
+    spaceUid: String,
+    templateChecklistUid: String,
+    name: String? = nil,
+    sortOrder: Double? = nil,
+    newSpaceUid: String? = nil
+  ) async throws(KaitenError) -> Components.Schemas.SpaceTemplateChecklist {
+    let response = try await call {
+      try await client.update_space_template_checklist(
+        path: .init(space_uid: spaceUid, template_checklist_uid: templateChecklistUid),
+        body: .json(.init(name: name, sort_order: sortOrder, space_uid: newSpaceUid))
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Removes a template checklist from a space.
+  ///
+  /// - Parameters:
+  ///   - spaceUid: The space UID.
+  ///   - templateChecklistUid: The template checklist UID.
+  /// - Returns: The removal confirmation carrying the deleted template checklist UID.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for not found (404) or other
+  ///     undocumented HTTP status codes. A 404 is reported as `unexpectedResponse` rather than
+  ///     ``KaitenError/notFound(resource:id:)`` because both the space and the template checklist
+  ///     are addressed by string UID, which that case cannot represent.
+  public func removeSpaceTemplateChecklist(
+    spaceUid: String,
+    templateChecklistUid: String
+  ) async throws(KaitenError) -> Components.Schemas.RemoveSpaceTemplateChecklistResponse {
+    let response = try await call {
+      try await client.remove_space_template_checklist(
+        path: .init(space_uid: spaceUid, template_checklist_uid: templateChecklistUid)
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -2317,3 +2317,53 @@ extension Operations.delete_document.Output {
     }
   }
 }
+
+// MARK: - Space Template Checklists
+
+extension Operations.list_space_template_checklists.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.list_space_template_checklists.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.create_space_template_checklist.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.create_space_template_checklist.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.update_space_template_checklist.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.update_space_template_checklist.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.remove_space_template_checklist.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.remove_space_template_checklist.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -190,6 +190,10 @@ struct Kaiten: AsyncParsableCommand {
       CreateDocument.self,
       UpdateDocument.self,
       DeleteDocument.self,
+      ListSpaceTemplateChecklists.self,
+      CreateSpaceTemplateChecklist.self,
+      UpdateSpaceTemplateChecklist.self,
+      RemoveSpaceTemplateChecklist.self,
     ]
   )
 }

--- a/Sources/kaiten/SpaceTemplateChecklist/SpaceTemplateChecklistCommands.swift
+++ b/Sources/kaiten/SpaceTemplateChecklist/SpaceTemplateChecklistCommands.swift
@@ -1,0 +1,119 @@
+import ArgumentParser
+import Foundation
+import KaitenSDK
+
+// MARK: - List Space Template Checklists
+
+struct ListSpaceTemplateChecklists: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-space-template-checklists",
+    abstract: "List template checklists in a space"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Space UID")
+  var spaceUid: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let checklists = try await client.listSpaceTemplateChecklists(spaceUid: spaceUid)
+    try printJSON(checklists)
+  }
+}
+
+// MARK: - Create Space Template Checklist
+
+struct CreateSpaceTemplateChecklist: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "create-space-template-checklist",
+    abstract: "Create a template checklist in a space"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Space UID")
+  var spaceUid: String
+
+  @Option(name: .long, help: "Template checklist name (1 to 512 characters)")
+  var name: String?
+
+  @Option(name: .long, help: "Position (greater than 0)")
+  var sortOrder: Double?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let checklist = try await client.createSpaceTemplateChecklist(
+      spaceUid: spaceUid,
+      name: name,
+      sortOrder: sortOrder
+    )
+    try printJSON(checklist)
+  }
+}
+
+// MARK: - Update Space Template Checklist
+
+struct UpdateSpaceTemplateChecklist: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "update-space-template-checklist",
+    abstract: "Update a space template checklist"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Space UID")
+  var spaceUid: String
+
+  @Option(name: .long, help: "Template checklist UID")
+  var templateChecklistUid: String
+
+  @Option(name: .long, help: "Template checklist name (1 to 512 characters)")
+  var name: String?
+
+  @Option(name: .long, help: "Position (greater than 0)")
+  var sortOrder: Double?
+
+  @Option(
+    name: .long,
+    help: "The space_uid request attribute. The documentation does not describe its effect")
+  var newSpaceUid: String?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let checklist = try await client.updateSpaceTemplateChecklist(
+      spaceUid: spaceUid,
+      templateChecklistUid: templateChecklistUid,
+      name: name,
+      sortOrder: sortOrder,
+      newSpaceUid: newSpaceUid
+    )
+    try printJSON(checklist)
+  }
+}
+
+// MARK: - Remove Space Template Checklist
+
+struct RemoveSpaceTemplateChecklist: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "remove-space-template-checklist",
+    abstract: "Remove a template checklist from a space"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Space UID")
+  var spaceUid: String
+
+  @Option(name: .long, help: "Template checklist UID")
+  var templateChecklistUid: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let response = try await client.removeSpaceTemplateChecklist(
+      spaceUid: spaceUid,
+      templateChecklistUid: templateChecklistUid
+    )
+    try printJSON(response)
+  }
+}

--- a/Tests/KaitenSDKTests/SpaceTemplateChecklistsTests.swift
+++ b/Tests/KaitenSDKTests/SpaceTemplateChecklistsTests.swift
@@ -1,0 +1,251 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Space Template Checklists")
+struct SpaceTemplateChecklistsTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// `KaitenError` is not `Equatable`, so the status code is matched by pattern.
+  private func expectUnexpectedResponse(
+    statusCode: Int,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      Issue.record(
+        "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), no error thrown",
+        sourceLocation: sourceLocation)
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == statusCode else {
+        Issue.record(
+          "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), got \(error)",
+          sourceLocation: sourceLocation)
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)", sourceLocation: sourceLocation)
+    }
+  }
+
+  // MARK: - List
+
+  /// Sanitized live response. The API adds an integer `id` to both the checklist and its items,
+  /// which the documentation does not list, and `sort_order` is a fractional number.
+  @Test("200 returns array of SpaceTemplateChecklist")
+  func listSuccess() async throws {
+    let json = """
+      [{
+        "created": "2026-06-08T10:29:11.582Z",
+        "updated": "2026-06-08T11:32:45.276Z",
+        "id": 101,
+        "uid": "checklist-uid-1",
+        "name": "Planning process",
+        "sort_order": 1.185695424827543,
+        "space_uid": "space-uid-1",
+        "items": [
+          {
+            "created": "2026-06-08T10:29:11.873Z",
+            "updated": "2026-06-08T10:29:11.873Z",
+            "id": 201,
+            "text": "Hold the daily meeting",
+            "sort_order": 1,
+            "user_id": 42,
+            "uid": "item-uid-1"
+          },
+          {
+            "created": "2026-06-08T10:29:11.833Z",
+            "updated": "2026-06-08T10:39:02.338Z",
+            "id": 202,
+            "text": "Review the sprint board",
+            "sort_order": 2.5035946967394869,
+            "user_id": 42,
+            "uid": "item-uid-2"
+          }
+        ]
+      }]
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let checklists = try await client.listSpaceTemplateChecklists(spaceUid: "space-uid-1")
+
+    #expect(checklists.count == 1)
+    #expect(checklists[0].uid == "checklist-uid-1")
+    #expect(checklists[0].id == 101)
+    #expect(checklists[0].name == "Planning process")
+    #expect(checklists[0].sort_order == 1.185695424827543)
+    #expect(checklists[0].space_uid == "space-uid-1")
+    #expect(checklists[0].items?.count == 2)
+    #expect(checklists[0].items?[0].uid == "item-uid-1")
+    #expect(checklists[0].items?[0].id == 201)
+    #expect(checklists[0].items?[0].text == "Hold the daily meeting")
+    #expect(checklists[0].items?[0].user_id == 42)
+    #expect(checklists[0].items?[1].sort_order == 2.5035946967394869)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    #expect(recorded.request.path == "/spaces/space-uid-1/template-checklists")
+  }
+
+  @Test("200 with empty body returns empty array")
+  func listEmptyBody() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: ""))
+    let checklists = try await client.listSpaceTemplateChecklists(spaceUid: "space-uid-1")
+    #expect(checklists.isEmpty)
+  }
+
+  @Test("401 throws unauthorized")
+  func listUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listSpaceTemplateChecklists(spaceUid: "space-uid-1")
+    }
+  }
+
+  /// Spaces are addressed here by string UID, which ``KaitenError/notFound(resource:id:)``
+  /// cannot represent, so a 404 surfaces as `unexpectedResponse`.
+  @Test("404 throws unexpectedResponse")
+  func listNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await expectUnexpectedResponse(statusCode: 404) {
+      _ = try await client.listSpaceTemplateChecklists(spaceUid: "missing-uid")
+    }
+  }
+
+  // MARK: - Create
+
+  /// The documented create response carries the checklist without its `items`.
+  @Test("create sends name and sort_order in the body")
+  func createSendsBody() async throws {
+    let json = """
+      {
+        "uid": "checklist-uid-2",
+        "name": "Release checklist",
+        "sort_order": 1,
+        "space_uid": "space-uid-1",
+        "created": "2026-06-08T10:29:11.582Z",
+        "updated": "2026-06-08T10:29:11.582Z"
+      }
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let checklist = try await client.createSpaceTemplateChecklist(
+      spaceUid: "space-uid-1", name: "Release checklist", sortOrder: 1)
+
+    #expect(checklist.uid == "checklist-uid-2")
+    #expect(checklist.name == "Release checklist")
+    #expect(checklist.items == nil)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .post)
+    #expect(recorded.request.path == "/spaces/space-uid-1/template-checklists")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["name"] as? String == "Release checklist")
+    #expect(sent["sort_order"] as? Double == 1)
+  }
+
+  @Test("create 401 throws unauthorized")
+  func createUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.createSpaceTemplateChecklist(
+        spaceUid: "space-uid-1", name: "Release checklist")
+    }
+  }
+
+  // MARK: - Update
+
+  @Test("update targets the template checklist UID")
+  func updateSuccess() async throws {
+    let json = """
+      {
+        "uid": "checklist-uid-1",
+        "name": "Renamed checklist",
+        "sort_order": 2.5,
+        "space_uid": "space-uid-1",
+        "created": "2026-06-08T10:29:11.582Z",
+        "updated": "2026-06-09T08:00:00.000Z"
+      }
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let checklist = try await client.updateSpaceTemplateChecklist(
+      spaceUid: "space-uid-1",
+      templateChecklistUid: "checklist-uid-1",
+      name: "Renamed checklist",
+      sortOrder: 2.5
+    )
+
+    #expect(checklist.name == "Renamed checklist")
+    #expect(checklist.sort_order == 2.5)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .patch)
+    #expect(recorded.request.path == "/spaces/space-uid-1/template-checklists/checklist-uid-1")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["name"] as? String == "Renamed checklist")
+    #expect(sent["sort_order"] as? Double == 2.5)
+    #expect(sent["space_uid"] == nil)
+  }
+
+  /// Both path components are string UIDs, which ``KaitenError/notFound(resource:id:)``
+  /// cannot represent, so a 404 surfaces as `unexpectedResponse`.
+  @Test("update 404 throws unexpectedResponse")
+  func updateNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await expectUnexpectedResponse(statusCode: 404) {
+      _ = try await client.updateSpaceTemplateChecklist(
+        spaceUid: "space-uid-1", templateChecklistUid: "missing-uid", name: "Renamed")
+    }
+  }
+
+  // MARK: - Remove
+
+  /// The documented remove response is an object carrying only the deleted checklist UID.
+  @Test("remove returns the deleted UID")
+  func removeSuccess() async throws {
+    let json = """
+      {"uid": "checklist-uid-1"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let response = try await client.removeSpaceTemplateChecklist(
+      spaceUid: "space-uid-1", templateChecklistUid: "checklist-uid-1")
+
+    #expect(response.uid == "checklist-uid-1")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .delete)
+    #expect(recorded.request.path == "/spaces/space-uid-1/template-checklists/checklist-uid-1")
+  }
+
+  @Test("remove 401 throws unauthorized")
+  func removeUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.removeSpaceTemplateChecklist(
+        spaceUid: "space-uid-1", templateChecklistUid: "checklist-uid-1")
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -4180,6 +4180,110 @@ paths:
           description: Not found
         '409':
           description: Conflict
+  /spaces/{space_uid}/template-checklists:
+    get:
+      summary: Get list of space template checklists
+      operationId: list_space_template_checklists
+      parameters:
+      - name: space_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Space UID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SpaceTemplateChecklist'
+        '401':
+          description: Invalid token
+    post:
+      summary: Create new space template checklist
+      operationId: create_space_template_checklist
+      parameters:
+      - name: space_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Space UID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSpaceTemplateChecklistRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpaceTemplateChecklist'
+        '401':
+          description: Invalid token
+  /spaces/{space_uid}/template-checklists/{template_checklist_uid}:
+    patch:
+      summary: Update space template checklist
+      operationId: update_space_template_checklist
+      parameters:
+      - name: space_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Space UID
+      - name: template_checklist_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Template checklist UID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateSpaceTemplateChecklistRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpaceTemplateChecklist'
+        '401':
+          description: Invalid token
+    delete:
+      summary: Remove space template checklist
+      operationId: remove_space_template_checklist
+      parameters:
+      - name: space_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Space UID
+      - name: template_checklist_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Template checklist UID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoveSpaceTemplateChecklistResponse'
+        '401':
+          description: Invalid token
   /categories:
     get:
       summary: Retrieve list of categories
@@ -10490,6 +10594,95 @@ components:
           items:
             type: string
           description: User role ids
+    SpaceTemplateChecklist:
+      type: object
+      properties:
+        uid:
+          type: string
+          description: Template checklist UID
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/space-template-checklist/get-list-of-space-template-checklists
+        id:
+          type: integer
+          description: Template checklist id
+        name:
+          type: string
+          description: Template checklist name
+        sort_order:
+          type: number
+          description: Position
+        space_uid:
+          type: string
+          description: Space UID
+        created:
+          type: string
+          description: Create timestamp
+        updated:
+          type: string
+          description: Last update timestamp
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SpaceTemplateChecklistItem'
+          description: Template checklist items. Present in list responses; the documented create and update responses do not include it
+    SpaceTemplateChecklistItem:
+      type: object
+      properties:
+        uid:
+          type: string
+          description: Template checklist item UID
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/space-template-checklist/get-list-of-space-template-checklists
+        id:
+          type: integer
+          description: Template checklist item id
+        # DOC_MISMATCH: docs=`text`, actual=`string` — https://developers.kaiten.ru/space-template-checklist/get-list-of-space-template-checklists
+        text:
+          type: string
+          description: Template checklist item text
+        sort_order:
+          type: number
+          description: Position
+        user_id:
+          type: integer
+          description: Author id
+        created:
+          type: string
+          description: Create timestamp
+        updated:
+          type: string
+          description: Last update timestamp
+    CreateSpaceTemplateChecklistRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 512
+          description: Template checklist name
+        sort_order:
+          type: number
+          exclusiveMinimum: 0
+          description: Position
+    UpdateSpaceTemplateChecklistRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 512
+          description: Template checklist name
+        sort_order:
+          type: number
+          exclusiveMinimum: 0
+          description: Position
+        space_uid:
+          type: string
+          description: Space UID
+    RemoveSpaceTemplateChecklistResponse:
+      type: object
+      properties:
+        uid:
+          type: string
+          description: Deleted template checklist UID
     BlockerCategory:
       type: object
       properties:

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -445,6 +445,12 @@ let sections: [Section] = [
     Operation(
       name: "delete_document", errors: [.badRequest, .unauthorized, .forbidden, .notFound]),
   ]),
+  Section(mark: "Space Template Checklists", operations: [
+    Operation(name: "list_space_template_checklists", errors: [.unauthorized]),
+    Operation(name: "create_space_template_checklist", errors: [.unauthorized]),
+    Operation(name: "update_space_template_checklist", errors: [.unauthorized]),
+    Operation(name: "remove_space_template_checklist", errors: [.unauthorized]),
+  ]),
 ]
 
 // MARK: - Generator


### PR DESCRIPTION
Implements the 4 `space-template-checklist` endpoints from #448.

## Endpoints

- [x] `GET /spaces/{space_uid}/template-checklists` — `listSpaceTemplateChecklists(spaceUid:)` / `list-space-template-checklists`
- [x] `POST /spaces/{space_uid}/template-checklists` — `createSpaceTemplateChecklist(spaceUid:name:sortOrder:)` / `create-space-template-checklist`
- [x] `PATCH /spaces/{space_uid}/template-checklists/{template_checklist_uid}` — `updateSpaceTemplateChecklist(spaceUid:templateChecklistUid:name:sortOrder:newSpaceUid:)` / `update-space-template-checklist`
- [x] `DELETE /spaces/{space_uid}/template-checklists/{template_checklist_uid}` — `removeSpaceTemplateChecklist(spaceUid:templateChecklistUid:)` / `remove-space-template-checklist`

## Verification

- **Live-verified (read-only):** `GET /spaces/{space_uid}/template-checklists` was fetched from a live instance and every field compared against the schema (types and nullability). The list test fixture is a sanitized real response. A request with an unknown space UID was confirmed to answer HTTP 404, which the SDK surfaces as `unexpectedResponse` — both path components are string UIDs, which `notFound(resource:id:)` cannot represent.
- **Docs-only:** the POST, PATCH and DELETE schemas and fixtures come strictly from the documentation pages; no mutating request was sent to the live instance.

## DOC_MISMATCH annotations (3)

- `SpaceTemplateChecklist.id` — not in docs, present in actual API responses
- `SpaceTemplateChecklistItem.id` — not in docs, present in actual API responses
- `SpaceTemplateChecklistItem.text` — docs=`text`, actual=`string`

## Notes

- No documented query parameters on any of the four endpoints, and no discriminator/status fields, so no new hand-written enums.
- The list response embeds checklist items; the documented create/update responses do not, so `items` is optional in the shared schema.
- README "API Reference" gained a Space Template Checklists section with the SDK table and CLI usage.
- 10 new tests in `SpaceTemplateChecklistsTests`; full suite (423 tests) and `swift format lint --strict` are green.

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)
