### PR TITLE
feat(tree-entity-roles): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1105,6 +1105,20 @@ for entity in page.items where entity.treeEntityType == .space {
 CLI: `kaiten list-tree-entities` with `--parent-entity-uid`, `--levels-count`,
 `--offset`, `--limit`.
 
+### Tree Entity Roles
+
+| Method | Description |
+|--------|-------------|
+| `listTreeEntityRoles()` | List tree entity roles of the company |
+
+Kaiten documents this endpoint as under active development, so its response
+format is subject to change. The response nests per-entity permission objects
+(menu root, spaces, documents, folders, story maps); card custom property
+permissions arrive either as a blanket boolean or as an object keyed by custom
+property id.
+
+CLI: `list-tree-entity-roles`.
+
 ## Pagination
 
 Most list endpoints accept `offset` and `limit` parameters and return a `Page<T>`:

--- a/Sources/KaitenSDK/KaitenClient+TreeEntityRoles.swift
+++ b/Sources/KaitenSDK/KaitenClient+TreeEntityRoles.swift
@@ -1,0 +1,30 @@
+import Foundation
+import OpenAPIRuntime
+
+// MARK: - Tree Entity Roles
+
+extension KaitenClient {
+  /// Lists tree entity roles of the company.
+  ///
+  /// The Kaiten documentation marks this endpoint as under active development,
+  /// so its response format is subject to change.
+  ///
+  /// - Returns: An array of tree entity roles. Returns an empty array if the company has none.
+  /// - Throws:
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for forbidden (403) or other undocumented HTTP status codes.
+  public func listTreeEntityRoles() async throws(KaitenError) -> [Components.Schemas
+    .TreeEntityRole]
+  {
+    guard
+      let response = try await callList({
+        try await client.list_tree_entity_roles()
+      })
+    else {
+      return []
+    }
+    return try decodeResponse(response.toCase()) { try $0.json }
+  }
+}

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -2703,3 +2703,16 @@ extension Operations.delete_user_role.Output {
     }
   }
 }
+
+// MARK: - Tree Entity Roles
+
+extension Operations.list_tree_entity_roles.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.list_tree_entity_roles.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -219,6 +219,7 @@ struct Kaiten: AsyncParsableCommand {
       GetUserRole.self,
       UpdateUserRole.self,
       DeleteUserRole.self,
+      ListTreeEntityRoles.self,
     ]
   )
 }

--- a/Sources/kaiten/TreeEntityRoles/TreeEntityRoleCommands.swift
+++ b/Sources/kaiten/TreeEntityRoles/TreeEntityRoleCommands.swift
@@ -1,0 +1,23 @@
+import ArgumentParser
+import KaitenSDK
+
+// MARK: - List Tree Entity Roles
+
+struct ListTreeEntityRoles: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "list-tree-entity-roles",
+    abstract: "List tree entity roles of the company",
+    discussion: """
+      Kaiten documents this endpoint as under active development, so its response format is \
+      subject to change.
+      """
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  func run() async throws {
+    let client = try await global.makeClient()
+    let roles = try await client.listTreeEntityRoles()
+    try printJSON(roles, expand: global.expandedFields)
+  }
+}

--- a/Tests/KaitenSDKTests/TreeEntityRolesTests.swift
+++ b/Tests/KaitenSDKTests/TreeEntityRolesTests.swift
@@ -1,0 +1,206 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("TreeEntityRoles")
+struct TreeEntityRolesTests {
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  /// `KaitenError` is not `Equatable`, so the status code is matched by pattern.
+  private func expectUnexpectedResponse(
+    statusCode: Int,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      Issue.record(
+        "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), no error thrown",
+        sourceLocation: sourceLocation)
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let code, _) = error, code == statusCode else {
+        Issue.record(
+          "expected KaitenError.unexpectedResponse(statusCode: \(statusCode)), got \(error)",
+          sourceLocation: sourceLocation)
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)", sourceLocation: sourceLocation)
+    }
+  }
+
+  /// Sanitized live response. The API answers with an array even though the
+  /// documentation declares a single object, uses `permissions` where the
+  /// documentation says `role_permissions`, and adds `company_uid` and `locked`
+  /// the documentation does not mention.
+  private static let listFixture = """
+    [{
+      "id": "role-uid-1",
+      "created": "2025-10-20T14:45:40.507Z",
+      "updated": "2025-10-21T18:25:12.663Z",
+      "name": "Reviewer",
+      "sort_order": 1.3732937753954515,
+      "new_permissions_default_value": true,
+      "company_uid": "company-uid-1",
+      "locked": null,
+      "permissions": {
+        "root": {"move": false, "share": true, "create": false, "import": false},
+        "space": {
+          "card": {
+            "move": true, "read": true, "create": true, "delete": true, "update": true,
+            "comment": true, "read_own": false,
+            "properties": {"id_101": {"read": true}}
+          },
+          "read": true,
+          "board": {"read": true, "create": false, "delete": false, "update": false},
+          "share": true,
+          "addons": {"read": false, "update": false},
+          "create": false,
+          "delete": false,
+          "import": true,
+          "update": false,
+          "webhook": {"read": false, "delete": false, "update": false},
+          "workflow": {"read": true, "delete": true, "update": true},
+          "iteration": {"read": true, "delete": true, "update": true},
+          "automation": {"read": false, "delete": false, "update": false},
+          "i_calendar": {"read": false, "delete": false, "update": false},
+          "user_group": {"read": true},
+          "move_within": false,
+          "restriction": {"read": false, "delete": false, "update": false},
+          "move_outside": false,
+          "view_settings": false,
+          "access_control": false,
+          "external_webhook": {"read": false, "delete": false, "update": false},
+          "public_filters_manage": true
+        },
+        "document": {
+          "read": true, "share": true, "create": true, "delete": false, "import": true,
+          "update": false, "comment": true, "user_group": {"read": true},
+          "move_within": false, "move_outside": false, "access_control": false
+        },
+        "story_map": {
+          "read": true, "share": true, "create": false, "delete": false, "import": true,
+          "update": false, "user_group": {"read": true},
+          "move_within": false, "move_outside": false, "access_control": false
+        },
+        "document_group": {
+          "read": true, "share": true, "create": false, "delete": false, "import": true,
+          "update": false, "user_group": {"read": true},
+          "move_within": false, "move_outside": false, "access_control": false
+        }
+      }
+    },
+    {
+      "id": "role-uid-2",
+      "created": "2025-01-10T09:00:00.000Z",
+      "updated": "2025-01-10T09:00:00.000Z",
+      "name": "Editor",
+      "sort_order": 2,
+      "new_permissions_default_value": false,
+      "company_uid": null,
+      "locked": null,
+      "permissions": {
+        "root": {"move": true, "share": true, "create": true, "import": true},
+        "space": {
+          "card": {
+            "move": true, "read": true, "create": true, "delete": true, "update": true,
+            "comment": true, "read_own": false,
+            "properties": true
+          },
+          "read": true,
+          "board": {"read": true, "create": true, "delete": true, "update": true}
+        }
+      }
+    }]
+    """
+
+  // MARK: - List
+
+  @Test("200 returns array of TreeEntityRole")
+  func listSuccess() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: Self.listFixture))
+
+    let roles = try await client.listTreeEntityRoles()
+    #expect(roles.count == 2)
+
+    let custom = roles[0]
+    #expect(custom.id == "role-uid-1")
+    #expect(custom.name == "Reviewer")
+    #expect(custom.sort_order == 1.3732937753954515)
+    #expect(custom.new_permissions_default_value == true)
+    #expect(custom.company_uid == "company-uid-1")
+    #expect(custom.locked == nil)
+    #expect(custom.role_permissions == nil)
+
+    let permissions = try #require(custom.permissions)
+    #expect(permissions.root?.move == false)
+    #expect(permissions.root?.share == true)
+    #expect(permissions.root?._import == false)
+
+    let space = try #require(permissions.space)
+    #expect(space.read == true)
+    #expect(space.public_filters_manage == true)
+    #expect(space.webhook?.read == false)
+    #expect(space.webhooks == nil)
+    #expect(space.workflow?.additionalProperties.value["read"] as? Bool == true)
+
+    let card = try #require(space.card)
+    #expect(card.read == true)
+    #expect(card.read_own == false)
+    // Per-property permissions arrive as an object keyed by custom property id.
+    #expect(card.properties?.value1 == nil)
+    #expect(card.properties?.value2 != nil)
+
+    #expect(permissions.document?.comment == true)
+    #expect(permissions.document_group?.read == true)
+    #expect(permissions.story_map?.access_control == false)
+
+    let builtIn = roles[1]
+    #expect(builtIn.company_uid == nil)
+    #expect(builtIn.sort_order == 2)
+    // A blanket boolean grants or denies all custom properties at once.
+    #expect(builtIn.permissions?.space?.card?.properties?.value1 == true)
+    #expect(builtIn.permissions?.space?.card?.properties?.value2 == nil)
+  }
+
+  @Test("list requests GET /tree-entity-roles")
+  func listRequestShape() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: "[]")
+    let client = try makeClient(transport)
+
+    _ = try await client.listTreeEntityRoles()
+
+    let recorded = try #require(transport.recordedRequests.first)
+    #expect(recorded.request.method == .get)
+    #expect(recorded.request.path == "/tree-entity-roles")
+  }
+
+  @Test("200 with empty body returns empty array")
+  func listEmptyBody() async throws {
+    let client = try makeClient(.returning(statusCode: 200, body: ""))
+    let roles = try await client.listTreeEntityRoles()
+    #expect(roles.isEmpty)
+  }
+
+  @Test("401 throws unauthorized")
+  func listUnauthorized() async throws {
+    let client = try makeClient(.returning(statusCode: 401))
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.listTreeEntityRoles()
+    }
+  }
+
+  @Test("403 throws unexpectedResponse")
+  func listForbidden() async throws {
+    let client = try makeClient(.returning(statusCode: 403))
+    await expectUnexpectedResponse(statusCode: 403) {
+      _ = try await client.listTreeEntityRoles()
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -7119,6 +7119,24 @@ paths:
           description: Forbidden
         '404':
           description: Not found
+  /tree-entity-roles:
+    get:
+      summary: Get list of tree entity roles
+      operationId: list_tree_entity_roles
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                # DOC_MISMATCH: docs=`object`, actual=`array` of role objects — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+                type: array
+                items:
+                  $ref: '#/components/schemas/TreeEntityRole'
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
 components:
   securitySchemes:
     bearerAuth:
@@ -15435,3 +15453,349 @@ components:
         updated:
           type: string
           description: Last update timestamp. ISO 8601 format
+    # NOTE: the documentation marks the tree-entity-roles endpoint as under active development,
+    # so parameters, attributes and response formats are subject to change.
+    TreeEntityRole:
+      type: object
+      description: Company tree entity role
+      properties:
+        id:
+          type: string
+          description: Role uid
+        created:
+          type: string
+          description: Create date
+        updated:
+          type: string
+          description: Last update timestamp
+        name:
+          type: string
+          description: Role name
+        sort_order:
+          type: number
+          description: Role sort order
+        new_permissions_default_value:
+          type: boolean
+          description: When changing the permissions structure, grant rights to new actions by default
+        # DOC_MISMATCH: docs=`role_permissions`, actual key is `permissions` — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        permissions:
+          $ref: '#/components/schemas/TreeEntityRolePermissions'
+          description: Group entity permissions
+        # DOC_MISMATCH: docs=`role_permissions`, absent from actual API responses (actual key is `permissions`) — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        role_permissions:
+          $ref: '#/components/schemas/TreeEntityRolePermissions'
+          description: Group entity permissions under the documented key
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        company_uid:
+          type:
+          - string
+          - 'null'
+          description: Company uid. Built-in roles carry null
+        # DOC_MISMATCH: not in docs, present in actual API responses; observed only `null` — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        locked:
+          type:
+          - boolean
+          - 'null'
+          description: Whether the role is locked. Only null has been observed in live responses
+    TreeEntityRolePermissions:
+      type: object
+      description: Group entity permissions of a tree entity role
+      properties:
+        root:
+          $ref: '#/components/schemas/TreeEntityRoleRootPermissions'
+          description: Permissions for menu root
+        space:
+          $ref: '#/components/schemas/TreeEntityRoleSpacePermissions'
+          description: Permissions for space
+        document:
+          $ref: '#/components/schemas/TreeEntityRoleDocumentPermissions'
+          description: Permissions for documents
+        document_group:
+          $ref: '#/components/schemas/TreeEntityRoleDocumentGroupPermissions'
+          description: Permissions for folders
+        story_map:
+          $ref: '#/components/schemas/TreeEntityRoleStoryMapPermissions'
+          description: Permissions for story maps
+    TreeEntityRoleRootPermissions:
+      type: object
+      description: Tree entity role permissions for the menu root
+      properties:
+        move:
+          type: boolean
+          description: Permissions for move in the menu root
+        create:
+          type: boolean
+          description: Permissions for create in the menu root
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        import:
+          type: boolean
+          description: Permissions for import in the menu root
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        share:
+          type: boolean
+          description: Permissions for share in the menu root
+    TreeEntityRoleSpacePermissions:
+      type: object
+      description: Tree entity role permissions for spaces
+      properties:
+        read:
+          type: boolean
+          description: Permissions to view space
+        create:
+          type: boolean
+          description: Permissions for create space
+        delete:
+          type: boolean
+          description: Permissions for delete space
+        update:
+          type: boolean
+          description: Permissions for update space
+        move_within:
+          type: boolean
+          description: Permissions for moving within a hierarchy
+        move_outside:
+          type: boolean
+          description: Permissions for moving outside a hierarchy
+        access_control:
+          type: boolean
+          description: Permissions for space access control
+        card:
+          $ref: '#/components/schemas/TreeEntityRoleCardPermissions'
+          description: Permissions for space cards
+        board:
+          $ref: '#/components/schemas/TreeEntityRoleBoardPermissions'
+          description: Permissions for boards
+        # DOC_MISMATCH: docs=`webhooks`, absent from actual API responses (actual key is `webhook`) — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        webhooks:
+          $ref: '#/components/schemas/TreeEntityRoleResourcePermissions'
+          description: Permissions for webhooks under the documented key
+        # DOC_MISMATCH: not in docs (docs use `webhooks`), present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        webhook:
+          $ref: '#/components/schemas/TreeEntityRoleResourcePermissions'
+          description: Permissions for webhooks
+        automation:
+          $ref: '#/components/schemas/TreeEntityRoleResourcePermissions'
+          description: Permissions for automations
+        i_calendar:
+          $ref: '#/components/schemas/TreeEntityRoleResourcePermissions'
+          description: Permissions for calendar integrations
+        restriction:
+          $ref: '#/components/schemas/TreeEntityRoleResourcePermissions'
+          description: Permissions for restrictions
+        external_webhook:
+          $ref: '#/components/schemas/TreeEntityRoleResourcePermissions'
+          description: Permissions for external webhook
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        import:
+          type: boolean
+          description: Permissions for import in the space
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        share:
+          type: boolean
+          description: Permissions for share the space
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        public_filters_manage:
+          type: boolean
+          description: Permissions for managing public filters
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        view_settings:
+          type: boolean
+          description: Permissions for space view settings
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        addons:
+          type: object
+          additionalProperties: true
+          description: Permissions for addons. Shape is not described in the Kaiten documentation
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        iteration:
+          type: object
+          additionalProperties: true
+          description: Permissions for iterations. Shape is not described in the Kaiten documentation
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        user_group:
+          type: object
+          additionalProperties: true
+          description: Permissions for user groups. Shape is not described in the Kaiten documentation
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        workflow:
+          type: object
+          additionalProperties: true
+          description: Permissions for workflows. Shape is not described in the Kaiten documentation
+    TreeEntityRoleCardPermissions:
+      type: object
+      description: Tree entity role permissions for space cards
+      properties:
+        move:
+          type: boolean
+          description: Permissions for move card
+        read:
+          type: boolean
+          description: Permissions for read card
+        create:
+          type: boolean
+          description: Permissions for create card
+        delete:
+          type: boolean
+          description: Permissions for delete card
+        update:
+          type: boolean
+          description: Permissions for update card
+        comment:
+          type: boolean
+          description: Permissions for leave card comments
+        read_own:
+          type: boolean
+          description: Permissions for reading card, where user is a member or owner
+        properties:
+          anyOf:
+          - type: boolean
+          - type: object
+            additionalProperties: true
+          description: Permissions for managing card custom properties. If it is an object, then there will be permissions to specific custom properties inside
+    TreeEntityRoleBoardPermissions:
+      type: object
+      description: Tree entity role permissions for boards
+      properties:
+        create:
+          type: boolean
+          description: Permissions for creating boards
+        read:
+          type: boolean
+          description: Permissions to view board
+        update:
+          type: boolean
+          description: Permissions for update board
+        delete:
+          type: boolean
+          description: Permissions for delete board
+    TreeEntityRoleResourcePermissions:
+      type: object
+      description: Tree entity role read, update, and delete permissions for a space resource, such as webhooks, automations, calendar integrations, restrictions, or external webhooks
+      properties:
+        read:
+          type: boolean
+          description: Permissions to view the resource
+        update:
+          type: boolean
+          description: Permissions for update the resource
+        delete:
+          type: boolean
+          description: Permissions for delete the resource
+    TreeEntityRoleDocumentPermissions:
+      type: object
+      description: Tree entity role permissions for documents
+      properties:
+        read:
+          type: boolean
+          description: Permissions to view document
+        create:
+          type: boolean
+          description: Permissions for create document
+        delete:
+          type: boolean
+          description: Permissions for delete document
+        update:
+          type: boolean
+          description: Permissions for update document
+        move_within:
+          type: boolean
+          description: Permissions for moving within a hierarchy
+        move_outside:
+          type: boolean
+          description: Permissions for moving outside a hierarchy
+        access_control:
+          type: boolean
+          description: Permissions for document access control
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        comment:
+          type: boolean
+          description: Permissions for leave document comments
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        import:
+          type: boolean
+          description: Permissions for import documents
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        share:
+          type: boolean
+          description: Permissions for share documents
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        user_group:
+          type: object
+          additionalProperties: true
+          description: Permissions for user groups. Shape is not described in the Kaiten documentation
+    TreeEntityRoleDocumentGroupPermissions:
+      type: object
+      description: Tree entity role permissions for folders
+      properties:
+        read:
+          type: boolean
+          description: Permissions to view folder
+        create:
+          type: boolean
+          description: Permissions for create folder
+        delete:
+          type: boolean
+          description: Permissions for delete folder
+        update:
+          type: boolean
+          description: Permissions for update folder
+        move_within:
+          type: boolean
+          description: Permissions for moving within a hierarchy
+        move_outside:
+          type: boolean
+          description: Permissions for moving outside a hierarchy
+        access_control:
+          type: boolean
+          description: Permissions for folder access control
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        import:
+          type: boolean
+          description: Permissions for import folders
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        share:
+          type: boolean
+          description: Permissions for share folders
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        user_group:
+          type: object
+          additionalProperties: true
+          description: Permissions for user groups. Shape is not described in the Kaiten documentation
+    TreeEntityRoleStoryMapPermissions:
+      type: object
+      description: Tree entity role permissions for story maps
+      properties:
+        read:
+          type: boolean
+          description: Permissions to view story map
+        create:
+          type: boolean
+          description: Permissions for create story map
+        delete:
+          type: boolean
+          description: Permissions for delete story map
+        update:
+          type: boolean
+          description: Permissions for update story map
+        move_within:
+          type: boolean
+          description: Permissions for moving within a hierarchy
+        move_outside:
+          type: boolean
+          description: Permissions for moving outside a hierarchy
+        access_control:
+          type: boolean
+          description: Permissions for story map access control
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        import:
+          type: boolean
+          description: Permissions for import story maps
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        share:
+          type: boolean
+          description: Permissions for share story maps
+        # DOC_MISMATCH: not in docs, present in actual API responses — https://developers.kaiten.ru/tree-entity-roles/get-list-of-tree-entity-roles
+        user_group:
+          type: object
+          additionalProperties: true
+          description: Permissions for user groups. Shape is not described in the Kaiten documentation

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -518,6 +518,9 @@ let sections: [Section] = [
       name: "update_user_role", errors: [.badRequest, .unauthorized, .forbidden, .notFound]),
     Operation(name: "delete_user_role", errors: [.unauthorized, .forbidden, .notFound]),
   ]),
+  Section(mark: "Tree Entity Roles", operations: [
+    Operation(name: "list_tree_entity_roles", errors: [.unauthorized, .forbidden])
+  ]),
 ]
 
 // MARK: - Generator


### PR DESCRIPTION
## Endpoints

- [x] `GET /tree-entity-roles` — Get list of tree entity roles

## Verification

- **Live-verified**: `GET /tree-entity-roles` was fetched from a live instance; every field in the spec was cross-checked against the real response for type and nullability. The test fixture is the sanitized live response (invented ids, fake names, one sample per-property permission key). The built CLI was also run against the live instance end-to-end: all roles decode, and both shapes of `card.properties` (blanket boolean and per-property object) were observed live.
- The docs mark this endpoint as **under active development**, which explains the unusually large divergence between docs and live behaviour.

## DOC_MISMATCH annotations (27)

- Response: docs declare an `object`, the API answers an `array` of role objects.
- Docs name the permissions field `role_permissions`; the API sends `permissions`. Both keys are modelled, each annotated.
- `company_uid` and `locked` are absent from docs but present in live responses (`locked` observed only as `null`).
- `root`: undocumented `import` and `share`.
- `space`: docs say `webhooks`, live sends `webhook` (both modelled and annotated); undocumented `import`, `share`, `public_filters_manage`, `view_settings` booleans and `addons`, `iteration`, `user_group`, `workflow` objects (kept free-form — their shape is not documented).
- `document`: undocumented `comment`, `import`, `share`, `user_group`.
- `document_group` / `story_map`: undocumented `import`, `share`, `user_group` each.

## Definition of done

- [x] `openapi/kaiten.yaml` — path and `TreeEntityRole*` schemas from docs, cross-checked against a live response (FR-009)
- [x] All documented query parameters exposed — the endpoint documents none (FR-010)
- [x] `Sources/KaitenSDK/KaitenClient+TreeEntityRoles.swift` with DocC comments (NFR-007)
- [x] `Sources/kaiten/TreeEntityRoles/TreeEntityRoleCommands.swift`, registered in `Kaiten.swift`
- [x] README "API Reference" updated (Tree Entity Roles section with CLI line)
- [x] `Tests/KaitenSDKTests/TreeEntityRolesTests.swift` — 5 tests: 200 with sanitized live fixture, request shape, empty body, 401, 403
- [x] `swift format lint --strict` clean; `swift test` green (427 tests)

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)