### PR TITLE
feat(user-roles): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,24 @@ is unverified.
 CLI: `list-tags` with `--limit`, `--offset`, `--space-id`, `--ids`, `--query`;
 `add-tag --name <name>`.
 
+### User Roles
+
+| Method | Description |
+|--------|-------------|
+| `listUserRoles()` | List user roles in the company |
+| `getUserRole(id:)` | Get a single user role |
+| `createUserRole(name:)` | Create a user role |
+| `updateUserRole(id:name:)` | Update a user role |
+| `deleteUserRole(id:replaceRoleId:)` | Delete a user role, moving its users to a replacement role |
+
+Deleting a role requires a replacement: users holding the deleted role are
+moved to the role named by `replaceRoleId`, and the API returns the deleted
+role.
+
+CLI: `list-user-roles`, `get-user-role --id <id>`,
+`create-user-role --name <name>`, `update-user-role --id <id> --name <name>`,
+`delete-user-role --id <id> --replace-role-id <id>`.
+
 ### Card Types & Sprints
 
 | Method | Description |

--- a/Sources/KaitenSDK/KaitenClient+UserRoles.swift
+++ b/Sources/KaitenSDK/KaitenClient+UserRoles.swift
@@ -1,0 +1,117 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - User Roles
+
+extension KaitenClient {
+  /// Lists all user roles in the company.
+  ///
+  /// - Returns: An array of user roles. Returns an empty array if the company has no roles.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for forbidden (403) or other
+  ///     undocumented HTTP status codes.
+  public func listUserRoles() async throws(KaitenError) -> [Components.Schemas.UserRole] {
+    guard
+      let response = try await callList({
+        try await client.list_user_roles()
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Creates a user role.
+  ///
+  /// - Parameter name: The role name. Kaiten accepts 1 to 64 characters.
+  /// - Returns: The created user role.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for validation error (400),
+  ///     forbidden (403) or other undocumented HTTP status codes.
+  public func createUserRole(name: String) async throws(KaitenError) -> Components.Schemas.UserRole
+  {
+    let response = try await call {
+      try await client.create_user_role(body: .json(.init(name: name)))
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+
+  /// Gets a single user role.
+  ///
+  /// - Parameter id: The role identifier.
+  /// - Returns: The user role.
+  /// - Throws:
+  ///   - ``KaitenError/notFound(resource:id:)`` if the role does not exist.
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for forbidden (403) or other
+  ///     undocumented HTTP status codes.
+  public func getUserRole(id: Int) async throws(KaitenError) -> Components.Schemas.UserRole {
+    let response = try await call {
+      try await client.get_user_role(path: .init(role_id: id))
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("userRole", id)) {
+      try $0.json
+    }
+  }
+
+  /// Updates a user role.
+  ///
+  /// - Parameters:
+  ///   - id: The role identifier.
+  ///   - name: The updated role name. Kaiten accepts 1 to 64 characters.
+  /// - Returns: The updated user role.
+  /// - Throws:
+  ///   - ``KaitenError/notFound(resource:id:)`` if the role does not exist.
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for validation error (400),
+  ///     forbidden (403) or other undocumented HTTP status codes.
+  public func updateUserRole(id: Int, name: String) async throws(KaitenError)
+    -> Components.Schemas
+    .UserRole
+  {
+    let response = try await call {
+      try await client.update_user_role(path: .init(role_id: id), body: .json(.init(name: name)))
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("userRole", id)) {
+      try $0.json
+    }
+  }
+
+  /// Deletes a user role.
+  ///
+  /// Users holding the deleted role are moved to the replacement role.
+  ///
+  /// - Parameters:
+  ///   - id: The role identifier.
+  ///   - replaceRoleId: The identifier of the role that replaces the deleted one.
+  /// - Returns: The deleted user role.
+  /// - Throws:
+  ///   - ``KaitenError/notFound(resource:id:)`` if the role does not exist.
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for forbidden (403) or other
+  ///     undocumented HTTP status codes.
+  @discardableResult
+  public func deleteUserRole(id: Int, replaceRoleId: Int) async throws(KaitenError)
+    -> Components.Schemas.UserRole
+  {
+    let response = try await call {
+      try await client.delete_user_role(
+        path: .init(role_id: id), body: .json(.init(replace_role_id: replaceRoleId)))
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("userRole", id)) {
+      try $0.json
+    }
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -1411,8 +1411,7 @@ extension Operations.remove_space_user.Output {
 // MARK: - Iterations
 
 extension Operations.get_card_iterations_history.Output {
-  func toCase() -> KaitenClient.ResponseCase<Operations.get_card_iterations_history.Output.Ok.Body>
-  {
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_card_iterations_history.Output.Ok.Body> {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
@@ -1551,8 +1550,7 @@ extension Operations.add_sd_external_recipient.Output {
 }
 
 extension Operations.remove_sd_external_recipient.Output {
-  func toCase() -> KaitenClient.ResponseCase<Operations.remove_sd_external_recipient.Output.Ok.Body>
-  {
+  func toCase() -> KaitenClient.ResponseCase<Operations.remove_sd_external_recipient.Output.Ok.Body> {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .badRequest: .undocumented(statusCode: 400)
@@ -1617,8 +1615,7 @@ extension Operations.remove_blocker_category.Output {
 // MARK: - Card Type Tree Entities
 
 extension Operations.list_card_type_tree_entities.Output {
-  func toCase() -> KaitenClient.ResponseCase<Operations.list_card_type_tree_entities.Output.Ok.Body>
-  {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_card_type_tree_entities.Output.Ok.Body> {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
@@ -1643,8 +1640,7 @@ extension Operations.add_card_type_tree_entity.Output {
 }
 
 extension Operations.delete_card_type_tree_entity.Output {
-  func toCase() -> KaitenClient.ResponseCase<Operations.delete_card_type_tree_entity.Output.Ok.Body>
-  {
+  func toCase() -> KaitenClient.ResponseCase<Operations.delete_card_type_tree_entity.Output.Ok.Body> {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
@@ -1658,8 +1654,7 @@ extension Operations.delete_card_type_tree_entity.Output {
 // MARK: - Card Allowed Users
 
 extension Operations.retrieve_card_allowed_users.Output {
-  func toCase() -> KaitenClient.ResponseCase<Operations.retrieve_card_allowed_users.Output.Ok.Body>
-  {
+  func toCase() -> KaitenClient.ResponseCase<Operations.retrieve_card_allowed_users.Output.Ok.Body> {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
@@ -1901,8 +1896,7 @@ extension Operations.remove_virtual_user.Output {
 // MARK: - Custom Directory Fields
 
 extension Operations.list_custom_directory_fields.Output {
-  func toCase() -> KaitenClient.ResponseCase<Operations.list_custom_directory_fields.Output.Ok.Body>
-  {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_custom_directory_fields.Output.Ok.Body> {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
@@ -1993,8 +1987,7 @@ extension Operations.create_custom_directory_record.Output {
 }
 
 extension Operations.get_custom_directory_record.Output {
-  func toCase() -> KaitenClient.ResponseCase<Operations.get_custom_directory_record.Output.Ok.Body>
-  {
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_custom_directory_record.Output.Ok.Body> {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
@@ -2603,8 +2596,7 @@ extension Operations.get_custom_property_file.Output {
 }
 
 extension Operations.delete_custom_property_file.Output {
-  func toCase() -> KaitenClient.ResponseCase<Operations.delete_custom_property_file.Output.Ok.Body>
-  {
+  func toCase() -> KaitenClient.ResponseCase<Operations.delete_custom_property_file.Output.Ok.Body> {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
@@ -2624,6 +2616,68 @@ extension Operations.list_time_logs.Output {
     case .badRequest: .undocumented(statusCode: 400)
     case .unauthorized: .unauthorized
     case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+// MARK: - User Roles
+
+extension Operations.list_user_roles.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_user_roles.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.create_user_role.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.create_user_role.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.get_user_role.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_user_role.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.update_user_role.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.update_user_role.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
+extension Operations.delete_user_role.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.delete_user_role.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
     case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
     }
   }

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -1411,7 +1411,8 @@ extension Operations.remove_space_user.Output {
 // MARK: - Iterations
 
 extension Operations.get_card_iterations_history.Output {
-  func toCase() -> KaitenClient.ResponseCase<Operations.get_card_iterations_history.Output.Ok.Body> {
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_card_iterations_history.Output.Ok.Body>
+  {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
@@ -1550,7 +1551,8 @@ extension Operations.add_sd_external_recipient.Output {
 }
 
 extension Operations.remove_sd_external_recipient.Output {
-  func toCase() -> KaitenClient.ResponseCase<Operations.remove_sd_external_recipient.Output.Ok.Body> {
+  func toCase() -> KaitenClient.ResponseCase<Operations.remove_sd_external_recipient.Output.Ok.Body>
+  {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .badRequest: .undocumented(statusCode: 400)
@@ -1615,7 +1617,8 @@ extension Operations.remove_blocker_category.Output {
 // MARK: - Card Type Tree Entities
 
 extension Operations.list_card_type_tree_entities.Output {
-  func toCase() -> KaitenClient.ResponseCase<Operations.list_card_type_tree_entities.Output.Ok.Body> {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_card_type_tree_entities.Output.Ok.Body>
+  {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
@@ -1640,7 +1643,8 @@ extension Operations.add_card_type_tree_entity.Output {
 }
 
 extension Operations.delete_card_type_tree_entity.Output {
-  func toCase() -> KaitenClient.ResponseCase<Operations.delete_card_type_tree_entity.Output.Ok.Body> {
+  func toCase() -> KaitenClient.ResponseCase<Operations.delete_card_type_tree_entity.Output.Ok.Body>
+  {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
@@ -1654,7 +1658,8 @@ extension Operations.delete_card_type_tree_entity.Output {
 // MARK: - Card Allowed Users
 
 extension Operations.retrieve_card_allowed_users.Output {
-  func toCase() -> KaitenClient.ResponseCase<Operations.retrieve_card_allowed_users.Output.Ok.Body> {
+  func toCase() -> KaitenClient.ResponseCase<Operations.retrieve_card_allowed_users.Output.Ok.Body>
+  {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
@@ -1896,7 +1901,8 @@ extension Operations.remove_virtual_user.Output {
 // MARK: - Custom Directory Fields
 
 extension Operations.list_custom_directory_fields.Output {
-  func toCase() -> KaitenClient.ResponseCase<Operations.list_custom_directory_fields.Output.Ok.Body> {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_custom_directory_fields.Output.Ok.Body>
+  {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
@@ -1987,7 +1993,8 @@ extension Operations.create_custom_directory_record.Output {
 }
 
 extension Operations.get_custom_directory_record.Output {
-  func toCase() -> KaitenClient.ResponseCase<Operations.get_custom_directory_record.Output.Ok.Body> {
+  func toCase() -> KaitenClient.ResponseCase<Operations.get_custom_directory_record.Output.Ok.Body>
+  {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized
@@ -2596,7 +2603,8 @@ extension Operations.get_custom_property_file.Output {
 }
 
 extension Operations.delete_custom_property_file.Output {
-  func toCase() -> KaitenClient.ResponseCase<Operations.delete_custom_property_file.Output.Ok.Body> {
+  func toCase() -> KaitenClient.ResponseCase<Operations.delete_custom_property_file.Output.Ok.Body>
+  {
     switch self {
     case .ok(let ok): .ok(ok.body)
     case .unauthorized: .unauthorized

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -213,6 +213,11 @@ struct Kaiten: AsyncParsableCommand {
       AttachCustomPropertyFile.self,
       GetCustomPropertyFile.self,
       DeleteCustomPropertyFile.self,
+      ListUserRoles.self,
+      CreateUserRole.self,
+      GetUserRole.self,
+      UpdateUserRole.self,
+      DeleteUserRole.self,
     ]
   )
 }

--- a/Sources/kaiten/UserRoles/UserRoleCommands.swift
+++ b/Sources/kaiten/UserRoles/UserRoleCommands.swift
@@ -1,0 +1,106 @@
+import ArgumentParser
+import Foundation
+import KaitenSDK
+
+// MARK: - List User Roles
+
+struct ListUserRoles: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-user-roles",
+    abstract: "List user roles in the company"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let roles = try await client.listUserRoles()
+    try printJSON(roles, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Create User Role
+
+struct CreateUserRole: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "create-user-role",
+    abstract: "Create a user role"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Role name (1-64 characters)")
+  var name: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let role = try await client.createUserRole(name: name)
+    try printJSON(role, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Get User Role
+
+struct GetUserRole: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "get-user-role",
+    abstract: "Get a user role"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Role ID")
+  var id: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let role = try await client.getUserRole(id: id)
+    try printJSON(role, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Update User Role
+
+struct UpdateUserRole: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "update-user-role",
+    abstract: "Update a user role"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Role ID")
+  var id: Int
+
+  @Option(name: .long, help: "Role name (1-64 characters)")
+  var name: String
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let role = try await client.updateUserRole(id: id, name: name)
+    try printJSON(role, expand: global.expandedFields)
+  }
+}
+
+// MARK: - Delete User Role
+
+struct DeleteUserRole: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "delete-user-role",
+    abstract: "Delete a user role, moving its users to a replacement role"
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "Role ID")
+  var id: Int
+
+  @Option(name: .long, help: "ID of the role that replaces the deleted one")
+  var replaceRoleId: Int
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let role = try await client.deleteUserRole(id: id, replaceRoleId: replaceRoleId)
+    try printJSON(role, expand: global.expandedFields)
+  }
+}

--- a/Tests/KaitenSDKTests/UserRolesTests.swift
+++ b/Tests/KaitenSDKTests/UserRolesTests.swift
@@ -1,0 +1,255 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("User Roles")
+struct UserRolesTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// `KaitenError` is not `Equatable`, so the status code is matched by pattern.
+  private func expectUnexpectedResponse(
+    statusCode: Int,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      Issue.record(
+        "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), no error thrown",
+        sourceLocation: sourceLocation)
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == statusCode else {
+        Issue.record(
+          "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), got \(error)",
+          sourceLocation: sourceLocation)
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)", sourceLocation: sourceLocation)
+    }
+  }
+
+  // MARK: - List
+
+  /// Fixture mirrors a sanitized live response. The built-in company-wide role
+  /// carries a negative id and a JSON `null` company_id, which the documentation
+  /// declares as a non-nullable integer.
+  @Test("200 returns array of UserRole")
+  func listSuccess() async throws {
+    let json = """
+      [{
+        "created": "2017-03-21T14:00:22.934Z",
+        "updated": "2017-03-21T14:00:22.934Z",
+        "id": -1,
+        "name": "Employee",
+        "company_id": null,
+        "uid": "00000000-0000-0000-0000-000000000001"
+      },
+      {
+        "created": "2018-03-12T07:16:37.527Z",
+        "updated": "2018-03-12T07:16:37.527Z",
+        "id": 12,
+        "name": "Tester",
+        "company_id": 55,
+        "uid": "00000000-0000-0000-0000-000000000002"
+      }]
+      """
+    let client = try makeClient(.returning(statusCode: 200, body: json))
+
+    let roles = try await client.listUserRoles()
+    #expect(roles.count == 2)
+    #expect(roles[0].id == -1)
+    #expect(roles[0].name == "Employee")
+    #expect(roles[0].company_id == nil)
+    #expect(roles[1].id == 12)
+    #expect(roles[1].company_id == 55)
+    #expect(roles[1].uid == "00000000-0000-0000-0000-000000000002")
+  }
+
+  @Test("200 with empty body returns empty array")
+  func listEmptyBody() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: ""))
+    let roles = try await client.listUserRoles()
+    #expect(roles.isEmpty)
+  }
+
+  @Test("401 throws unauthorized")
+  func listUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listUserRoles()
+    }
+  }
+
+  // MARK: - Create
+
+  @Test("create sends name in the body")
+  func createSendsBody() async throws {
+    let json = """
+      {
+        "created": "2026-01-01T00:00:00.000Z",
+        "updated": "2026-01-01T00:00:00.000Z",
+        "id": 13,
+        "name": "Analyst",
+        "company_id": 55,
+        "uid": "00000000-0000-0000-0000-000000000003"
+      }
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let role = try await client.createUserRole(name: "Analyst")
+    #expect(role.id == 13)
+    #expect(role.name == "Analyst")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .post)
+    #expect(recorded.request.path == "/user-roles")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["name"] as? String == "Analyst")
+  }
+
+  @Test("create 400 throws unexpectedResponse")
+  func createValidationError() async throws {
+    let client = try makeClient(.returning(statusCode: 400, body: #"{"message": "invalid"}"#))
+    await expectUnexpectedResponse(statusCode: 400) {
+      _ = try await client.createUserRole(name: "")
+    }
+  }
+
+  // MARK: - Get
+
+  @Test("200 returns a single UserRole")
+  func getSuccess() async throws {
+    let json = """
+      {
+        "created": "2018-03-12T07:16:37.527Z",
+        "updated": "2018-03-12T07:16:37.527Z",
+        "id": 12,
+        "name": "Tester",
+        "company_id": 55,
+        "uid": "00000000-0000-0000-0000-000000000002"
+      }
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let role = try await client.getUserRole(id: 12)
+    #expect(role.id == 12)
+    #expect(role.name == "Tester")
+    #expect(role.company_id == 55)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    #expect(recorded.request.path == "/user-roles/12")
+  }
+
+  @Test("get 404 throws notFound")
+  func getNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    do {
+      _ = try await client.getUserRole(id: 999)
+      Issue.record("expected KaitenError.notFound, no error thrown")
+    } catch let error as KaitenError {
+      guard case .notFound(let resource, let id) = error else {
+        Issue.record("expected KaitenError.notFound, got \(error)")
+        return
+      }
+      #expect(resource == "userRole")
+      #expect(id == 999)
+    } catch {
+      Issue.record("expected KaitenError, got \(error)")
+    }
+  }
+
+  // MARK: - Update
+
+  @Test("update targets the role id and sends name")
+  func updateSuccess() async throws {
+    let json = """
+      {
+        "created": "2018-03-12T07:16:37.527Z",
+        "updated": "2026-01-02T00:00:00.000Z",
+        "id": 12,
+        "name": "Renamed",
+        "company_id": 55,
+        "uid": "00000000-0000-0000-0000-000000000002"
+      }
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let role = try await client.updateUserRole(id: 12, name: "Renamed")
+    #expect(role.name == "Renamed")
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .patch)
+    #expect(recorded.request.path == "/user-roles/12")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["name"] as? String == "Renamed")
+  }
+
+  @Test("update 404 throws notFound")
+  func updateNotFound() async throws {
+    let client = try makeClient(.returning(statusCode: 404))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.updateUserRole(id: 999, name: "Renamed")
+    }
+  }
+
+  // MARK: - Delete
+
+  @Test("delete sends replace_role_id and returns the deleted role")
+  func deleteSuccess() async throws {
+    let json = """
+      {
+        "created": "2018-03-12T07:16:37.527Z",
+        "updated": "2018-03-12T07:16:37.527Z",
+        "id": 12,
+        "name": "Tester",
+        "company_id": 55,
+        "uid": "00000000-0000-0000-0000-000000000002"
+      }
+      """
+    let transport = MockClientTransport.returning(statusCode: 200, body: json)
+    let client = try makeClient(transport)
+
+    let role = try await client.deleteUserRole(id: 12, replaceRoleId: 13)
+    #expect(role.id == 12)
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .delete)
+    #expect(recorded.request.path == "/user-roles/12")
+
+    let body = try #require(recorded.body)
+    var bytes: [UInt8] = []
+    for try await chunk in body { bytes.append(contentsOf: chunk) }
+    let sent = try #require(
+      try JSONSerialization.jsonObject(with: Data(bytes)) as? [String: Any])
+    #expect(sent["replace_role_id"] as? Int == 13)
+  }
+
+  @Test("delete 403 throws unexpectedResponse")
+  func deleteForbidden() async throws {
+    let client = try makeClient(.returning(statusCode: 403))
+    await expectUnexpectedResponse(statusCode: 403) {
+      _ = try await client.deleteUserRole(id: 12, replaceRoleId: 13)
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -6957,6 +6957,129 @@ paths:
           description: Invalid token
         '403':
           description: Forbidden
+  /user-roles:
+    get:
+      summary: Get list of user roles
+      operationId: list_user_roles
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserRole'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+    post:
+      summary: Create user role
+      operationId: create_user_role
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateUserRoleRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserRole'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+  /user-roles/{role_id}:
+    get:
+      summary: Get user role
+      operationId: get_user_role
+      parameters:
+      - name: role_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Role ID
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserRole'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    patch:
+      summary: Update user role
+      operationId: update_user_role
+      parameters:
+      - name: role_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Role ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateUserRoleRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserRole'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+    delete:
+      summary: Remove user role
+      operationId: delete_user_role
+      parameters:
+      - name: role_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Role ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteUserRoleRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserRole'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
 components:
   securitySchemes:
     bearerAuth:
@@ -15078,3 +15201,55 @@ components:
           maxLength: 128
           pattern: '^[a-z0-9-]+$'
           description: Human-readable URL slug. Lowercase latin letters, digits and hyphens only. Must be unique within the public site subtree
+    UserRole:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Role id
+        uid:
+          type: string
+          description: Role uid
+        name:
+          type: string
+          description: Role name
+        # DOC_MISMATCH: docs=non-nullable `integer`, actual=`integer | null` (built-in company-wide roles carry no company id) — https://developers.kaiten.ru/user-roles/get-list-of-user-roles
+        company_id:
+          type:
+          - integer
+          - 'null'
+          description: Company Id
+        created:
+          type: string
+          description: Create date
+        updated:
+          type: string
+          description: Last update timestamp
+    CreateUserRoleRequest:
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 64
+          description: Role name
+    UpdateUserRoleRequest:
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 64
+          description: Role name
+    DeleteUserRoleRequest:
+      type: object
+      required:
+      - replace_role_id
+      properties:
+        replace_role_id:
+          type: integer
+          description: Role id to replace deleted

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -507,6 +507,14 @@ let sections: [Section] = [
   Section(mark: "Timesheet", operations: [
     Operation(name: "list_time_logs", errors: [.badRequest, .unauthorized, .forbidden]),
   ]),
+  Section(mark: "User Roles", operations: [
+    Operation(name: "list_user_roles", errors: [.unauthorized, .forbidden]),
+    Operation(name: "create_user_role", errors: [.badRequest, .unauthorized, .forbidden]),
+    Operation(name: "get_user_role", errors: [.unauthorized, .forbidden, .notFound]),
+    Operation(
+      name: "update_user_role", errors: [.badRequest, .unauthorized, .forbidden, .notFound]),
+    Operation(name: "delete_user_role", errors: [.unauthorized, .forbidden, .notFound]),
+  ]),
 ]
 
 // MARK: - Generator


### PR DESCRIPTION
## Endpoints

- [x] `GET /user-roles` — list user roles
- [x] `POST /user-roles` — create user role
- [x] `GET /user-roles/{role_id}` — get user role
- [x] `PATCH /user-roles/{role_id}` — update user role
- [x] `DELETE /user-roles/{role_id}` — remove user role (required `replace_role_id` body; returns the deleted role)

## Verification

- **Live-verified (read-only GETs):** `GET /user-roles` and `GET /user-roles/{role_id}` — every field compared against the schema for types and nullability; the list test fixture is a sanitized live response. CLI smoke-tested end-to-end against a live instance for both GETs.
- **Docs-only:** `POST`, `PATCH`, `DELETE` — schemas strictly from the documentation; no mutating request was sent to the live API.

## DOC_MISMATCH

- `UserRole.company_id`: docs declare a non-nullable `integer`, but built-in company-wide roles carry a JSON `null` — annotated in `openapi/kaiten.yaml`.

## Scope

- `openapi/kaiten.yaml`: paths + `UserRole`, `CreateUserRoleRequest`, `UpdateUserRoleRequest`, `DeleteUserRoleRequest` schemas. The endpoints document no query parameters, so none are exposed.
- SDK: `Sources/KaitenSDK/KaitenClient+UserRoles.swift` (DocC on every public symbol); response mappings regenerated via `scripts/generate-response-mapping.swift`.
- CLI: `list-user-roles`, `create-user-role`, `get-user-role`, `update-user-role`, `delete-user-role`, registered in `Kaiten.swift`.
- README: API Reference table + CLI commands for user roles.
- Tests: 11 tests in `Tests/KaitenSDKTests/UserRolesTests.swift` — at least one 200-parse test per endpoint plus error paths (400, 401, 403, 404). Full suite: 433 tests pass; `swift format lint --strict` clean.

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)