### PR TITLE
feat(space-template-checklist-items): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,21 @@ CLI: `list-space-template-checklists --space-uid <uid>`,
 `update-space-template-checklist --space-uid <uid> --template-checklist-uid <uid> [--name <name>] [--sort-order <n>] [--new-space-uid <uid>]`,
 `remove-space-template-checklist --space-uid <uid> --template-checklist-uid <uid>`.
 
+### Space Template Checklist Items
+
+| Method | Description |
+|--------|-------------|
+| `createSpaceTemplateChecklistItem(spaceUid:templateChecklistUid:text:sortOrder:)` | Create an item in a space template checklist |
+| `updateSpaceTemplateChecklistItem(spaceUid:templateChecklistUid:itemUid:text:sortOrder:)` | Update an item in a space template checklist |
+| `removeSpaceTemplateChecklistItem(spaceUid:templateChecklistUid:itemUid:)` | Remove an item from a space template checklist |
+
+CLI: `create-space-template-checklist-item --space-uid <uid>
+--template-checklist-uid <uid> --text <text>`,
+`update-space-template-checklist-item --space-uid <uid>
+--template-checklist-uid <uid> --item-uid <uid>`,
+`remove-space-template-checklist-item --space-uid <uid>
+--template-checklist-uid <uid> --item-uid <uid>`.
+
 ### Blocker Categories
 
 | Method | Description |

--- a/Sources/KaitenSDK/KaitenClient+SpaceTemplateChecklistItems.swift
+++ b/Sources/KaitenSDK/KaitenClient+SpaceTemplateChecklistItems.swift
@@ -1,0 +1,109 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - Space Template Checklist Items
+
+extension KaitenClient {
+  /// Creates an item in a space template checklist.
+  ///
+  /// - Parameters:
+  ///   - spaceUid: The space UID.
+  ///   - templateChecklistUid: The template checklist UID.
+  ///   - text: Content of the checklist item (1–4096 characters).
+  ///   - sortOrder: Position (must be > 0).
+  /// - Returns: The created template checklist item.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for not found (404) or other
+  ///     undocumented HTTP status codes. A 404 is reported as `unexpectedResponse` rather than
+  ///     ``KaitenError/notFound(resource:id:)`` because the space and the template checklist are
+  ///     addressed by string UIDs and the response does not say which one is missing.
+  public func createSpaceTemplateChecklistItem(
+    spaceUid: String,
+    templateChecklistUid: String,
+    text: String,
+    sortOrder: Double? = nil
+  ) async throws(KaitenError) -> Components.Schemas.SpaceTemplateChecklistItem {
+    let response = try await call {
+      try await client.create_space_template_checklist_item(
+        path: .init(space_uid: spaceUid, template_checklist_uid: templateChecklistUid),
+        body: .json(.init(text: text, sort_order: sortOrder))
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Updates an item in a space template checklist.
+  ///
+  /// All body parameters are optional — only provided values are changed.
+  ///
+  /// - Parameters:
+  ///   - spaceUid: The space UID.
+  ///   - templateChecklistUid: The template checklist UID.
+  ///   - itemUid: The template checklist item UID.
+  ///   - text: Content of the checklist item (1–4096 characters).
+  ///   - sortOrder: Position (must be > 0).
+  /// - Returns: The updated template checklist item.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for not found (404) or other
+  ///     undocumented HTTP status codes. A 404 is reported as `unexpectedResponse` rather than
+  ///     ``KaitenError/notFound(resource:id:)`` because the space, the template checklist and the
+  ///     item are addressed by string UIDs and the response does not say which one is missing.
+  public func updateSpaceTemplateChecklistItem(
+    spaceUid: String,
+    templateChecklistUid: String,
+    itemUid: String,
+    text: String? = nil,
+    sortOrder: Double? = nil
+  ) async throws(KaitenError) -> Components.Schemas.SpaceTemplateChecklistItem {
+    let response = try await call {
+      try await client.update_space_template_checklist_item(
+        path: .init(
+          space_uid: spaceUid,
+          template_checklist_uid: templateChecklistUid,
+          item_uid: itemUid
+        ),
+        body: .json(.init(text: text, sort_order: sortOrder))
+      )
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Removes an item from a space template checklist.
+  ///
+  /// - Parameters:
+  ///   - spaceUid: The space UID.
+  ///   - templateChecklistUid: The template checklist UID.
+  ///   - itemUid: The template checklist item UID.
+  /// - Returns: The deleted template checklist item UID.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for not found (404) or other
+  ///     undocumented HTTP status codes. A 404 is reported as `unexpectedResponse` rather than
+  ///     ``KaitenError/notFound(resource:id:)`` because the space, the template checklist and the
+  ///     item are addressed by string UIDs and the response does not say which one is missing.
+  public func removeSpaceTemplateChecklistItem(
+    spaceUid: String,
+    templateChecklistUid: String,
+    itemUid: String
+  ) async throws(KaitenError) -> String {
+    let response = try await call {
+      try await client.remove_space_template_checklist_item(
+        path: .init(
+          space_uid: spaceUid,
+          template_checklist_uid: templateChecklistUid,
+          item_uid: itemUid
+        )
+      )
+    }
+    let body = try decodeResponse(response.toCase()) { try $0.json }
+    return body.uid
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -2367,3 +2367,41 @@ extension Operations.remove_space_template_checklist.Output {
     }
   }
 }
+
+// MARK: - Space Template Checklist Items
+
+extension Operations.create_space_template_checklist_item.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.create_space_template_checklist_item.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.update_space_template_checklist_item.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.update_space_template_checklist_item.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.remove_space_template_checklist_item.Output {
+  func toCase()
+    -> KaitenClient.ResponseCase<Operations.remove_space_template_checklist_item.Output.Ok.Body>
+  {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -194,6 +194,9 @@ struct Kaiten: AsyncParsableCommand {
       CreateSpaceTemplateChecklist.self,
       UpdateSpaceTemplateChecklist.self,
       RemoveSpaceTemplateChecklist.self,
+      CreateSpaceTemplateChecklistItem.self,
+      UpdateSpaceTemplateChecklistItem.self,
+      RemoveSpaceTemplateChecklistItem.self,
     ]
   )
 }

--- a/Sources/kaiten/SpaceTemplateChecklistItems/SpaceTemplateChecklistItemCommands.swift
+++ b/Sources/kaiten/SpaceTemplateChecklistItems/SpaceTemplateChecklistItemCommands.swift
@@ -1,0 +1,100 @@
+import ArgumentParser
+import KaitenSDK
+
+// MARK: - Space Template Checklist Items
+
+struct CreateSpaceTemplateChecklistItem: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "create-space-template-checklist-item",
+    abstract: "Create an item in a space template checklist"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Space UID")
+  var spaceUid: String
+
+  @Option(name: .long, help: "Template checklist UID")
+  var templateChecklistUid: String
+
+  @Option(name: .long, help: "Item text (1-4096 characters)")
+  var text: String
+
+  @Option(name: .long, help: "Sort order (must be > 0)")
+  var sortOrder: Double?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let item = try await client.createSpaceTemplateChecklistItem(
+      spaceUid: spaceUid,
+      templateChecklistUid: templateChecklistUid,
+      text: text,
+      sortOrder: sortOrder
+    )
+    try printJSON(item, expand: global.expandedFields)
+  }
+}
+
+struct UpdateSpaceTemplateChecklistItem: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "update-space-template-checklist-item",
+    abstract: "Update an item in a space template checklist"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Space UID")
+  var spaceUid: String
+
+  @Option(name: .long, help: "Template checklist UID")
+  var templateChecklistUid: String
+
+  @Option(name: .long, help: "Template checklist item UID")
+  var itemUid: String
+
+  @Option(name: .long, help: "Item text (1-4096 characters)")
+  var text: String?
+
+  @Option(name: .long, help: "Sort order (must be > 0)")
+  var sortOrder: Double?
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let item = try await client.updateSpaceTemplateChecklistItem(
+      spaceUid: spaceUid,
+      templateChecklistUid: templateChecklistUid,
+      itemUid: itemUid,
+      text: text,
+      sortOrder: sortOrder
+    )
+    try printJSON(item, expand: global.expandedFields)
+  }
+}
+
+struct RemoveSpaceTemplateChecklistItem: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "remove-space-template-checklist-item",
+    abstract: "Remove an item from a space template checklist"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Space UID")
+  var spaceUid: String
+
+  @Option(name: .long, help: "Template checklist UID")
+  var templateChecklistUid: String
+
+  @Option(name: .long, help: "Template checklist item UID")
+  var itemUid: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let deletedUid = try await client.removeSpaceTemplateChecklistItem(
+      spaceUid: spaceUid,
+      templateChecklistUid: templateChecklistUid,
+      itemUid: itemUid
+    )
+    try printJSON(["uid": deletedUid], expand: global.expandedFields)
+  }
+}

--- a/Tests/KaitenSDKTests/SpaceTemplateChecklistItemsTests.swift
+++ b/Tests/KaitenSDKTests/SpaceTemplateChecklistItemsTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Space Template Checklist Items")
+struct SpaceTemplateChecklistItemsTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// `KaitenError` is not `Equatable`, so the status code is matched by pattern.
+  private func expectUnexpectedResponse(
+    statusCode: Int,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      Issue.record(
+        "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), no error thrown",
+        sourceLocation: sourceLocation)
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == statusCode else {
+        Issue.record(
+          "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), got \(error)",
+          sourceLocation: sourceLocation)
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)", sourceLocation: sourceLocation)
+    }
+  }
+
+  /// Fixture based on the documentation example response. Live template checklist items carry
+  /// fractional `sort_order` values, so the fixture uses one to prove `number` decoding.
+  private static let itemJSON = """
+    {
+      "uid": "item-uid-1",
+      "text": "Item name",
+      "sort_order": 1.5,
+      "user_id": 42,
+      "created": "2025-04-14T11:36:37.154Z",
+      "updated": "2025-04-14T11:36:37.154Z"
+    }
+    """
+
+  // MARK: - Create
+
+  @Test("create 200 returns the created item and sends the body")
+  func createSuccess() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: Self.itemJSON)
+    let client = try makeClient(transport)
+
+    let item = try await client.createSpaceTemplateChecklistItem(
+      spaceUid: "space-uid-1",
+      templateChecklistUid: "checklist-uid-1",
+      text: "Item name",
+      sortOrder: 1.5
+    )
+
+    #expect(item.uid == "item-uid-1")
+    #expect(item.text == "Item name")
+    #expect(item.sort_order == 1.5)
+    #expect(item.user_id == 42)
+    #expect(item.created == "2025-04-14T11:36:37.154Z")
+    #expect(item.updated == "2025-04-14T11:36:37.154Z")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .post)
+    #expect(
+      recorded.request.path == "/spaces/space-uid-1/template-checklists/checklist-uid-1/items")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["text"] as? String == "Item name")
+    #expect(sent["sort_order"] as? Double == 1.5)
+  }
+
+  @Test("create 401 throws unauthorized")
+  func createUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    do {
+      _ = try await client.createSpaceTemplateChecklistItem(
+        spaceUid: "space-uid-1", templateChecklistUid: "checklist-uid-1", text: "Item name")
+      Issue.record("expected KaitenError.unauthorized, no error thrown")
+    } catch let error as KaitenError {
+      guard case .unauthorized = error else {
+        Issue.record("expected KaitenError.unauthorized, got \(error)")
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)")
+    }
+  }
+
+  // MARK: - Update
+
+  @Test("update 200 targets the item UID and returns the item")
+  func updateSuccess() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: Self.itemJSON)
+    let client = try makeClient(transport)
+
+    let item = try await client.updateSpaceTemplateChecklistItem(
+      spaceUid: "space-uid-1",
+      templateChecklistUid: "checklist-uid-1",
+      itemUid: "item-uid-1",
+      text: "Item name"
+    )
+
+    #expect(item.uid == "item-uid-1")
+    #expect(item.sort_order == 1.5)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .patch)
+    #expect(
+      recorded.request.path
+        == "/spaces/space-uid-1/template-checklists/checklist-uid-1/items/item-uid-1")
+  }
+
+  /// The space, the template checklist and the item are all addressed by string UIDs, which
+  /// ``KaitenError/notFound(resource:id:)`` cannot represent, so a 404 surfaces as
+  /// `unexpectedResponse`.
+  @Test("update 404 throws unexpectedResponse")
+  func updateNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await expectUnexpectedResponse(statusCode: 404) {
+      _ = try await client.updateSpaceTemplateChecklistItem(
+        spaceUid: "space-uid-1", templateChecklistUid: "checklist-uid-1", itemUid: "missing")
+    }
+  }
+
+  // MARK: - Remove
+
+  @Test("remove 200 returns the deleted item UID")
+  func removeSuccess() async throws {
+    let json = """
+      {"uid": "item-uid-1"}
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let deletedUid = try await client.removeSpaceTemplateChecklistItem(
+      spaceUid: "space-uid-1",
+      templateChecklistUid: "checklist-uid-1",
+      itemUid: "item-uid-1"
+    )
+
+    #expect(deletedUid == "item-uid-1")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .delete)
+    #expect(
+      recorded.request.path
+        == "/spaces/space-uid-1/template-checklists/checklist-uid-1/items/item-uid-1")
+  }
+
+  @Test("remove 404 throws unexpectedResponse")
+  func removeNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await expectUnexpectedResponse(statusCode: 404) {
+      _ = try await client.removeSpaceTemplateChecklistItem(
+        spaceUid: "space-uid-1", templateChecklistUid: "checklist-uid-1", itemUid: "missing")
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -4284,6 +4284,107 @@ paths:
                 $ref: '#/components/schemas/RemoveSpaceTemplateChecklistResponse'
         '401':
           description: Invalid token
+  /spaces/{space_uid}/template-checklists/{template_checklist_uid}/items:
+    post:
+      summary: Create new space template checklist item
+      operationId: create_space_template_checklist_item
+      parameters:
+      - name: space_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Space UID
+      - name: template_checklist_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Template checklist UID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSpaceTemplateChecklistItemRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpaceTemplateChecklistItem'
+        '401':
+          description: Invalid token
+  /spaces/{space_uid}/template-checklists/{template_checklist_uid}/items/{item_uid}:
+    patch:
+      summary: Update space template checklist item
+      operationId: update_space_template_checklist_item
+      parameters:
+      - name: space_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Space UID
+      - name: template_checklist_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Template checklist UID
+      - name: item_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Template checklist item UID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateSpaceTemplateChecklistItemRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpaceTemplateChecklistItem'
+        '401':
+          description: Invalid token
+    delete:
+      summary: Remove space template checklist item
+      operationId: remove_space_template_checklist_item
+      parameters:
+      - name: space_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Space UID
+      - name: template_checklist_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Template checklist UID
+      - name: item_uid
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Template checklist item UID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeletedSpaceTemplateChecklistItemResponse'
+        '401':
+          description: Invalid token
   /categories:
     get:
       summary: Retrieve list of categories
@@ -10683,6 +10784,40 @@ components:
         uid:
           type: string
           description: Deleted template checklist UID
+    CreateSpaceTemplateChecklistItemRequest:
+      type: object
+      required:
+      - text
+      properties:
+        text:
+          type: string
+          minLength: 1
+          maxLength: 4096
+          description: Content of the checklist item
+        sort_order:
+          type: number
+          exclusiveMinimum: 0
+          description: Position
+    UpdateSpaceTemplateChecklistItemRequest:
+      type: object
+      properties:
+        text:
+          type: string
+          minLength: 1
+          maxLength: 4096
+          description: Content of the checklist item
+        sort_order:
+          type: number
+          exclusiveMinimum: 0
+          description: Position
+    DeletedSpaceTemplateChecklistItemResponse:
+      type: object
+      required:
+      - uid
+      properties:
+        uid:
+          type: string
+          description: Deleted template checklist item UID
     BlockerCategory:
       type: object
       properties:

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -451,6 +451,11 @@ let sections: [Section] = [
     Operation(name: "update_space_template_checklist", errors: [.unauthorized]),
     Operation(name: "remove_space_template_checklist", errors: [.unauthorized]),
   ]),
+  Section(mark: "Space Template Checklist Items", operations: [
+    Operation(name: "create_space_template_checklist_item", errors: [.unauthorized]),
+    Operation(name: "update_space_template_checklist_item", errors: [.unauthorized]),
+    Operation(name: "remove_space_template_checklist_item", errors: [.unauthorized]),
+  ]),
 ]
 
 // MARK: - Generator


### PR DESCRIPTION
## Endpoints

- [x] `POST /spaces/{space_uid}/template-checklists/{template_checklist_uid}/items` — create item
- [x] `PATCH /spaces/{space_uid}/template-checklists/{template_checklist_uid}/items/{item_uid}` — update item
- [x] `DELETE /spaces/{space_uid}/template-checklists/{template_checklist_uid}/items/{item_uid}` — remove item

## What was added

- `openapi/kaiten.yaml`: two paths, `SpaceTemplateChecklistItem`, `CreateSpaceTemplateChecklistItemRequest`, `UpdateSpaceTemplateChecklistItemRequest`, `DeletedSpaceTemplateChecklistItemResponse` schemas
- `Sources/KaitenSDK/KaitenClient+SpaceTemplateChecklistItems.swift` with DocC comments on every public method
- `Sources/kaiten/SpaceTemplateChecklistItems/SpaceTemplateChecklistItemCommands.swift`: `create-space-template-checklist-item`, `update-space-template-checklist-item`, `remove-space-template-checklist-item`, registered in `Kaiten.swift`
- README "API Reference" section with SDK methods and CLI commands
- `Tests/KaitenSDKTests/SpaceTemplateChecklistItemsTests.swift`: 6 tests — a 200 parse test per endpoint plus 401/404 error paths

## Live verification vs docs

All three endpoints mutate, so no live requests were sent to them — schemas and fixtures come from the official documentation pages. The item shape was additionally cross-checked read-only against a live instance through the parent template-checklists resource (GET only), which confirmed that `sort_order` carries fractional values (spec keeps `number`) and `user_id` is integer-valued.

All documented body parameters (`text`, `sort_order`) and path parameters are exposed; the endpoints document no query parameters.

## DOC_MISMATCH

None added — no divergence between the documentation and the observed item shape.

All resources are addressed by string UIDs, so a 404 surfaces as `unexpectedResponse` per FR-021.

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)