### PR TITLE
fix(release): drop duplicate root glob that made asset upload fail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,9 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
-          files: |
-            **/*.tar.gz
-            *.tar.gz
+          # A single recursive glob: it already matches the root-level agent
+          # archives. Listing `*.tar.gz` alongside it made every root archive
+          # match twice, and action-gh-release v3 deletes each matched asset
+          # before re-uploading — the second pass 404s on the already-deleted
+          # asset and fails the job.
+          files: "**/*.tar.gz"


### PR DESCRIPTION
The 2.3.0 release job failed twice at the Release step with \`Not Found - update/delete-a-release-asset\`.

Root cause: \`files:\` listed both \`**/*.tar.gz\` and \`*.tar.gz\`. The recursive glob already matches the root-level agent archives, so every root archive was fed to softprops/action-gh-release twice. v3 deletes each matched asset before re-uploading — the duplicate's delete 404s and fails the job after the upload already happened, leaving the release as a draft (and once with a missing asset).

Fix: keep the single recursive glob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)