### PR TITLE
feat(timesheet): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1033,6 +1033,35 @@ CLI: `list-groups` with `--with-tree-entities`, `--with-users-count`,
 `update-group --uid <uid>` with `--name`, `--permissions`,
 `--add-to-cards-and-spaces-enabled`; `remove-group --uid <uid>`.
 
+### Timesheet
+
+| Method | Description |
+|--------|-------------|
+| `listTimeLogs(from:to:tagIds:userIds:groupIds:spaceIds:boardIds:columnIds:cardIds:visibleColumnIds:condition:groupBy:timePrecision:timeUnit:withDailyDistribution:onlyGeneralSum:offset:limit:)` | List time logs for the whole company |
+
+Requires an API token of a user with access to the company timesheet; without
+it the API answers HTTP 403 with an empty body. The SDK models the documented
+(ungrouped) response shape; the grouping parameters are forwarded as
+documented, but the documentation does not describe how they change the
+response.
+
+```swift
+let page = try await client.listTimeLogs(
+  from: "2026-04-01",
+  to: "2026-04-30",
+  userIds: [42]
+)
+for timeLog in page.items {
+  print(timeLog.time_spent ?? 0)
+}
+```
+
+CLI: `kaiten list-time-logs` with `--from`, `--to`, `--tag-ids`, `--user-ids`,
+`--group-ids`, `--space-ids`, `--board-ids`, `--column-ids`, `--card-ids`,
+`--visible-column-ids`, `--condition`, `--group-by`, `--time-precision`,
+`--time-unit`, `--with-daily-distribution`, `--only-general-sum`, `--offset`,
+`--limit`.
+
 ## Pagination
 
 Most list endpoints accept `offset` and `limit` parameters and return a `Page<T>`:

--- a/Sources/KaitenSDK/KaitenClient+Timesheet.swift
+++ b/Sources/KaitenSDK/KaitenClient+Timesheet.swift
@@ -1,0 +1,103 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - Timesheet
+
+extension KaitenClient {
+  /// Returns a page of time logs for the whole company, filtered by query parameters.
+  ///
+  /// Requires an API token of a user who has access to the company timesheet. The SDK models the
+  /// documented (ungrouped) response shape; the `groupBy`, `withDailyDistribution` and
+  /// `onlyGeneralSum` parameters are forwarded as documented, but the documentation does not
+  /// describe how they change the response.
+  ///
+  /// - Parameters:
+  ///   - from: Start date of the reporting period, format `YYYY-MM-DD`.
+  ///   - to: End date of the reporting period, format `YYYY-MM-DD`.
+  ///   - tagIds: Filter by tag identifiers (optional).
+  ///   - userIds: Filter by user identifiers (optional).
+  ///   - groupIds: Filter by user group identifiers (optional).
+  ///   - spaceIds: Filter by space identifiers (optional).
+  ///   - boardIds: Filter by board identifiers (optional).
+  ///   - columnIds: Filter by column identifiers (optional).
+  ///   - cardIds: Filter by card identifiers (optional).
+  ///   - visibleColumnIds: Visible column identifiers (optional).
+  ///   - condition: Condition filter (optional). The documentation describes this parameter only
+  ///     with the `offset` description, so its accepted values are not documented.
+  ///   - groupBy: Grouping option: `0` — no groups, `1` — by user, `2` — by card (optional).
+  ///   - timePrecision: Time precision for the specified `timeUnit` (optional).
+  ///   - timeUnit: Time unit (optional).
+  ///   - withDailyDistribution: Returns data daily when grouped by user or card (optional).
+  ///   - onlyGeneralSum: Returns the general sum of time spent (optional).
+  ///   - offset: Number of records to skip (default `0`).
+  ///   - limit: Maximum number of records to return (default `100`, max `200`).
+  /// - Returns: A ``Page`` of time logs. Returns an empty page when no records match.
+  /// - Throws:
+  ///   - ``KaitenError/invalidPaginationRange(offset:limit:)`` if pagination parameters are out of range.
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for bad request (400), forbidden
+  ///     (403, the token's user has no access to the timesheet; the API answers with an empty
+  ///     body) or other undocumented HTTP status codes.
+  public func listTimeLogs(
+    from: String,
+    to: String,
+    tagIds: [Int]? = nil,
+    userIds: [Int]? = nil,
+    groupIds: [Int]? = nil,
+    spaceIds: [Int]? = nil,
+    boardIds: [Int]? = nil,
+    columnIds: [Int]? = nil,
+    cardIds: [Int]? = nil,
+    visibleColumnIds: [Int]? = nil,
+    condition: Int? = nil,
+    groupBy: Int? = nil,
+    timePrecision: Int? = nil,
+    timeUnit: Int? = nil,
+    withDailyDistribution: Int? = nil,
+    onlyGeneralSum: Int? = nil,
+    offset: Int = 0,
+    limit: Int = 100
+  ) async throws(KaitenError) -> Page<Components.Schemas.TimeLog> {
+    guard offset >= 0, (1...200).contains(limit) else {
+      throw .invalidPaginationRange(offset: offset, limit: limit)
+    }
+    let query = Operations.list_time_logs.Input.Query(
+      from: from,
+      to: to,
+      tag_ids: tagIds.map(joinIds),
+      user_ids: userIds.map(joinIds),
+      group_ids: groupIds.map(joinIds),
+      space_ids: spaceIds.map(joinIds),
+      board_ids: boardIds.map(joinIds),
+      column_ids: columnIds.map(joinIds),
+      card_ids: cardIds.map(joinIds),
+      visible_column_ids: visibleColumnIds.map(joinIds),
+      limit: limit,
+      offset: offset,
+      condition: condition,
+      group_by: groupBy,
+      time_precision: timePrecision,
+      time_unit: timeUnit,
+      with_daily_distribution: withDailyDistribution,
+      only_general_sum: onlyGeneralSum
+    )
+    guard
+      let response = try await callList({
+        try await client.list_time_logs(query: query)
+      })
+    else {
+      return Page(items: [], offset: offset, limit: limit)
+    }
+    let items: [Components.Schemas.TimeLog] = try decodeResponse(response.toCase()) {
+      try $0.json
+    }
+    return Page(items: items, offset: offset, limit: limit)
+  }
+
+  /// Joins identifier lists into the comma-separated string form the endpoint documents.
+  private func joinIds(_ ids: [Int]) -> String {
+    ids.map(String.init).joined(separator: ",")
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -2614,3 +2614,17 @@ extension Operations.delete_custom_property_file.Output {
     }
   }
 }
+
+// MARK: - Timesheet
+
+extension Operations.list_time_logs.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_time_logs.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -134,6 +134,7 @@ struct Kaiten: AsyncParsableCommand {
       AddTimeLog.self,
       UpdateTimeLog.self,
       RemoveTimeLog.self,
+      ListTimeLogs.self,
       ListAuditLogs.self,
       ListCardBlockerUsers.self,
       AddCardBlockerUser.self,

--- a/Sources/kaiten/Timesheet/TimesheetCommands.swift
+++ b/Sources/kaiten/Timesheet/TimesheetCommands.swift
@@ -1,0 +1,102 @@
+import ArgumentParser
+import Foundation
+import KaitenSDK
+
+// MARK: - List Time Logs
+
+struct ListTimeLogs: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-time-logs",
+    abstract: "List time logs for the whole company (paginated)",
+    discussion: """
+      Requires an API token of a user with access to the company timesheet; without it the API \
+      answers HTTP 403 with an empty body. The output models the ungrouped response shape; the \
+      grouping options are forwarded as documented, but the API documentation does not describe \
+      how they change the response.
+      """
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Start date of the reporting period (YYYY-MM-DD)")
+  var from: String
+
+  @Option(name: .long, help: "End date of the reporting period (YYYY-MM-DD)")
+  var to: String
+
+  @Option(name: .long, help: "Comma-separated tag IDs")
+  var tagIds: String?
+
+  @Option(name: .long, help: "Comma-separated user IDs")
+  var userIds: String?
+
+  @Option(name: .long, help: "Comma-separated user group IDs")
+  var groupIds: String?
+
+  @Option(name: .long, help: "Comma-separated space IDs")
+  var spaceIds: String?
+
+  @Option(name: .long, help: "Comma-separated board IDs")
+  var boardIds: String?
+
+  @Option(name: .long, help: "Comma-separated column IDs")
+  var columnIds: String?
+
+  @Option(name: .long, help: "Comma-separated card IDs")
+  var cardIds: String?
+
+  @Option(name: .long, help: "Comma-separated visible column IDs")
+  var visibleColumnIds: String?
+
+  @Option(
+    name: .long,
+    help: "Condition filter; the API documentation does not describe its accepted values"
+  )
+  var condition: Int?
+
+  @Option(name: .long, help: "Grouping option: 0 - no groups, 1 - by user, 2 - by card")
+  var groupBy: Int?
+
+  @Option(name: .long, help: "Time precision for the specified time unit")
+  var timePrecision: Int?
+
+  @Option(name: .long, help: "Time unit")
+  var timeUnit: Int?
+
+  @Option(name: .long, help: "Returns data daily when grouped by user or card")
+  var withDailyDistribution: Int?
+
+  @Option(name: .long, help: "Returns the general sum of time spent")
+  var onlyGeneralSum: Int?
+
+  @Option(name: .long, help: "Offset for pagination (default: 0)")
+  var offset: Int = 0
+
+  @Option(name: .long, help: "Limit for pagination (default: 100, max: 200)")
+  var limit: Int = 100
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let page = try await client.listTimeLogs(
+      from: from,
+      to: to,
+      tagIds: try parseIntegerCSV(tagIds, fieldName: "--tag-ids"),
+      userIds: try parseIntegerCSV(userIds, fieldName: "--user-ids"),
+      groupIds: try parseIntegerCSV(groupIds, fieldName: "--group-ids"),
+      spaceIds: try parseIntegerCSV(spaceIds, fieldName: "--space-ids"),
+      boardIds: try parseIntegerCSV(boardIds, fieldName: "--board-ids"),
+      columnIds: try parseIntegerCSV(columnIds, fieldName: "--column-ids"),
+      cardIds: try parseIntegerCSV(cardIds, fieldName: "--card-ids"),
+      visibleColumnIds: try parseIntegerCSV(visibleColumnIds, fieldName: "--visible-column-ids"),
+      condition: condition,
+      groupBy: groupBy,
+      timePrecision: timePrecision,
+      timeUnit: timeUnit,
+      withDailyDistribution: withDailyDistribution,
+      onlyGeneralSum: onlyGeneralSum,
+      offset: offset,
+      limit: limit
+    )
+    try printJSON(page, expand: global.expandedFields)
+  }
+}

--- a/Tests/KaitenSDKTests/TimesheetTests.swift
+++ b/Tests/KaitenSDKTests/TimesheetTests.swift
@@ -1,0 +1,272 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("Timesheet")
+struct TimesheetTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// `KaitenError` is not `Equatable`, so the status code is matched by pattern.
+  private func expectUnexpectedResponse(
+    statusCode: Int,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      Issue.record(
+        "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), no error thrown",
+        sourceLocation: sourceLocation)
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == statusCode else {
+        Issue.record(
+          "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), got \(error)",
+          sourceLocation: sourceLocation)
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)", sourceLocation: sourceLocation)
+    }
+  }
+
+  // MARK: - List
+
+  /// Fixture follows the 200 example in the Kaiten documentation (sanitized). The live 200 body
+  /// could not be verified: the endpoint needs timesheet access, which the verification token
+  /// does not have (the API answered 403 with an empty body, as documented).
+  @Test("200 returns page of TimeLog")
+  func listSuccess() async throws {
+    let json = """
+      [{
+        "created": "2026-04-01T10:50:30.191Z",
+        "updated": "2026-04-01T10:50:30.191Z",
+        "id": 1,
+        "card_id": 2,
+        "user_id": 3,
+        "role_id": -1,
+        "author_id": 3,
+        "updater_id": null,
+        "time_spent": 60,
+        "for_date": "2026-04-01",
+        "comment": "",
+        "card": {
+          "id": 2,
+          "created": "2026-03-20T09:06:11.715Z",
+          "updated": "2026-03-24T12:57:38.090Z",
+          "archived": false,
+          "title": "Example card",
+          "asap": false,
+          "due_date": null,
+          "sort_order": 1.5,
+          "state": 3,
+          "condition": 1,
+          "size": 8,
+          "size_unit": null,
+          "size_text": "8",
+          "board_id": 4,
+          "column_id": 5,
+          "lane_id": 6,
+          "owner_id": 3,
+          "type_id": 1,
+          "version": 10,
+          "updater_id": 3,
+          "completed_at": null,
+          "sprint_id": null,
+          "external_id": null,
+          "comments_total": 0,
+          "time_spent_sum": 60,
+          "type": {
+            "id": 1,
+            "name": "Card",
+            "color": 1,
+            "letter": "C",
+            "company_id": null,
+            "archived": false,
+            "properties": null
+          },
+          "lane": {
+            "id": 6,
+            "title": "",
+            "sort_order": 1,
+            "board_id": 4,
+            "condition": 1,
+            "external_id": null
+          },
+          "column": {
+            "id": 5,
+            "title": "Done",
+            "sort_order": 3,
+            "col_count": 1,
+            "type": 3,
+            "board_id": 4,
+            "column_id": null,
+            "external_id": null,
+            "rules": 0
+          },
+          "owner": {
+            "id": 3,
+            "full_name": "Example User",
+            "email": "user@example.com",
+            "username": "example.user",
+            "avatar_initials_url": "",
+            "initials": "EU",
+            "avatar_type": 3,
+            "lng": "en",
+            "timezone": "Europe/Moscow",
+            "theme": "light",
+            "created": "2025-07-09T13:34:04.694Z",
+            "updated": "2026-03-02T14:22:36.217Z",
+            "activated": true,
+            "ui_version": 2
+          }
+        },
+        "user": {
+          "id": 3,
+          "full_name": "Example User",
+          "email": "user@example.com",
+          "username": "example.user",
+          "avatar_initials_url": "",
+          "initials": "EU",
+          "avatar_type": 3,
+          "lng": "en",
+          "timezone": "Europe/Moscow",
+          "theme": "light",
+          "created": "2025-07-09T13:34:04.694Z",
+          "updated": "2026-03-02T14:22:36.217Z",
+          "activated": true,
+          "ui_version": 2
+        },
+        "role": {
+          "created": "2025-03-21T14:00:22.934Z",
+          "updated": "2025-03-21T14:00:22.934Z",
+          "id": -1,
+          "name": "Employee",
+          "company_id": null
+        }
+      }]
+      """
+    let client = try makeClient(.returning(statusCode: 200, body: json))
+
+    let page = try await client.listTimeLogs(from: "2026-04-01", to: "2026-04-30")
+    #expect(page.items.count == 1)
+    let timeLog = try #require(page.items.first)
+    #expect(timeLog.id == 1)
+    #expect(timeLog.card_id == 2)
+    #expect(timeLog.user_id == 3)
+    #expect(timeLog.role_id == -1)
+    #expect(timeLog.author_id == 3)
+    #expect(timeLog.updater_id == nil)
+    #expect(timeLog.time_spent == 60)
+    #expect(timeLog.for_date == "2026-04-01")
+    #expect(timeLog.comment == "")
+    #expect(timeLog.card?.id == 2)
+    #expect(timeLog.card?.title == "Example card")
+    #expect(timeLog.card?.owner?.full_name == "Example User")
+    #expect(timeLog.user?.id == 3)
+    #expect(timeLog.user?.email == "user@example.com")
+    #expect(timeLog.role?.id == -1)
+    #expect(timeLog.role?.name == "Employee")
+    #expect(timeLog.role?.company_id == nil)
+  }
+
+  @Test("200 with empty body returns empty page")
+  func listEmptyBody() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: ""))
+    let page = try await client.listTimeLogs(from: "2026-04-01", to: "2026-04-30")
+    #expect(page.items.isEmpty)
+    #expect(!page.hasMore)
+  }
+
+  @Test("query parameters are sent")
+  func listSendsQueryParameters() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
+    let client = try makeClient(transport)
+
+    _ = try await client.listTimeLogs(
+      from: "2026-04-01",
+      to: "2026-04-30",
+      tagIds: [1, 2],
+      userIds: [3],
+      groupIds: [4],
+      spaceIds: [5],
+      boardIds: [6],
+      columnIds: [7],
+      cardIds: [8],
+      visibleColumnIds: [9],
+      condition: 1,
+      groupBy: 2,
+      timePrecision: 2,
+      timeUnit: 1,
+      withDailyDistribution: 1,
+      onlyGeneralSum: 1,
+      offset: 50,
+      limit: 200
+    )
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    let path = try #require(recorded.request.path)
+    #expect(path.hasPrefix("/time-logs?"))
+    #expect(path.contains("from=2026-04-01"))
+    #expect(path.contains("to=2026-04-30"))
+    // The generated client percent-encodes the comma separator.
+    #expect(path.contains("tag_ids=1%2C2"))
+    #expect(path.contains("user_ids=3"))
+    #expect(path.contains("group_ids=4"))
+    #expect(path.contains("space_ids=5"))
+    #expect(path.contains("board_ids=6"))
+    #expect(path.contains("column_ids=7"))
+    #expect(path.contains("card_ids=8"))
+    #expect(path.contains("visible_column_ids=9"))
+    #expect(path.contains("condition=1"))
+    #expect(path.contains("group_by=2"))
+    #expect(path.contains("time_precision=2"))
+    #expect(path.contains("time_unit=1"))
+    #expect(path.contains("with_daily_distribution=1"))
+    #expect(path.contains("only_general_sum=1"))
+    #expect(path.contains("offset=50"))
+    #expect(path.contains("limit=200"))
+  }
+
+  @Test("limit above 200 throws invalidPaginationRange")
+  func listInvalidPagination() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: "[]"))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listTimeLogs(from: "2026-04-01", to: "2026-04-30", limit: 201)
+    }
+  }
+
+  @Test("400 throws unexpectedResponse")
+  func listBadRequest() async throws {
+    let client = try makeClient(
+      .returning(statusCode: 400, body: #"{"message": "attributes 'from' and 'to' are required"}"#)
+    )
+    await expectUnexpectedResponse(statusCode: 400) {
+      _ = try await client.listTimeLogs(from: "", to: "")
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func listUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listTimeLogs(from: "2026-04-01", to: "2026-04-30")
+    }
+  }
+
+  /// The endpoint answers 403 with an empty body when the token's user has no access to the
+  /// timesheet (verified live).
+  @Test("403 throws unexpectedResponse")
+  func listForbidden() async throws {
+    let client = try makeClient(.returning(statusCode: 403))
+    await expectUnexpectedResponse(statusCode: 403) {
+      _ = try await client.listTimeLogs(from: "2026-04-01", to: "2026-04-30")
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -6841,6 +6841,122 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /time-logs:
+    get:
+      summary: Get time logs list
+      operationId: list_time_logs
+      description: Get time logs list filtered by query parameters. The result is paginated (offset/limit)
+      parameters:
+      - name: from
+        in: query
+        required: true
+        schema:
+          type: string
+        description: Date from, format YYYY-MM-DD
+      - name: to
+        in: query
+        required: true
+        schema:
+          type: string
+        description: Date to, format YYYY-MM-DD
+      - name: tag_ids
+        in: query
+        schema:
+          type: string
+        description: Tag ids, comma-separated
+      - name: user_ids
+        in: query
+        schema:
+          type: string
+        description: User ids, comma-separated
+      - name: group_ids
+        in: query
+        schema:
+          type: string
+        description: User group ids, comma-separated
+      - name: space_ids
+        in: query
+        schema:
+          type: string
+        description: Space ids, comma-separated
+      - name: board_ids
+        in: query
+        schema:
+          type: string
+        description: Board ids, comma-separated
+      - name: column_ids
+        in: query
+        schema:
+          type: string
+        description: Column ids, comma-separated
+      - name: card_ids
+        in: query
+        schema:
+          type: string
+        description: Card ids, comma-separated
+      - name: visible_column_ids
+        in: query
+        schema:
+          type: string
+        description: Visible column ids, comma-separated
+      - name: limit
+        in: query
+        schema:
+          type: integer
+        description: 'Maximum number of records; the limit cannot be extended. Default: 100, max: 200'
+      - name: offset
+        in: query
+        schema:
+          type: integer
+        description: Number of records to skip
+      - name: condition
+        in: query
+        schema:
+          type: integer
+        description: Condition filter. The documentation describes this parameter only as "Number of records to skip", repeating the `offset` description
+      - name: group_by
+        in: query
+        schema:
+          type: integer
+        description: 'Options to group by. 0 - no groups, 1 - by user, 2 - by card'
+      - name: time_precision
+        in: query
+        schema:
+          type: integer
+        description: Time precision for specified time_unit
+      - name: time_unit
+        in: query
+        schema:
+          type: integer
+        description: Time unit
+      - name: with_daily_distribution
+        in: query
+        schema:
+          type: integer
+        description: Returns data daily when grouped by user or card
+      - name: only_general_sum
+        in: query
+        schema:
+          type: integer
+        description: Returns general sum time spent
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                # The docs label the 200 response type "Object", but the documented example is
+                # an array of time log records. The live 200 body could not be verified: the
+                # endpoint answered 403 with an empty body for the verification token.
+                type: array
+                items:
+                  $ref: '#/components/schemas/TimeLog'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
 components:
   securitySchemes:
     bearerAuth:
@@ -12213,6 +12329,61 @@ components:
         value:
           $ref: '#/components/schemas/NullableString'
           description: Value of card collective score custom property, 1 to 512 characters when set (null to clear, absent to leave unchanged)
+    # Time log record returned by GET /time-logs (timesheet). Shares the card time log fields
+    # but additionally embeds `card`, and documents no `author`. Built from the documentation
+    # and its 200 example only: the live response could not be verified — the endpoint answered
+    # 403 with an empty body for the verification token.
+    TimeLog:
+      type: object
+      properties:
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        id:
+          type: integer
+          description: Card time log id
+        card_id:
+          type: integer
+          description: Card id
+        user_id:
+          type: integer
+          description: User id
+        role_id:
+          type: integer
+          description: 'Role id, predefined role is: -1 - Employee'
+        author_id:
+          type: integer
+          description: Author id
+        # The docs attribute table declares `updater_id` non-nullable `integer`, but the docs'
+        # own 200 example shows `null` for a record that was never updated.
+        updater_id:
+          type:
+          - integer
+          - 'null'
+          description: Last updater id
+        time_spent:
+          type: integer
+          description: Minutes to log
+        for_date:
+          type: string
+          description: Log date
+        comment:
+          type:
+          - string
+          - 'null'
+          description: Time log comment
+        role:
+          $ref: '#/components/schemas/TimeLogRole'
+          description: Company user role info
+        user:
+          $ref: '#/components/schemas/User'
+          description: User info
+        card:
+          $ref: '#/components/schemas/Card'
+          description: Card info
     AuditLogEvent:
       type: object
       properties:

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -504,6 +504,9 @@ let sections: [Section] = [
     Operation(name: "get_custom_property_file", errors: [.unauthorized, .forbidden, .notFound]),
     Operation(name: "delete_custom_property_file", errors: [.unauthorized, .forbidden, .notFound]),
   ]),
+  Section(mark: "Timesheet", operations: [
+    Operation(name: "list_time_logs", errors: [.badRequest, .unauthorized, .forbidden]),
+  ]),
 ]
 
 // MARK: - Generator


### PR DESCRIPTION
## Endpoints

- [x] `GET /time-logs` — Get list ([docs](https://developers.kaiten.ru/timesheet/get-list))

## What was done

- `openapi/kaiten.yaml`: `/time-logs` path with all 18 documented query parameters (FR-010) and a `TimeLog` schema reusing the existing `TimeLogRole`, `User` and `Card` schemas.
- `Sources/KaitenSDK/KaitenClient+Timesheet.swift`: `listTimeLogs(...)` returning `Page<TimeLog>`, DocC on every public symbol (NFR-007).
- `Sources/kaiten/Timesheet/TimesheetCommands.swift`: `kaiten list-time-logs`, registered in `Kaiten.swift`.
- README: Timesheet section in "API Reference" with the CLI options list.
- `Tests/KaitenSDKTests/TimesheetTests.swift`: 7 tests — 200 fixture parse, empty body, query-parameter forwarding, pagination guard, 400, 401 and 403 error paths.

## Live verification

- The 200 body could **not** be verified live: the endpoint answered **HTTP 403 with an empty body** for the verification token (timesheet access is restricted), matching the documented 403 ("Response body does not exist"). The schema and the test fixture therefore follow the documentation and its 200 example, as the task rules prescribe for this case.
- The 403 empty-body behaviour itself was verified live (read-only GETs only).

## DOC_MISMATCH

None added — no live 200 response was available to compare against the docs. Two docs-internal inconsistencies are annotated with plain comments instead:

- the docs label the 200 response type "Object" while the documented example is an array;
- the docs table declares `updater_id` non-nullable `integer` while the docs' own example shows `null` (modelled as nullable).

Additionally, the `condition` query parameter's documentation repeats the `offset` description; the spec and CLI help state that its accepted values are undocumented rather than guessing.

## Notes

- No new string discriminators — no new enums needed (FR-020a not applicable).
- No `anyOf: [$ref, 'null']` patterns; nullable scalars use `type: [x, 'null']`, `OpenAPISpecIntegrityTests` passes.
- `swift format lint --strict` clean; full `swift test` suite green (429 tests).

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)