### PR TITLE
feat(users): add SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,19 @@ CLI: `list-collective-vote-values`, `create-collective-vote-value`,
 |--------|-------------|
 | `listUsers()` | List all users |
 | `getCurrentUser()` | Get the current user |
+| `updateUser(id:...)` | Update a user |
 | `getCurrentUserBlockers()` | Get cards blocked on the current user (see [Card Blocker Users](#card-blocker-users)) |
+
+`updateUser` changes only the fields that are set; the API requires at least
+one field and answers HTTP 400 otherwise. Closed-set fields are exposed as
+Swift enums (`UserAvatarType`, `UserTheme`, `UserEmailFrequency`,
+`UserEmailSubject`, `UserUiVersion`, `UserNotificationChannel`), each with an
+`unknown` case that preserves values the documentation does not list. The
+`email_settings`, `telegram_settings`, `slack_settings` and
+`notification_settings` payloads stay free-form JSON — the documentation does
+not describe their fields.
+
+CLI: `update-user --id <id> [--full-name <name>] [--theme <theme>] ...`.
 
 ### Company Users
 

--- a/Sources/KaitenSDK/Enums.swift
+++ b/Sources/KaitenSDK/Enums.swift
@@ -2453,3 +2453,273 @@ public enum TreeEntityType: Sendable, Equatable, CaseIterable, Codable {
     try container.encode(rawValue)
   }
 }
+
+// MARK: - Users
+
+/// User avatar type.
+///
+/// Used in ``KaitenClient/updateUser(id:username:fullName:initials:avatarType:password:oldPassword:lng:defaultSpaceId:theme:emailFrequency:timezone:subjectBy:emailSettings:telegramSettings:slackSettings:notificationEnabledChannels:notificationSettings:uiVersion:)``.
+/// - SeeAlso: [Kaiten API – Users](https://developers.kaiten.ru/users/update-user)
+public enum UserAvatarType: Sendable, Equatable, CaseIterable, Codable {
+  /// Gravatar avatar.
+  case gravatar
+  /// Avatar generated from the user initials.
+  case initials
+  /// Uploaded image avatar.
+  case uploaded
+  /// Unknown value returned by the API (forward compatibility).
+  case unknown(Int)
+
+  public static var allCases: [UserAvatarType] { [.gravatar, .initials, .uploaded] }
+
+  public init(rawValue: Int) {
+    switch rawValue {
+    case 1: self = .gravatar
+    case 2: self = .initials
+    case 3: self = .uploaded
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: Int {
+    switch self {
+    case .gravatar: 1
+    case .initials: 2
+    case .uploaded: 3
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(Int.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}
+
+/// User interface color theme.
+///
+/// Used in ``KaitenClient/updateUser(id:username:fullName:initials:avatarType:password:oldPassword:lng:defaultSpaceId:theme:emailFrequency:timezone:subjectBy:emailSettings:telegramSettings:slackSettings:notificationEnabledChannels:notificationSettings:uiVersion:)``.
+/// - SeeAlso: [Kaiten API – Users](https://developers.kaiten.ru/users/update-user)
+public enum UserTheme: Sendable, Equatable, CaseIterable, Codable {
+  /// Light color theme.
+  case light
+  /// Dark color theme.
+  case dark
+  /// Color theme based on OS settings.
+  case auto
+  /// Unknown value returned by the API (forward compatibility).
+  case unknown(String)
+
+  public static var allCases: [UserTheme] { [.light, .dark, .auto] }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "light": self = .light
+    case "dark": self = .dark
+    case "auto": self = .auto
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: String {
+    switch self {
+    case .light: "light"
+    case .dark: "dark"
+    case .auto: "auto"
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(String.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}
+
+/// Email notification frequency.
+///
+/// Used in ``KaitenClient/updateUser(id:username:fullName:initials:avatarType:password:oldPassword:lng:defaultSpaceId:theme:emailFrequency:timezone:subjectBy:emailSettings:telegramSettings:slackSettings:notificationEnabledChannels:notificationSettings:uiVersion:)``.
+/// - SeeAlso: [Kaiten API – Users](https://developers.kaiten.ru/users/update-user)
+public enum UserEmailFrequency: Sendable, Equatable, CaseIterable, Codable {
+  /// Never send email notifications.
+  case never
+  /// Send email notifications instantly.
+  case instantly
+  /// Unknown value returned by the API (forward compatibility).
+  case unknown(Int)
+
+  public static var allCases: [UserEmailFrequency] { [.never, .instantly] }
+
+  public init(rawValue: Int) {
+    switch rawValue {
+    case 1: self = .never
+    case 2: self = .instantly
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: Int {
+    switch self {
+    case .never: 1
+    case .instantly: 2
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(Int.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}
+
+/// Email notification subject format.
+///
+/// Used in ``KaitenClient/updateUser(id:username:fullName:initials:avatarType:password:oldPassword:lng:defaultSpaceId:theme:emailFrequency:timezone:subjectBy:emailSettings:telegramSettings:slackSettings:notificationEnabledChannels:notificationSettings:uiVersion:)``.
+/// - SeeAlso: [Kaiten API – Users](https://developers.kaiten.ru/users/update-user)
+public enum UserEmailSubject: Sendable, Equatable, CaseIterable, Codable {
+  /// Subject contains the entity id and title.
+  case idAndTitle
+  /// Subject contains the action.
+  case action
+  /// Unknown value returned by the API (forward compatibility).
+  case unknown(Int)
+
+  public static var allCases: [UserEmailSubject] { [.idAndTitle, .action] }
+
+  public init(rawValue: Int) {
+    switch rawValue {
+    case 1: self = .idAndTitle
+    case 2: self = .action
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: Int {
+    switch self {
+    case .idAndTitle: 1
+    case .action: 2
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(Int.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}
+
+/// User interface version.
+///
+/// Used in ``KaitenClient/updateUser(id:username:fullName:initials:avatarType:password:oldPassword:lng:defaultSpaceId:theme:emailFrequency:timezone:subjectBy:emailSettings:telegramSettings:slackSettings:notificationEnabledChannels:notificationSettings:uiVersion:)``.
+/// - SeeAlso: [Kaiten API – Users](https://developers.kaiten.ru/users/update-user)
+public enum UserUiVersion: Sendable, Equatable, CaseIterable, Codable {
+  /// Old user interface.
+  case oldUi
+  /// New user interface.
+  case newUi
+  /// Unknown value returned by the API (forward compatibility).
+  case unknown(Int)
+
+  public static var allCases: [UserUiVersion] { [.oldUi, .newUi] }
+
+  public init(rawValue: Int) {
+    switch rawValue {
+    case 1: self = .oldUi
+    case 2: self = .newUi
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: Int {
+    switch self {
+    case .oldUi: 1
+    case .newUi: 2
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(Int.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}
+
+/// Notification delivery channel.
+///
+/// Used in ``KaitenClient/updateUser(id:username:fullName:initials:avatarType:password:oldPassword:lng:defaultSpaceId:theme:emailFrequency:timezone:subjectBy:emailSettings:telegramSettings:slackSettings:notificationEnabledChannels:notificationSettings:uiVersion:)``.
+/// - SeeAlso: [Kaiten API – Users](https://developers.kaiten.ru/users/update-user)
+public enum UserNotificationChannel: Sendable, Equatable, CaseIterable, Codable {
+  /// In-app notifications.
+  case inner
+  /// Mobile app push notifications.
+  case mobileApp
+  /// Email notifications.
+  case email
+  /// Slack notifications.
+  case slack
+  /// Telegram notifications.
+  case telegram
+  /// Unknown value returned by the API (forward compatibility).
+  case unknown(String)
+
+  public static var allCases: [UserNotificationChannel] {
+    [.inner, .mobileApp, .email, .slack, .telegram]
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "inner": self = .inner
+    case "mobile_app": self = .mobileApp
+    case "email": self = .email
+    case "slack": self = .slack
+    case "telegram": self = .telegram
+    default: self = .unknown(rawValue)
+    }
+  }
+
+  public var rawValue: String {
+    switch self {
+    case .inner: "inner"
+    case .mobileApp: "mobile_app"
+    case .email: "email"
+    case .slack: "slack"
+    case .telegram: "telegram"
+    case .unknown(let v): v
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer().decode(String.self)
+    self.init(rawValue: value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}

--- a/Sources/KaitenSDK/KaitenClient+Users.swift
+++ b/Sources/KaitenSDK/KaitenClient+Users.swift
@@ -58,4 +58,85 @@ extension KaitenClient {
     let response = try await call { try await client.retrieve_current_user() }
     return try decodeResponse(response.toCase()) { try $0.json }
   }
+
+  /// Updates a user.
+  ///
+  /// All fields are optional — only set values are changed. The API requires
+  /// at least one field in the request and answers HTTP 400 otherwise.
+  ///
+  /// - Parameters:
+  ///   - id: The user identifier.
+  ///   - username: Username for mentions and login.
+  ///   - fullName: Full name (1–128 characters).
+  ///   - initials: Initials (exactly 2 characters).
+  ///   - avatarType: Avatar type.
+  ///   - password: New password (at least 6 characters).
+  ///   - oldPassword: Old password (at least 6 characters).
+  ///   - lng: Interface language.
+  ///   - defaultSpaceId: Default space identifier.
+  ///   - theme: Interface color theme.
+  ///   - emailFrequency: Email notification frequency.
+  ///   - timezone: Time zone.
+  ///   - subjectBy: Email notification subject format.
+  ///   - emailSettings: Email settings. The documentation does not describe the fields.
+  ///   - telegramSettings: Telegram settings. The documentation does not describe the fields.
+  ///   - slackSettings: Slack settings. The documentation does not describe the fields.
+  ///   - notificationEnabledChannels: Channels enabled for notifications.
+  ///   - notificationSettings: Channel lists where notifications for specified events
+  ///     should be sent. The documentation does not describe the fields.
+  ///   - uiVersion: User interface version.
+  /// - Returns: The updated user.
+  /// - Throws:
+  ///   - ``KaitenError/notFound(resource:id:)`` if the user does not exist.
+  ///   - ``KaitenError/unauthorized`` if the API token is invalid or lacks permissions.
+  ///   - ``KaitenError/decodingError(underlying:)`` if the response body cannot be decoded.
+  ///   - ``KaitenError/networkError(underlying:)`` for connectivity failures.
+  ///   - ``KaitenError/unexpectedResponse(statusCode:body:)`` for validation errors (400),
+  ///     forbidden (403) or other undocumented HTTP status codes.
+  public func updateUser(
+    id: Int,
+    username: String? = nil,
+    fullName: String? = nil,
+    initials: String? = nil,
+    avatarType: UserAvatarType? = nil,
+    password: String? = nil,
+    oldPassword: String? = nil,
+    lng: String? = nil,
+    defaultSpaceId: Int? = nil,
+    theme: UserTheme? = nil,
+    emailFrequency: UserEmailFrequency? = nil,
+    timezone: String? = nil,
+    subjectBy: UserEmailSubject? = nil,
+    emailSettings: Components.Schemas.UpdateUserRequest.email_settingsPayload? = nil,
+    telegramSettings: Components.Schemas.UpdateUserRequest.telegram_settingsPayload? = nil,
+    slackSettings: Components.Schemas.UpdateUserRequest.slack_settingsPayload? = nil,
+    notificationEnabledChannels: [UserNotificationChannel]? = nil,
+    notificationSettings: Components.Schemas.UpdateUserRequest.notification_settingsPayload? = nil,
+    uiVersion: UserUiVersion? = nil
+  ) async throws(KaitenError) -> Components.Schemas.UpdateUserResponse {
+    let body = Components.Schemas.UpdateUserRequest(
+      username: username,
+      full_name: fullName,
+      initials: initials,
+      avatar_type: avatarType?.rawValue,
+      password: password,
+      old_password: oldPassword,
+      lng: lng,
+      default_space_id: defaultSpaceId,
+      theme: theme?.rawValue,
+      email_frequency: emailFrequency?.rawValue,
+      timezone: timezone,
+      subject_by: subjectBy?.rawValue,
+      email_settings: emailSettings,
+      telegram_settings: telegramSettings,
+      slack_settings: slackSettings,
+      notification_enabled_channels: notificationEnabledChannels?.map(\.rawValue),
+      notification_settings: notificationSettings,
+      ui_version: uiVersion?.rawValue
+    )
+    let response = try await call {
+      try await client.update_user(path: .init(id: id), body: .json(body))
+    }
+    return try decodeResponse(response.toCase(), notFoundResource: ("user", id)) { try $0.json }
+  }
 }

--- a/Sources/KaitenSDK/ResponseMapping.swift
+++ b/Sources/KaitenSDK/ResponseMapping.swift
@@ -746,6 +746,19 @@ extension Operations.retrieve_current_user.Output {
   }
 }
 
+extension Operations.update_user.Output {
+  func toCase() -> KaitenClient.ResponseCase<Operations.update_user.Output.Ok.Body> {
+    switch self {
+    case .ok(let ok): .ok(ok.body)
+    case .badRequest: .undocumented(statusCode: 400)
+    case .unauthorized: .unauthorized
+    case .forbidden: .forbidden
+    case .notFound: .notFound
+    case .undocumented(statusCode: let code, _): .undocumented(statusCode: code)
+    }
+  }
+}
+
 // MARK: - Card Blockers
 
 extension Operations.list_card_blockers.Output {

--- a/Sources/kaiten/Kaiten.swift
+++ b/Sources/kaiten/Kaiten.swift
@@ -67,6 +67,7 @@ struct Kaiten: AsyncParsableCommand {
       AddTag.self,
       ListUsers.self,
       GetCurrentUser.self,
+      UpdateUser.self,
       ListCardChildren.self,
       AddCardChild.self,
       RemoveCardChild.self,

--- a/Sources/kaiten/Users/UserCommands.swift
+++ b/Sources/kaiten/Users/UserCommands.swift
@@ -41,6 +41,121 @@ struct ListUsers: AsyncParsableCommand {
   }
 }
 
+struct UpdateUser: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "update-user",
+    abstract: "Update a user by ID",
+    discussion: "The API requires at least one field to update and answers HTTP 400 otherwise."
+  )
+
+  @OptionGroup var global: GlobalOptions
+
+  @Option(name: .long, help: "User ID")
+  var id: Int
+
+  @Option(name: .long, help: "Username for mentions and login")
+  var username: String?
+
+  @Option(name: .long, help: "Full name (1-128 characters)")
+  var fullName: String?
+
+  @Option(name: .long, help: "Initials (exactly 2 characters)")
+  var initials: String?
+
+  @Option(name: .long, help: "Avatar type: 1 = gravatar, 2 = initials, 3 = uploaded")
+  var avatarType: Int?
+
+  @Option(name: .long, help: "New password (at least 6 characters)")
+  var password: String?
+
+  @Option(name: .long, help: "Old password (at least 6 characters)")
+  var oldPassword: String?
+
+  @Option(name: .long, help: "Interface language")
+  var lng: String?
+
+  @Option(name: .long, help: "Default space ID")
+  var defaultSpaceId: Int?
+
+  @Option(name: .long, help: "Interface color theme: light, dark, auto")
+  var theme: String?
+
+  @Option(name: .long, help: "Email notification frequency: 1 = never, 2 = instantly")
+  var emailFrequency: Int?
+
+  @Option(name: .long, help: "Time zone")
+  var timezone: String?
+
+  @Option(name: .long, help: "Email subject format: 1 = id and title, 2 = action")
+  var subjectBy: Int?
+
+  @Option(name: .long, help: "Email settings as a JSON object")
+  var emailSettings: String?
+
+  @Option(name: .long, help: "Telegram settings as a JSON object")
+  var telegramSettings: String?
+
+  @Option(name: .long, help: "Slack settings as a JSON object")
+  var slackSettings: String?
+
+  @Option(
+    name: .long,
+    help: "Comma-separated notification channels: inner, mobile_app, email, slack, telegram")
+  var notificationEnabledChannels: String?
+
+  @Option(name: .long, help: "Notification settings as a JSON object")
+  var notificationSettings: String?
+
+  @Option(name: .long, help: "User interface version: 1 = old UI, 2 = new UI")
+  var uiVersion: Int?
+
+  func run() async throws {
+    let parsedEmailSettings = try parseAutomationJSON(
+      emailSettings,
+      as: Components.Schemas.UpdateUserRequest.email_settingsPayload.self,
+      fieldName: "email-settings")
+    let parsedTelegramSettings = try parseAutomationJSON(
+      telegramSettings,
+      as: Components.Schemas.UpdateUserRequest.telegram_settingsPayload.self,
+      fieldName: "telegram-settings")
+    let parsedSlackSettings = try parseAutomationJSON(
+      slackSettings,
+      as: Components.Schemas.UpdateUserRequest.slack_settingsPayload.self,
+      fieldName: "slack-settings")
+    let parsedNotificationSettings = try parseAutomationJSON(
+      notificationSettings,
+      as: Components.Schemas.UpdateUserRequest.notification_settingsPayload.self,
+      fieldName: "notification-settings")
+    let channels = notificationEnabledChannels.map { raw in
+      raw.split(separator: ",").map { UserNotificationChannel(rawValue: String($0)) }
+    }
+
+    let client = try await global.makeClient()
+    let user = try await client.updateUser(
+      id: id,
+      username: username,
+      fullName: fullName,
+      initials: initials,
+      avatarType: avatarType.map(UserAvatarType.init(rawValue:)),
+      password: password,
+      oldPassword: oldPassword,
+      lng: lng,
+      defaultSpaceId: defaultSpaceId,
+      theme: theme.map(UserTheme.init(rawValue:)),
+      emailFrequency: emailFrequency.map(UserEmailFrequency.init(rawValue:)),
+      timezone: timezone,
+      subjectBy: subjectBy.map(UserEmailSubject.init(rawValue:)),
+      emailSettings: parsedEmailSettings,
+      telegramSettings: parsedTelegramSettings,
+      slackSettings: parsedSlackSettings,
+      notificationEnabledChannels: channels,
+      notificationSettings: parsedNotificationSettings,
+      uiVersion: uiVersion.map(UserUiVersion.init(rawValue:))
+    )
+    try printJSON(user, expand: global.expandedFields)
+  }
+}
+
 struct GetCurrentUser: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "get-current-user",

--- a/Tests/KaitenSDKTests/UpdateUserTests.swift
+++ b/Tests/KaitenSDKTests/UpdateUserTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import KaitenSDK
+
+@Suite("UpdateUser")
+struct UpdateUserTests {
+
+  /// Based on the documentation's 200 example response (sanitized).
+  /// `sd_telegram_id`, `email_settings` and `telegram_id` are null there even
+  /// though the attribute table declares them non-nullable, and `show_tour` is
+  /// present without being documented at all.
+  private let userJSON = """
+    {
+      "created": "2022-10-14T12:52:19.462Z",
+      "updated": "2022-10-19T12:12:03.016Z",
+      "id": 42,
+      "full_name": "Test User",
+      "username": "testuser",
+      "email": "user@example.com",
+      "activated": true,
+      "show_tour": true,
+      "avatar_initials_url": "data:image/png;base64,AAAA",
+      "avatar_uploaded_url": "https://files.example.com/avatar-1.png",
+      "initials": "TU",
+      "avatar_type": 3,
+      "lng": "en",
+      "sd_telegram_id": null,
+      "timezone": "UTC",
+      "news_subscription": false,
+      "theme": "auto",
+      "ui_version": 2,
+      "default_space_id": 1,
+      "email_frequency": 2,
+      "email_settings": null,
+      "work_time_settings": {"work_days": [0, 1, 2, 3, 4], "hours_count": 8},
+      "telegram_id": null,
+      "telegram_settings": {},
+      "has_password": true
+    }
+    """
+
+  private func makeClient(_ transport: MockClientTransport) throws -> KaitenClient {
+    try KaitenClient(
+      baseURL: "https://test.kaiten.ru/api/latest", token: "test-token", transport: transport)
+  }
+
+  @Test("200 returns updated user")
+  func success() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: userJSON)
+    let client = try makeClient(transport)
+
+    let user = try await client.updateUser(id: 42, fullName: "Test User")
+    #expect(user.id == 42)
+    #expect(user.full_name == "Test User")
+    #expect(user.username == "testuser")
+    #expect(user.avatar_type == 3)
+    #expect(user.sd_telegram_id == nil)
+    #expect(user.email_settings == nil)
+    #expect(user.telegram_id == nil)
+    #expect(user.theme == "auto")
+    #expect(user.default_space_id == 1)
+    #expect(user.email_frequency == 2)
+    #expect(user.work_time_settings?.hours_count == 8)
+    #expect(user.work_time_settings?.work_days == [0, 1, 2, 3, 4])
+    #expect(user.has_password == true)
+  }
+
+  @Test("request body encodes enum raw values and omits unset fields")
+  func requestBodyEncoding() async throws {
+    let transport = MockClientTransport.returning(statusCode: 200, body: userJSON)
+    let client = try makeClient(transport)
+
+    _ = try await client.updateUser(
+      id: 42,
+      avatarType: .initials,
+      theme: .dark,
+      emailFrequency: .never,
+      subjectBy: .action,
+      notificationEnabledChannels: [.inner, .mobileApp],
+      uiVersion: .newUi
+    )
+
+    let req = try #require(transport.recordedRequests.first)
+    let bodyData = try await Data(collecting: #require(req.body), upTo: 1024 * 1024)
+    let json = try #require(
+      try JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+    #expect(json["avatar_type"] as? Int == 2)
+    #expect(json["theme"] as? String == "dark")
+    #expect(json["email_frequency"] as? Int == 1)
+    #expect(json["subject_by"] as? Int == 2)
+    #expect(json["notification_enabled_channels"] as? [String] == ["inner", "mobile_app"])
+    #expect(json["ui_version"] as? Int == 2)
+    #expect(json["username"] == nil)
+    #expect(json["password"] == nil)
+  }
+
+  @Test("user enums round-trip and map unknown values")
+  func enumRoundTrip() {
+    for c in UserAvatarType.allCases { #expect(UserAvatarType(rawValue: c.rawValue) == c) }
+    for c in UserTheme.allCases { #expect(UserTheme(rawValue: c.rawValue) == c) }
+    for c in UserEmailFrequency.allCases { #expect(UserEmailFrequency(rawValue: c.rawValue) == c) }
+    for c in UserEmailSubject.allCases { #expect(UserEmailSubject(rawValue: c.rawValue) == c) }
+    for c in UserUiVersion.allCases { #expect(UserUiVersion(rawValue: c.rawValue) == c) }
+    for c in UserNotificationChannel.allCases {
+      #expect(UserNotificationChannel(rawValue: c.rawValue) == c)
+    }
+    #expect(UserAvatarType(rawValue: 999) == .unknown(999))
+    #expect(UserTheme(rawValue: "sepia") == .unknown("sepia"))
+    #expect(UserNotificationChannel(rawValue: "pager") == .unknown("pager"))
+  }
+
+  @Test("404 throws notFound")
+  func notFound() async throws {
+    let transport = MockClientTransport.returning(statusCode: 404)
+    let client = try makeClient(transport)
+
+    let operation: () async throws -> Void = {
+      _ = try await client.updateUser(id: 999, fullName: "x")
+    }
+    do {
+      try await operation()
+      Issue.record("expected KaitenError.notFound, no error thrown")
+    } catch let error as KaitenError {
+      guard case .notFound(let resource, let id) = error else {
+        Issue.record("expected KaitenError.notFound, got \(error)")
+        return
+      }
+      #expect(resource == "user")
+      #expect(id == 999)
+    } catch {
+      Issue.record("expected KaitenError, got \(error)")
+    }
+  }
+
+  @Test("401 throws unauthorized")
+  func unauthorized() async throws {
+    let transport = MockClientTransport.returning(statusCode: 401)
+    let client = try makeClient(transport)
+
+    await #expect(throws: KaitenError.self) {
+      _ = try await client.updateUser(id: 1, fullName: "x")
+    }
+  }
+
+  @Test("400 throws unexpectedResponse")
+  func badRequest() async throws {
+    let transport = MockClientTransport.returning(
+      statusCode: 400, body: #"{"message": "User should have required property '.username'"}"#)
+    let client = try makeClient(transport)
+
+    let operation: () async throws -> Void = {
+      _ = try await client.updateUser(id: 1)
+    }
+    do {
+      try await operation()
+      Issue.record("expected KaitenError.unexpectedResponse, no error thrown")
+    } catch let error as KaitenError {
+      guard case .unexpectedResponse(let statusCode, _) = error, statusCode == 400 else {
+        Issue.record("expected KaitenError.unexpectedResponse(400), got \(error)")
+        return
+      }
+    } catch {
+      Issue.record("expected KaitenError, got \(error)")
+    }
+  }
+}

--- a/openapi/kaiten.yaml
+++ b/openapi/kaiten.yaml
@@ -2454,6 +2454,38 @@ paths:
                   $ref: '#/components/schemas/User'
         '401':
           description: Invalid token
+  /users/{id}:
+    patch:
+      summary: Update user
+      operationId: update_user
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: User ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateUserRequest'
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateUserResponse'
+        '400':
+          description: Validation error
+        '401':
+          description: Invalid token
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
   /users/current:
     get:
       summary: Retrieve current user
@@ -8768,6 +8800,189 @@ components:
           - string
           - 'null'
           description: Date of last request
+    UpdateUserRequest:
+      type: object
+      properties:
+        username:
+          type: string
+          description: Username for mentions and login
+        full_name:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: Full name
+        initials:
+          type: string
+          minLength: 2
+          maxLength: 2
+          description: Initials
+        avatar_type:
+          type: integer
+          description: 1 - gravatar, 2 - initials, 3 - uploaded
+        password:
+          type: string
+          minLength: 6
+          description: New password
+        old_password:
+          type:
+          - string
+          - 'null'
+          description: Old password
+        lng:
+          type: string
+          description: Language
+        default_space_id:
+          type:
+          - integer
+          - 'null'
+          description: Default space
+        theme:
+          type: string
+          description: light - light color theme, dark - dark color theme, auto - color theme based on OS settings
+        email_frequency:
+          type: integer
+          description: 1 - never, 2 - instantly
+        timezone:
+          type: string
+          description: Time zone
+        subject_by:
+          type: integer
+          description: 1 - id and title, 2 - action
+        email_settings:
+          type: object
+          additionalProperties: true
+          description: Email settings
+        telegram_settings:
+          type: object
+          additionalProperties: true
+          description: Telegram settings
+        slack_settings:
+          type: object
+          additionalProperties: true
+          description: Slack settings
+        notification_enabled_channels:
+          type: array
+          items:
+            type: string
+          description: 'List of enabled channels for notifications. Documented values: inner, mobile_app, email, slack, telegram'
+        notification_settings:
+          type: object
+          additionalProperties: true
+          description: Channel lists where notifications for specified events should be sent
+        ui_version:
+          type: integer
+          description: 1 - old ui, 2 - new ui
+    UpdateUserResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: User id
+        full_name:
+          type: string
+          description: User full name
+        email:
+          type: string
+          description: User email
+        username:
+          type: string
+          description: Username for mentions and login
+        updated:
+          type: string
+          description: Last update timestamp
+        created:
+          type: string
+          description: Create date
+        avatar_initials_url:
+          type: string
+          description: Default user avatar
+        avatar_uploaded_url:
+          type:
+          - string
+          - 'null'
+          description: User uploaded avatar url
+        activated:
+          type: boolean
+          description: User activated flag
+        initials:
+          type: string
+          description: User initials
+        avatar_type:
+          type: integer
+          description: 1 - gravatar, 2 - initials, 3 - uploaded
+        lng:
+          type: string
+          description: Language
+        # DOC_MISMATCH: docs=non-nullable `integer`, actual=`integer | null` (the docs' own 200 example shows null) — https://developers.kaiten.ru/users/update-user
+        sd_telegram_id:
+          type:
+          - integer
+          - 'null'
+          description: Service desk telegram id
+        timezone:
+          type: string
+          description: Time zone
+        news_subscription:
+          type: boolean
+          description: News subscription flag
+        theme:
+          type: string
+          description: light - light color theme, dark - dark color theme, auto - based on OS settings
+        ui_version:
+          type: integer
+          description: 1 - old ui, 2 - new ui
+        default_space_id:
+          type:
+          - integer
+          - 'null'
+          description: Default space
+        email_frequency:
+          type: integer
+          description: 1 - never, 2 - instantly
+        # NOTE: nullable, but expressed as a plain $ref rather than `anyOf: [$ref, 'null']` —
+        # swift-openapi-generator silently drops properties using that pattern. The property is
+        # optional, and the synthesized decoder maps an explicit JSON `null` to `nil`.
+        # Guarded by Tests/KaitenSDKTests/OpenAPISpecIntegrityTests.swift.
+        # DOC_MISMATCH: docs=non-nullable `object`, actual=`object | null` (null in the docs' own 200 example and in live user responses) — https://developers.kaiten.ru/users/update-user
+        email_settings:
+          $ref: '#/components/schemas/UserEmailSettings'
+          description: Email settings
+        work_time_settings:
+          $ref: '#/components/schemas/UserWorkTimeSettings'
+          description: Work time settings
+        # DOC_MISMATCH: docs=non-nullable `integer`, actual=`integer | null` (null in the docs' own 200 example and in live user responses) — https://developers.kaiten.ru/users/update-user
+        telegram_id:
+          type:
+          - integer
+          - 'null'
+          description: Telegram id
+        telegram_settings:
+          type: object
+          additionalProperties: true
+          description: Telegram settings
+        has_password:
+          type: boolean
+          description: Has user password flag
+    UserEmailSettings:
+      type: object
+      properties:
+        deadlines:
+          type: boolean
+          description: Daily due dates digest flag
+        subject_by:
+          type: integer
+          description: Subject format. 1 - id and title, 2 - action
+    UserWorkTimeSettings:
+      type: object
+      properties:
+        work_days:
+          type: array
+          items:
+            type: integer
+          description: Work days
+        hours_count:
+          type: integer
+          description: Work time hours count
     AllowedUser:
       type: object
       properties:

--- a/scripts/generate-response-mapping.swift
+++ b/scripts/generate-response-mapping.swift
@@ -161,6 +161,8 @@ let sections: [Section] = [
   Section(mark: "Users", operations: [
     Operation(name: "retrieve_list_of_users", errors: [.unauthorized]),
     Operation(name: "retrieve_current_user", errors: [.unauthorized]),
+    Operation(
+      name: "update_user", errors: [.badRequest, .unauthorized, .forbidden, .notFound]),
   ]),
   Section(mark: "Card Blockers", operations: [
     Operation(name: "list_card_blockers", errors: [.unauthorized, .forbidden, .notFound]),


### PR DESCRIPTION
## Endpoints

- [x] `PATCH /users/{id}` — Update user ([docs](https://developers.kaiten.ru/users/update-user))

## What was done

- **Spec** (`openapi/kaiten.yaml`): `update_user` operation with `UpdateUserRequest`, `UpdateUserResponse`, `UserEmailSettings` and `UserWorkTimeSettings` schemas, built from the official documentation. All documented body attributes are exposed (the endpoint has no query parameters). The nullable `email_settings` $ref uses the plain-$ref pattern guarded by `OpenAPISpecIntegrityTests`.
- **SDK**: `KaitenClient.updateUser(id:...)` in `Sources/KaitenSDK/KaitenClient+Users.swift` with DocC comments. Closed-set fields are typed via new hand-written enums with an `unknown` case: `UserAvatarType`, `UserTheme`, `UserEmailFrequency`, `UserEmailSubject`, `UserUiVersion`, `UserNotificationChannel`.
- **CLI**: `update-user` subcommand in `Sources/kaiten/Users/UserCommands.swift`, registered in `Kaiten.swift`. JSON-carrying options (`--email-settings`, `--telegram-settings`, `--slack-settings`, `--notification-settings`) are decoded and validated locally before the SDK call.
- **README**: Users API Reference table row and CLI usage line.
- **Tests** (`Tests/KaitenSDKTests/UpdateUserTests.swift`, 6 tests): 200 parsing from the documentation's example response (sanitized), request-body enum encoding, enum round-trips, and 400/401/404 error paths.

## Live verification

The endpoint is mutating, so it was **not** exercised against the live API — the schema comes strictly from the documentation and the fixture from the docs' example response. Nullability of the shared user serializer was cross-checked with a read-only `GET /users/current` against a live instance.

## DOC_MISMATCH annotations (3)

The docs' attribute table and their own 200 example disagree; live user responses confirm the example:

- `sd_telegram_id`: docs `integer`, null in the docs' own example
- `email_settings`: docs non-nullable `object`, null in the example and in live user responses
- `telegram_id`: docs `integer`, null in the example and in live user responses

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)